### PR TITLE
Avoid multiple in-memory copies of image layers during pull

### DIFF
--- a/src/decrypt.rs
+++ b/src/decrypt.rs
@@ -14,7 +14,7 @@ use ocicrypt_rs::spec::{
 use oci_distribution::manifest;
 use oci_distribution::manifest::OciDescriptor;
 
-use std::io::Read;
+use std::io;
 
 #[derive(Default, Clone)]
 pub struct Decryptor {
@@ -60,12 +60,16 @@ impl Decryptor {
     ///           - \<filename>:fd=\<filedescriptor> \
     ///           - \<filename>:\<password> \
     ///           - provider:<cmd/gprc>
-    pub async fn get_plaintext_layer(
+    pub async fn get_plaintext_layer<
+        R: io::Read + Send + 'static,
+        W: io::Write + Send + 'static,
+    >(
         &self,
         descriptor: &OciDescriptor,
-        encrypted_layer: Vec<u8>,
+        encrypted_layer: R,
         decrypt_config: &str,
-    ) -> Result<Vec<u8>> {
+        plaintext_layer: W,
+    ) -> Result<()> {
         if !self.is_encrypted() {
             return Err(anyhow!("unencrypted media type: {}", self.media_type));
         }
@@ -81,31 +85,31 @@ impl Decryptor {
         // attestation agent, to avoid startup a runtime within a runtime, we
         // spawn a new thread here.
         let handler = tokio::task::spawn_blocking(move || {
-            decrypt_layer_data(&encrypted_layer, &descript, &cc)
+            decrypt_layer_data(encrypted_layer, &descript, &cc, plaintext_layer)
         });
 
-        if let Ok(decrypted_data) = handler.await? {
-            Ok(decrypted_data)
+        if let Ok(()) = handler.await? {
+            Ok(())
         } else {
             Err(anyhow!("decrypt failed!"))
         }
     }
 }
 
-fn decrypt_layer_data(
-    encrypted_layer: &[u8],
+fn decrypt_layer_data<R: io::Read + Send + 'static, W: io::Write + Send + 'static>(
+    encrypted_layer: R,
     descriptor: &OciDescriptor,
     crypto_config: &CryptoConfig,
-) -> Result<Vec<u8>> {
+    mut plaintext_layer: W,
+) -> Result<()> {
     if let Some(decrypt_config) = &crypto_config.decrypt_config {
         let (layer_decryptor, _dec_digest) =
             decrypt_layer(decrypt_config, encrypted_layer, descriptor, false)?;
-        let mut plaintext_data: Vec<u8> = Vec::new();
         let mut decryptor = layer_decryptor.ok_or_else(|| anyhow!("missing layer decryptor"))?;
 
-        decryptor.read_to_end(&mut plaintext_data)?;
+        std::io::copy(&mut decryptor, &mut plaintext_layer)?;
 
-        Ok(plaintext_data)
+        Ok(())
     } else {
         Err(anyhow!("no decrypt config available"))
     }

--- a/src/pull.rs
+++ b/src/pull.rs
@@ -83,19 +83,30 @@ impl PullClient {
         decrypt_config: &Option<&str>,
         meta_store: Arc<Mutex<MetaStore>>,
     ) -> Result<Vec<LayerMeta>> {
+        fs::create_dir_all(&self.data_dir)?;
         let layer_metas = layer_descs.into_iter().enumerate().map(|(i, layer)| {
             let client = &self.client;
             let reference = &self.reference;
             let ms = meta_store.clone();
 
+            // Create a path for the file into which the layers blob will be pulled.
+            // data_dir is expected to reside in secure storage.
+            let layer_digest_hex = layer.digest.split(':').last().unwrap();
+            let blob_path = self.data_dir.join(layer_digest_hex);
+
             async move {
-                let mut layer_data: Vec<u8> = Vec::new();
+                // Use a separate scope so that the file is completely written to by
+                // the end of the scope.
+                {
+                    // pull_blob requires an object that implements the AsyncWrite trait.
+                    // Hence, use tokio's async File.
+                    let mut blob_file = tokio::fs::File::create(blob_path.clone()).await?;
+                    client
+                        .pull_blob(reference, &layer.digest, &mut blob_file)
+                        .await?;
+                }
 
-                client
-                    .pull_blob(reference, &layer.digest, &mut layer_data)
-                    .await?;
-
-                self.handle_layer(layer, diff_ids[i].clone(), decrypt_config, layer_data, ms)
+                self.handle_layer(layer, diff_ids[i].clone(), decrypt_config, &blob_path, ms)
                     .await
             }
         });
@@ -110,11 +121,10 @@ impl PullClient {
         layer: OciDescriptor,
         diff_id: String,
         decrypt_config: &Option<&str>,
-        layer_data: Vec<u8>,
+        blob_path: &PathBuf,
         ms: Arc<Mutex<MetaStore>>,
     ) -> Result<LayerMeta> {
-        let mut out: Vec<u8> = Vec::new();
-        let plaintext_layer: Vec<u8>;
+        let mut plaintext_blob_path: PathBuf;
 
         let mut layer_meta = LayerMeta::default();
         let mut media_type_str: &str = layer.media_type.as_str();
@@ -123,16 +133,25 @@ impl PullClient {
 
         if decryptor.is_encrypted() {
             if let Some(dc) = decrypt_config {
-                plaintext_layer = decryptor
-                    .get_plaintext_layer(&layer, layer_data, dc)
+                plaintext_blob_path = blob_path.clone();
+                plaintext_blob_path.set_extension("plain");
+
+                // Open files for passing along to decryptor.
+                let blob_file = std::fs::File::open(blob_path)?;
+                let plain_blob_file = std::fs::File::create(&plaintext_blob_path)?;
+                decryptor
+                    .get_plaintext_layer(&layer, blob_file, dc, plain_blob_file)
                     .await?;
                 media_type_str = decryptor.media_type.as_str();
                 layer_meta.encrypted = true;
+
+                // Delete the encrypted blob.
+                fs::remove_file(blob_path)?;
             } else {
                 return Err(anyhow!(ERR_NO_DECRYPT_CFG));
             }
         } else {
-            plaintext_layer = layer_data;
+            plaintext_blob_path = blob_path.clone();
         }
 
         let layer_db = &ms.lock().await.layer_db;
@@ -143,37 +162,48 @@ impl PullClient {
 
         layer_meta.decoder = Compression::try_from(media_type_str)?;
 
+        let mut plaintext_blob_file = std::fs::File::open(&plaintext_blob_path)?;
+        let mut layer_blob_path: PathBuf;
         if layer_meta.decoder == Compression::Uncompressed {
             let digest = if diff_id.starts_with(DIGEST_SHA256) {
-                format!(
-                    "{}:{:x}",
-                    DIGEST_SHA256,
-                    sha2::Sha256::digest(plaintext_layer.as_slice())
-                )
+                let mut hasher = sha2::Sha256::new();
+                let _ = std::io::copy(&mut plaintext_blob_file, &mut hasher)?;
+                format!("{}:{:x}", DIGEST_SHA256, hasher.finalize())
             } else if diff_id.starts_with(DIGEST_SHA512) {
-                format!(
-                    "{}:{:x}",
-                    DIGEST_SHA512,
-                    sha2::Sha512::digest(plaintext_layer.as_slice())
-                )
+                let mut hasher = sha2::Sha512::new();
+                let _ = std::io::copy(&mut plaintext_blob_file, &mut hasher)?;
+                format!("{}:{:x}", DIGEST_SHA512, hasher.finalize())
             } else {
                 return Err(anyhow!("{}: {:?}", ERR_BAD_UNCOMPRESSED_DIGEST, diff_id));
             };
 
             layer_meta.uncompressed_digest = digest.clone();
             layer_meta.compressed_digest = digest;
+            layer_blob_path = plaintext_blob_path;
         } else {
-            layer_meta.compressed_digest = layer.digest.clone();
+            // Create path for uncompressed layer in secure storage.
+            layer_blob_path = blob_path.clone();
+            layer_blob_path.set_extension("uncompressed");
+
+            // Decompress the layer.
+            let mut layer_blob_file = std::fs::File::create(&layer_blob_path)?;
             layer_meta
                 .decoder
-                .decompress(plaintext_layer.as_slice(), &mut out)?;
+                .decompress(&mut plaintext_blob_file, &mut layer_blob_file)?;
+            // Delete the compressed blob.
+            fs::remove_file(&plaintext_blob_path)?;
 
+            layer_meta.compressed_digest = layer.digest.clone();
+            // Open layer file for digest computation.
+            let mut layer_blob_file = std::fs::File::open(&layer_blob_path)?;
             if diff_id.starts_with(DIGEST_SHA256) {
-                layer_meta.uncompressed_digest =
-                    format!("{DIGEST_SHA256}:{:x}", sha2::Sha256::digest(&out));
+                let mut hasher = sha2::Sha256::new();
+                let _ = std::io::copy(&mut layer_blob_file, &mut hasher)?;
+                layer_meta.uncompressed_digest = format!("{DIGEST_SHA256}:{:x}", hasher.finalize());
             } else if diff_id.starts_with(DIGEST_SHA512) {
-                layer_meta.uncompressed_digest =
-                    format!("{DIGEST_SHA512}:{:x}", sha2::Sha512::digest(&out));
+                let mut hasher = sha2::Sha512::new();
+                let _ = std::io::copy(&mut layer_blob_file, &mut hasher)?;
+                layer_meta.uncompressed_digest = format!("{DIGEST_SHA512}:{:x}", hasher.finalize());
             } else {
                 return Err(anyhow!("{}: {:?}", ERR_BAD_COMPRESSED_DIGEST, diff_id));
             }
@@ -195,8 +225,9 @@ impl PullClient {
         );
 
         let destination = Path::new(&store_path);
+        let mut layer_file = std::fs::File::open(&layer_blob_path)?;
 
-        if let Err(e) = unpack(out, destination) {
+        if let Err(e) = unpack(&mut layer_file, destination) {
             fs::remove_dir_all(destination)?;
             return Err(e);
         }
@@ -352,15 +383,22 @@ mod tests {
             },
         ];
 
+        let data_dir = tempfile::tempdir().unwrap();
         for (i, d) in tests.iter().enumerate() {
             let msg = format!("test[{}]: {:?}", i, d);
+
+            let file_path = data_dir.path().join(format!("{}-data", i));
+            {
+                let mut file = fs::File::create(&file_path).unwrap();
+                file.write_all(&d.layer_data).unwrap();
+            }
 
             let result = client
                 .handle_layer(
                     d.layer.clone(),
                     d.diff_id.to_string(),
                     &d.decrypt_config,
-                    d.layer_data.clone(),
+                    &file_path,
                     ms.clone(),
                 )
                 .await;

--- a/src/unpack.rs
+++ b/src/unpack.rs
@@ -12,8 +12,8 @@ use std::path::Path;
 use tar::Archive;
 
 /// Unpack the contents of tarball to the destination path
-pub fn unpack(input: Vec<u8>, destination: &Path) -> Result<()> {
-    let mut archive = Archive::new(input.as_slice());
+pub fn unpack<R: io::Read>(input: R, destination: &Path) -> Result<()> {
+    let mut archive = Archive::new(input);
 
     if destination.exists() {
         return Err(anyhow!(
@@ -116,7 +116,7 @@ mod tests {
             fs::remove_dir_all(destination).unwrap();
         }
 
-        assert!(unpack(data.clone(), destination).is_ok());
+        assert!(unpack(data.clone().as_slice(), destination).is_ok());
 
         let path = destination.join("file.txt");
         let metadata = fs::metadata(&path).unwrap();
@@ -129,6 +129,6 @@ mod tests {
         assert_eq!(mtime, new_mtime);
 
         // destination already exists
-        assert!(unpack(data, destination).is_err());
+        assert!(unpack(data.as_slice(), destination).is_err());
     }
 }


### PR DESCRIPTION
New flow:
blob ->  download to secure storage file -> optional decrypt to secure storage file -> optional decompress to secure storage file -> unpack to layer folder

With this PR, pulling `docker.io/library/python:latest` using a test image-rs program under heaptrack reports:
```
peak heap memory consumption:
53.2MB after 04.025s
peak RSS (including heaptrack overhead):
72.6MB
total memory leaked:
50.9MB (10.6kB suppressed)
```

fixes #66 

Signed-off-by: Anand Krishnamoorthi <anakrish@microsoft.com>