### PR TITLE
decrypt: Improve error handling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,7 @@ strum_macros = "0.24"
 serial_test = "0.9.0"
 rstest = "0.16.0"
 test-utils = { path = "libs/test-utils" }
+regex = "1.7.0"
 
 [workspace]
 members = ["libs/test-utils"]


### PR DESCRIPTION
Enhanced `get_plaintext_layer()` so that it passes the full error back to the caller, along with error context. This resolves the issue of the method returning a generic "decrypt failed" message. Now, we return something like:

```
decrypt failed

Caused by:
    missing private key needed for decryption
```

This change necessitated reworking the tests to assert that the expected error stack / context is checked.

Fixes: #92.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>