### PR TITLE
Simple Signing: Replece sequoia-openpgp with pgp

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ oci-distribution = { git = "https://github.com/krustlet/oci-distribution.git", r
 oci-spec = "0.5.8"
 ocicrypt-rs = { git = "https://github.com/confidential-containers/ocicrypt-rs", rev = "55ab22d", default-features = false, features = ["keywrap-jwe", "async-io"], optional = true }
 prost = { version = "0.11", optional = true }
-sequoia-openpgp = { version = "1.7.0", default-features = false, features = ["compression", "crypto-rust", "allow-experimental-crypto", "allow-variable-time-crypto"], optional = true }
+pgp = { git = "https://github.com/Xynnn007/rpgp.git", branch = "feat-packet", optional = true }
 protobuf = { version = "3.2.0", optional = true }
 serde = { version = ">=1.0.27", features = ["serde_derive", "rc"] }
 serde_json = ">=1.0.9"
@@ -90,7 +90,7 @@ keywrap-ttrpc = ["ocicrypt-rs/keywrap-keyprovider-ttrpc", "dep:ttrpc", "dep:prot
 eaa-kbc = ["attestation_agent/eaa_kbc", "ocicrypt-rs/eaa_kbc"]
 
 signature = ["hex"]
-signature-simple = ["signature", "sequoia-openpgp", "serde_yaml"]
+signature-simple = ["signature", "pgp", "serde_yaml"]
 signature-cosign = ["signature", "sigstore"]
 
 snapshot-overlayfs = ["nix"]


### PR DESCRIPTION
> **warning** We should wait for https://github.com/rpgp/rpgp/pull/234 to be merged

sequoia-openpgp has a significant error in Nightly Rust due to address alignment. Also, sequoia-openpgp is larger than `pgp`. `pgp` is a purely rust crypto dependency.

This PR brings `pgp` to replace `sequoia-openpgp`.

Hi @jialez0 Please check this PR is good to you. Thanks!

Close https://github.com/confidential-containers/image-rs/issues/136