### PR TITLE
Add cc_kbc e2e tests

### DIFF
--- a/.github/workflows/cc_kbc-e2e.yaml
+++ b/.github/workflows/cc_kbc-e2e.yaml
@@ -1,0 +1,89 @@
+name: cc_kbc-e2e
+
+on:
+  push:
+    branches: [ "main" ]
+
+# Self-hosted runners do not set -o pipefail otherwise
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  e2e-test:
+    runs-on: 'ubuntu-22.04'
+    env:
+      SKOPEO_VERSION: "1.12.0"
+    strategy:
+      matrix:
+        test: [credentials-e2e.sh, decryption-e2e.sh]
+
+    steps:
+    - uses: actions-rs/toolchain@v1
+      with:
+        profile: minimal
+        toolchain: stable
+
+    - uses: actions/setup-go@v4
+      with:
+        go-version: stable
+
+    - name: Install dependencies
+      env:
+        SGX_URL: https://download.01.org/intel-sgx/sgx_repo/ubuntu
+      run: |
+        curl -L "${SGX_URL}/intel-sgx-deb.key" | sudo apt-key add -
+        echo "deb [arch=amd64] ${SGX_URL} jammy main" \
+          | sudo tee /etc/apt/sources.list.d/intel-sgx.list
+        sudo apt-get update
+        sudo apt-get install -y \
+          build-essential \
+          clang \
+          libassuan-dev \
+          libbtrfs-dev \
+          libdevmapper-dev \
+          libgpgme-dev \
+          libsgx-dcap-quote-verify-dev \
+          libtdx-attest-dev \
+          libtss2-dev \
+          openssl \
+          pkg-config \
+          protobuf-compiler \
+          wait-for-it \
+          wget
+
+    - uses: actions/checkout@v3
+
+    - uses: actions/checkout@v3
+      with:
+        repository: confidential-containers/kbs
+        path: kbs
+
+    - name: Set up rust build cache
+      uses: actions/cache@v3
+      continue-on-error: false
+      with:
+        path: |
+          ~/.cargo/registry/index/
+          ~/.cargo/registry/cache/
+          target
+          kbs/target
+        key: rust-${{ hashFiles('**/Cargo.toml') }}
+
+    - name: Set up skopeo build cache
+      uses: actions/cache@v3
+      continue-on-error: false
+      with:
+        path: /usr/local/bin/skopeo
+        key: skopeo-${{ env.SKOPEO_VERSION }}
+
+    - name: Build skopeo
+      run: |
+        if [ -f /usr/local/bin/skopeo ]; then exit 0; fi
+        wget -qO- "https://github.com/containers/skopeo/archive/refs/tags/v${SKOPEO_VERSION}.tar.gz" | tar xz
+        cd "skopeo-${SKOPEO_VERSION}"
+        DISABLE_DOCS=1 make bin/skopeo
+        sudo cp bin/skopeo /usr/local/bin
+
+    - name: Run ${{ matrix.test }}
+      run: ./hack/${{ matrix.test }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,4 +34,3 @@ zeroize = "1.5.7"
 
 [patch.crates-io]
 oci-distribution = { git = "https://github.com/krustlet/oci-distribution.git", rev = "f44124c" }
-

--- a/hack/common/attestation-agent.sh
+++ b/hack/common/attestation-agent.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+set -euo pipefail
+
+bold_echo() {
+  echo -e "\033[1m${1}\033[0m"
+}
+
+start_aa() {
+	bold_echo "Build attestation-agent..."
+	cargo b --release -p attestation-agent \
+		--no-default-features \
+		--features grpc,cc_kbc,openssl
+
+	bold_echo "Start attestation-agent..."
+	AA_SAMPLE_ATTESTER_TEST=1 ./target/release/attestation-agent \
+		--keyprovider_sock 127.0.0.1:50000 --getresource_sock 127.0.0.1:50001 &
+	aa_pid=$!
+	wait-for-it 127.0.0.1:50000 --timeout=10
+}

--- a/hack/common/kbs.sh
+++ b/hack/common/kbs.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+set -euo pipefail
+
+bold_echo() {
+  echo -e "\033[1m${1}\033[0m"
+}
+
+start_kbs() {
+	bold_echo "Build kbs..."
+	pushd kbs
+	cargo b --release -p kbs
+
+	bold_echo "Start kbs..."
+	openssl genpkey -algorithm ed25519 > kbs.key
+	openssl pkey -in kbs.key -pubout -out kbs.pem
+	./target/release/kbs --socket 127.0.0.1:8080 --insecure-http --auth-public-key ./kbs.pem &
+	kbs_pid=$!
+	wait-for-it 127.0.0.1:8080 --timeout=10
+	popd
+}

--- a/hack/common/registry.sh
+++ b/hack/common/registry.sh
@@ -1,0 +1,105 @@
+#!/bin/bash
+
+set -euo pipefail
+
+bold_echo() {
+  echo -e "\033[1m${1}\033[0m"
+}
+
+create_registry_certs() {
+	bold_echo "Create CA + certificates for local registry..."
+	mkdir -p ca certs
+
+	# Create a certificate authority
+	openssl rand -base64 48 > passphrase.txt
+
+	openssl genrsa \
+		-des3 \
+		-out ca.key \
+		--passout file:passphrase.txt 2048
+
+	openssl req \
+		-x509 \
+		-new \
+		-nodes \
+		-key ca.key \
+		--passin file:passphrase.txt \
+		-sha256 \
+		-days 1825 \
+		-out ca.pem \
+		-subj "/C=US/CN=faux-ca"
+
+	# Create a certificate signing request for localhost
+	openssl req \
+		-nodes \
+		-newkey rsa:2048 \
+		-keyout certs/domain.key \
+		-out certs/domain.csr \
+		-subj "/C=US/CN=coco-tests"
+
+	cat <<EOF > domains.ext
+authorityKeyIdentifier = keyid,issuer
+basicConstraints = CA:FALSE
+keyUsage = digitalSignature, nonRepudiation, keyEncipherment, dataEncipherment
+subjectAltName = @alt_names
+
+[alt_names]
+DNS.1 = localhost
+IP.1 = 127.0.0.1
+EOF
+
+	# Sign the certificate using the CA cert
+	openssl x509 -req \
+		-in certs/domain.csr \
+		-CA ./ca.pem \
+		-CAkey ./ca.key \
+		--passin file:passphrase.txt \
+		-CAcreateserial \
+		-days 1 \
+		-sha256 \
+		-extfile domains.ext \
+		-out certs/domain.crt
+
+	bold_echo "Add CA to OS trust store..."
+	sudo cp ca.pem /usr/local/share/ca-certificates/coco-test.crt
+	sudo update-ca-certificates
+}
+
+start_tls_registry_with_auth() {
+	create_registry_certs
+
+	bold_echo "Create auth file for registry..."
+	mkdir -p auth
+	docker run \
+		--entrypoint htpasswd \
+		httpd:2 -Bbn "$REGISTRY_USER" "$REGISTRY_PASSWORD" \
+		> auth/htpasswd
+
+	bold_echo "Start a registry with TLS and basic auth..."
+	docker run -d \
+		-p 5000:5000 \
+		--name registry \
+		-v "$(pwd)"/auth:/auth \
+		-e "REGISTRY_AUTH=htpasswd" \
+		-e "REGISTRY_AUTH_HTPASSWD_REALM=Registry Realm" \
+		-e REGISTRY_AUTH_HTPASSWD_PATH=/auth/htpasswd \
+		-v "$(pwd)"/certs:/certs \
+		-e REGISTRY_HTTP_TLS_CERTIFICATE=/certs/domain.crt \
+		-e REGISTRY_HTTP_TLS_KEY=/certs/domain.key \
+		registry:2
+	wait-for-it 127.0.0.1:5000 --timeout=60
+}
+
+start_tls_registry() {
+	create_registry_certs
+
+	bold_echo "Start a registry with TLS and basic auth..."
+	docker run -d \
+		-p 5000:5000 \
+		--name registry \
+		-v "$(pwd)"/certs:/certs \
+		-e REGISTRY_HTTP_TLS_CERTIFICATE=/certs/domain.crt \
+		-e REGISTRY_HTTP_TLS_KEY=/certs/domain.key \
+		registry:2
+	wait-for-it 127.0.0.1:5000 --timeout=60
+}

--- a/hack/credentials-e2e.sh
+++ b/hack/credentials-e2e.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+
+set -euo pipefail
+
+CRED_RESOURCE=default/credential/coco
+REGISTRY_USER=ci-user
+REGISTRY_PASSWORD=ci-password
+
+cleanup() {
+	docker ps -q --filter "name=registry" | grep -q . && docker rm -f registry
+	test -f /run/image-security/kbs/* && sudo rm /run/image-security/kbs/* || true
+	jobs -p | grep -q . && jobs -p | xargs kill
+}
+trap 'cleanup' EXIT
+
+bold_echo() {
+  echo -e "\033[1m${1}\033[0m"
+}
+
+# shellcheck source=hack/common/registry.sh
+. "$(dirname "${BASH_SOURCE[0]}")/common/registry.sh"
+# shellcheck source=hack/common/kbs.sh
+. "$(dirname "${BASH_SOURCE[0]}")/common/kbs.sh"
+# shellcheck source=hack/common/attestation-agent.sh
+. "$(dirname "${BASH_SOURCE[0]}")/common/attestation-agent.sh"
+
+[ -d "./kbs" ] || git clone https://github.com/confidential-containers/kbs.git
+
+start_kbs
+start_aa
+
+start_tls_registry_with_auth
+
+bold_echo "Store credentials in kbs..."
+cat <<EOF > auth.json
+{
+	"auths": {
+		"localhost:5000": {
+			"auth": "$(echo -n "$REGISTRY_USER:$REGISTRY_PASSWORD" | base64)"
+		}
+	}
+}
+EOF
+mkdir -p "/opt/confidential-containers/kbs/repository/$(dirname "$CRED_RESOURCE")"
+cp auth.json "/opt/confidential-containers/kbs/repository/${CRED_RESOURCE}"
+
+bold_echo "Store image in local registry..."
+docker login -u "$REGISTRY_USER" -p "$REGISTRY_PASSWORD" localhost:5000
+skopeo copy docker://busybox docker://localhost:5000/coco/busybox:v1
+
+bold_echo "Run registry credentials test..."
+CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUNNER='sudo -E' cargo test \
+	-p image-rs \
+	--features getresource,snapshot-overlayfs,oci-distribution/rustls-tls-native-roots,e2e-test \
+	-- --test retrieve_credentials_via_kbs --nocapture

--- a/hack/decryption-e2e.sh
+++ b/hack/decryption-e2e.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+
+set -euo pipefail
+
+KEYPROVIDER_SOCKET=127.0.0.1:50000
+KBS_RESOURCE=default/key/image
+
+cleanup() {
+	docker ps -q --filter "name=registry" | grep -q . && docker rm -f registry
+	jobs -p | grep -q . && jobs -p | xargs kill
+}
+trap 'cleanup' EXIT
+
+bold_echo() {
+  echo -e "\033[1m${1}\033[0m"
+}
+
+# shellcheck source=hack/common/registry.sh
+. "$(dirname "${BASH_SOURCE[0]}")/common/registry.sh"
+# shellcheck source=hack/common/kbs.sh
+. "$(dirname "${BASH_SOURCE[0]}")/common/kbs.sh"
+# shellcheck source=hack/common/attestation-agent.sh
+. "$(dirname "${BASH_SOURCE[0]}")/common/attestation-agent.sh"
+
+[ -d "./kbs" ] || git clone https://github.com/confidential-containers/kbs.git
+
+bold_echo "Build coco_keyprovider..."
+cargo b --release -p coco_keyprovider
+
+bold_echo "Start coco_keyprovider..."
+./target/release/coco_keyprovider --socket "$KEYPROVIDER_SOCKET" &
+keyprovider_pid=$!
+wait-for-it "$KEYPROVIDER_SOCKET" --timeout=10
+
+start_tls_registry
+
+bold_echo "Encrypt image with random secret..."
+cat <<EOF > ocicrypt.conf
+{
+	"key-providers": {
+		"attestation-agent": {
+			"grpc": "$KEYPROVIDER_SOCKET"
+		}
+	}
+}
+EOF
+keypath="${PWD}/image_key"
+head -c 32 < /dev/urandom > "$keypath"
+keyid="kbs://127.0.0.1:8080/${KBS_RESOURCE}"
+OCICRYPT_KEYPROVIDER_CONFIG="${PWD}/ocicrypt.conf" skopeo copy \
+	--insecure-policy \
+	--encryption-key "provider:attestation-agent:keypath=${keypath}::keyid=${keyid}::algorithm=A256GCM" \
+	--dest-tls-verify=false \
+	docker://busybox \
+	docker://localhost:5000/coco/busybox_encrypted:v1
+kill "$keyprovider_pid"
+
+start_kbs
+
+bold_echo "Store key in kbs repository..."
+mkdir -p "/opt/confidential-containers/kbs/repository/$(dirname "$KBS_RESOURCE")"
+cp "$keypath" "/opt/confidential-containers/kbs/repository/${KBS_RESOURCE}"
+
+start_aa
+
+bold_echo "Run image decryption test..."
+CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUNNER='sudo -E' cargo test \
+	-p image-rs \
+	--features encryption-ring,getresource,oci-distribution/rustls-tls-native-roots,e2e-test \
+	-- --test decrypt_layers_via_kbs --nocapture

--- a/image-rs/Cargo.toml
+++ b/image-rs/Cargo.toml
@@ -114,3 +114,5 @@ snapshot-overlayfs = ["nix"]
 snapshot-unionfs = ["nix", "dircpy", "fs_extra"]
 
 getresource = [ "lazy_static", "cfg-if" ]
+
+e2e-test = []

--- a/image-rs/tests/common/mod.rs
+++ b/image-rs/tests/common/mod.rs
@@ -20,12 +20,39 @@ pub const AA_PARAMETER: &str = "provider:attestation-agent:offline_fs_kbc::null"
 
 const OFFLINE_FS_KBC_RESOURCE: &str = "aa-offline_fs_kbc-resources.json";
 
-pub async fn prepare_test() {
+pub struct TempDirs {
+    pub work_dir: tempfile::TempDir,
+    pub bundle_dir: tempfile::TempDir,
+}
+
+impl TempDirs {
+    pub fn new() -> Self {
+        let work_dir = tempfile::tempdir().unwrap();
+        let bundle_dir = tempfile::tempdir().unwrap();
+        Self {
+            work_dir,
+            bundle_dir,
+        }
+    }
+}
+
+#[cfg(feature = "snapshot-overlayfs")]
+impl Drop for TempDirs {
+    fn drop(&mut self) {
+        umount_bundle(&self.bundle_dir);
+    }
+}
+
+pub fn assert_root_privilege() {
     // Check whether is in root privilege
     assert!(
         nix::unistd::Uid::effective().is_root(),
         "The test needs to run as root."
     );
+}
+
+pub async fn prepare_test() {
+    assert_root_privilege();
 
     // Prepare files
     Command::new(SIGNATURE_SCRIPT)


### PR DESCRIPTION
## cc_kbc e2e tests

## Rationale

This code wants to cover an e2e scenario for image decryption and repository cred retrieval in a cc_kbc + kbs setup. It could detect unintended breakage in those components, but maybe also provide spec + documentation.

It's two tests that are ignored by default, because they are rather costly to run (> 20m without cache, ~4m w/ populated cache) and it requires a bit of setup ceremony. 

## Implementation

The decryption test encrypts an image with a random key using aa's `coco_keyprovider` and skopeo. The encrypted image is stored in a local registry (to keep the test self-contained).

Attestation Agent is started using the sample attester (could use a matrix to also run it on real TEEs). A kbs instance (bundled w/ Attestion Service) is also started locally. The test then retrieves the encrypted image from the local registry, triggering a remote attestation procedure via attestation-agent. After a successful attestation ocicrypt-rs is decrypting the layers via the KBS-released key.

The credentials test creates a local registry with auth and stores an image in it. A dockerconfig auth is put into the kbs repo. On image pull the attestation-agent then requests the credentials from kbs which is then used to access the local registry.

I'd suggest a good schedule for the trigger would be merges to main.

## Example

[example run](https://github.com/mkulke/image-rs/actions/runs/5390050114)