### PR TITLE
Adjusted the handling of URLs to support more types of hosts

### DIFF
--- a/attestation-agent/kbc/src/cc_kbc/mod.rs
+++ b/attestation-agent/kbc/src/cc_kbc/mod.rs
@@ -6,7 +6,7 @@
 use crate::{KbcCheckInfo, KbcInterface};
 use crypto::decrypt;
 
-use kbs_protocol::{KbsProtocolWrapper, KbsRequest, KBS_URL_PREFIX};
+use kbs_protocol::{KbsProtocolWrapper, KbsRequest, KBS_PREFIX};
 
 use super::AnnotationPacket;
 use anyhow::*;
@@ -98,7 +98,7 @@ impl Kbc {
         let r#type = &resource.r#type;
         let tag = &resource.tag;
         Ok(format!(
-            "{kbs_addr}{KBS_URL_PREFIX}/resource/{repo}/{type}/{tag}"
+            "{kbs_addr}{KBS_PREFIX}/resource/{repo}/{type}/{tag}"
         ))
     }
 }


### PR DESCRIPTION
Currently, our default host URL format for KBS is http://IP:PORT, But in productization, we may give host URL more forms. For example: http://my-kbs.com , http://my-kbs.com/user-alice Therefore, it is necessary to expand the supported KBS host URL format, More precisely, it should no longer be referred to as the "host URL", but rather as the "root URL".