### PR TITLE
ci: Occlum: fix ci test

### DIFF
--- a/.github/workflows/aa_occlum_sgx.yml
+++ b/.github/workflows/aa_occlum_sgx.yml
@@ -3,14 +3,17 @@ on:
   push:
     paths:
       - 'attestation-agent/attester/src/sgx_occlum'
+      - 'attestation-agent/ci/occlum**'
       - '.github/workflows/aa_occlum_sgx.yml'
   pull_request:
     paths:
       - 'attestation-agent/attester/src/sgx_occlum'
+      - 'attestation-agent/ci/occlum**'
       - '.github/workflows/aa_occlum_sgx.yml'
   create:
     paths:
       - 'attestation-agent/attester/src/sgx_occlum'
+      - 'attestation-agent/ci/occlum**'
       - '.github/workflows/aa_occlum_sgx.yml'
 
 jobs:

--- a/attestation-agent/ci/occlum.yaml
+++ b/attestation-agent/ci/occlum.yaml
@@ -4,4 +4,4 @@ targets:
   - target: /bin
     copy:
       - files:
-        - ../../target/debug/occlum-attester
+        - ../../../target/debug/occlum-attester


### PR DESCRIPTION
Built binary `occlum-attester` will be put in the top `target` directory of the workspace.