### PR TITLE
AA: use URL safe base64 encoding for TeePubKey

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ cfg-if = "1.0.0"
 clap = "3.2.5"
 const_format = "0.2.30"
 env_logger = "0.9.0"
-kbs-types = "0.3"
+kbs-types = "0.4"
 lazy_static = "1.4.0"
 log = "0.4.14"
 resource_uri = { path = "attestation-agent/deps/resource_uri" }

--- a/attestation-agent/deps/crypto/src/teekey.rs
+++ b/attestation-agent/deps/crypto/src/teekey.rs
@@ -13,6 +13,7 @@ use sha2::{Digest, Sha384};
 const RSA_PUBKEY_LENGTH: usize = 2048;
 const NEW_PADDING: fn() -> PaddingScheme = PaddingScheme::new_pkcs1v15_encrypt;
 
+pub const RSA_KEY_TYPE: &str = "RSA";
 pub const RSA_ALGORITHM: &str = "RSA1_5";
 pub const AES_256_GCM_ALGORITHM: &str = "A256GCM";
 
@@ -36,12 +37,15 @@ impl TeeKey {
         })
     }
 
-    // Export TEE public key as specific structure.
+    // Export TEE public key as JWK, as defined in RFC 7517.
     pub fn export_pubkey(&self) -> Result<TeePubKey> {
-        let k_mod = base64::encode(self.public_key.n().to_bytes_be());
-        let k_exp = base64::encode(self.public_key.e().to_bytes_be());
+        let k_mod =
+            base64::encode_config(self.public_key.n().to_bytes_be(), base64::URL_SAFE_NO_PAD);
+        let k_exp =
+            base64::encode_config(self.public_key.e().to_bytes_be(), base64::URL_SAFE_NO_PAD);
 
         Ok(TeePubKey {
+            kty: RSA_KEY_TYPE.to_string(),
             alg: RSA_ALGORITHM.to_string(),
             k_mod,
             k_exp,


### PR DESCRIPTION
Port of https://github.com/confidential-containers/attestation-agent/pull/211

---

Fixes https://github.com/confidential-containers/guest-components/issues/184