### PR TITLE
aa/attester: Update virtee/sev dep to 1.2

### DIFF
--- a/attestation-agent/attester/Cargo.toml
+++ b/attestation-agent/attester/Cargo.toml
@@ -13,7 +13,7 @@ log.workspace = true
 occlum_dcap = { git = "https://github.com/occlum/occlum", rev = "dbe404f", optional = true }
 serde.workspace = true
 serde_json.workspace = true
-sev = { git = "https://github.com/virtee/sev", rev = "3dca05d2c93388cb00534ad18f5928fd812e99cc", optional = true }
+sev = { git = "https://github.com/virtee/sev", version = "1.2", default-features = false, features = ["snp"], optional = true }
 strum.workspace = true
 tdx-attest-rs = { git = "https://github.com/intel/SGXDataCenterAttestationPrimitives", tag = "DCAP_1.16", optional = true }
 

--- a/attestation-agent/attester/src/snp/mod.rs
+++ b/attestation-agent/attester/src/snp/mod.rs
@@ -6,9 +6,9 @@
 use super::Attester;
 use anyhow::*;
 use serde::{Deserialize, Serialize};
-use sev::firmware::guest::types::{AttestationReport, SnpReportReq};
+use sev::firmware::guest::AttestationReport;
 use sev::firmware::guest::Firmware;
-use sev::firmware::host::types::CertTableEntry;
+use sev::firmware::host::CertTableEntry;
 use std::path::Path;
 
 pub fn detect_platform() -> bool {
@@ -35,10 +35,10 @@ impl Attester for SnpAttester {
         report_data_bin.extend([0; 16]);
 
         let mut firmware = Firmware::open()?;
-        let report_request = SnpReportReq::new(Some(report_data_bin.as_slice().try_into()?), 0);
+        let data = report_data_bin.as_slice().try_into()?;
 
         let (report, certs) = firmware
-            .snp_get_ext_report(None, report_request)
+            .get_ext_report(None, Some(data), Some(0))
             .context("Failed to get attestation report")?;
 
         let evidence = SnpEvidence {


### PR DESCRIPTION
virtee/sev 1.2 broke the API from 1.1, but we ended up using it in az-snp-vtpm. Now we see issue building kbs when multiple conflicting versions of virtee/sev are required. Bump the dependency here and adapt the code to the new API.