### PR TITLE
Optimize implementation of image-rs/stream

### DIFF
--- a/image-rs/Cargo.toml
+++ b/image-rs/Cargo.toml
@@ -17,7 +17,6 @@ base64 = "0.13.0"
 cfg-if = { version = "1.0.0", optional = true }
 dircpy = { version = "0.3.12", optional = true }
 flate2 = "1.0"
-flume = "0.10.14"
 fs_extra = { version = "1.2.0", optional = true }
 futures = { version = "0.3.28", optional = true }
 futures-util = "0.3"

--- a/image-rs/src/digest.rs
+++ b/image-rs/src/digest.rs
@@ -1,0 +1,43 @@
+// Copyright (c) 2022 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+
+use sha2::Digest;
+
+pub const DIGEST_SHA256_PREFIX: &str = "sha256:";
+pub const DIGEST_SHA512_PREFIX: &str = "sha512:";
+
+pub trait DigestHasher {
+    fn digest_update(&mut self, buf: &[u8]);
+    fn digest_finalize(self) -> String;
+}
+
+#[derive(Clone, Debug)]
+pub enum LayerDigestHasher {
+    Sha256(sha2::Sha256),
+    Sha512(sha2::Sha512),
+}
+
+impl DigestHasher for LayerDigestHasher {
+    fn digest_update(&mut self, buf: &[u8]) {
+        match self {
+            LayerDigestHasher::Sha256(hasher) => {
+                hasher.update(buf);
+            }
+            LayerDigestHasher::Sha512(hasher) => {
+                hasher.update(buf);
+            }
+        }
+    }
+
+    fn digest_finalize(self) -> String {
+        match self {
+            LayerDigestHasher::Sha256(hasher) => {
+                format!("{}{:x}", DIGEST_SHA256_PREFIX, hasher.finalize())
+            }
+            LayerDigestHasher::Sha512(hasher) => {
+                format!("{}{:x}", DIGEST_SHA512_PREFIX, hasher.finalize())
+            }
+        }
+    }
+}

--- a/image-rs/src/lib.rs
+++ b/image-rs/src/lib.rs
@@ -10,6 +10,7 @@ pub mod bundle;
 pub mod config;
 pub mod decoder;
 pub mod decrypt;
+pub mod digest;
 pub mod image;
 pub mod meta_store;
 #[cfg(feature = "nydus")]

--- a/image-rs/src/stream.rs
+++ b/image-rs/src/stream.rs
@@ -89,8 +89,8 @@ async fn channel_processing(
         Result::<()>::Ok(())
     });
 
-    let mut buffer = [0; CAPACITY];
     loop {
+        let mut buffer = vec![0u8; CAPACITY];
         let n = layer_reader
             .read(&mut buffer)
             .await
@@ -99,8 +99,9 @@ async fn channel_processing(
             break;
         }
 
-        hasher.digest_update(&buffer[..n]);
-        tx.send_async(buffer[..n].to_vec())
+        buffer.resize(n, 0);
+        hasher.digest_update(&buffer);
+        tx.send_async(buffer)
             .await
             .map_err(|e| anyhow!("channel: send failed {:?}", e))?;
     }

--- a/image-rs/src/stream.rs
+++ b/image-rs/src/stream.rs
@@ -57,23 +57,17 @@ pub async fn stream_processing(
     destination: &Path,
 ) -> Result<String> {
     let dest = destination.to_path_buf();
-    let digest_str = if diff_id.starts_with(DIGEST_SHA256_PREFIX) {
-        let hasher = LayerDigestHasher::Sha256(sha2::Sha256::new());
-
-        channel_processing(layer_reader, hasher, dest)
-            .await
-            .map_err(|e| anyhow!("hasher {} {:?}", DIGEST_SHA256_PREFIX, e))?
+    let hasher = if diff_id.starts_with(DIGEST_SHA256_PREFIX) {
+        LayerDigestHasher::Sha256(sha2::Sha256::new())
     } else if diff_id.starts_with(DIGEST_SHA512_PREFIX) {
-        let hasher = LayerDigestHasher::Sha512(sha2::Sha512::new());
-
-        channel_processing(layer_reader, hasher, dest)
-            .await
-            .map_err(|e| anyhow!("hasher {} {:?}", DIGEST_SHA512_PREFIX, e))?
+        LayerDigestHasher::Sha512(sha2::Sha512::new())
     } else {
         bail!("{}: {:?}", ERR_BAD_UNCOMPRESSED_DIGEST, diff_id);
     };
 
-    Ok(digest_str)
+    channel_processing(layer_reader, hasher, dest)
+        .await
+        .map_err(|e| anyhow!("hasher {} {:?}", DIGEST_SHA256_PREFIX, e))
 }
 
 async fn channel_processing(


### PR DESCRIPTION
Optimize implementation of image-rs/stream:
1) unify digest algorithm prefixes
2) avoid unnecessary memory copy
3) simplify function stream_processing()
4) get rid of flume crate to reduce dependency