### PR TITLE
Optimize implementation of image-rs/pull

### DIFF
--- a/image-rs/src/lib.rs
+++ b/image-rs/src/lib.rs
@@ -5,6 +5,8 @@
 /// Environment macro for `image-rs` work dir.
 pub const CC_IMAGE_WORK_DIR: &str = "CC_IMAGE_WORK_DIR";
 
+pub const ERR_BAD_UNCOMPRESSED_DIGEST: &str = "unsupported uncompressed digest format";
+
 pub mod auth;
 pub mod bundle;
 pub mod config;

--- a/image-rs/src/pull.rs
+++ b/image-rs/src/pull.rs
@@ -2,29 +2,22 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-use anyhow::{anyhow, bail, Context, Result};
-use futures_util::future;
+use anyhow::{anyhow, bail, Result};
 use futures_util::stream::{self, StreamExt, TryStreamExt};
 use oci_distribution::manifest::{OciDescriptor, OciImageManifest};
 use oci_distribution::{secrets::RegistryAuth, Client, Reference};
-use sha2::Digest;
 use std::convert::TryFrom;
-use std::fs;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use tokio::sync::Mutex;
 
 use crate::decoder::Compression;
 use crate::decrypt::Decryptor;
-use crate::digest::{DIGEST_SHA256_PREFIX, DIGEST_SHA512_PREFIX};
 use crate::image::LayerMeta;
 use crate::meta_store::MetaStore;
 use crate::stream::stream_processing;
-use crate::unpack::unpack;
 
 const ERR_NO_DECRYPT_CFG: &str = "decrypt_config is None";
-const ERR_BAD_UNCOMPRESSED_DIGEST: &str = "unsupported uncompressed digest format";
-const ERR_BAD_COMPRESSED_DIGEST: &str = "unsupported compressed digest format";
 
 /// The PullClient connects to remote OCI registry, pulls the container image,
 /// and save the image layers under data_dir and return the layer meta info.
@@ -73,41 +66,6 @@ impl<'a> PullClient<'a> {
             .map_err(|e| anyhow!("failed to pull manifest {}", e.to_string()))
     }
 
-    /// pull_layers pulls an image layers and do ondemand decrypt/decompress.
-    /// It returns the layer metadata for layer db to track.
-    pub async fn pull_layers(
-        &self,
-        layer_descs: Vec<OciDescriptor>,
-        diff_ids: &[String],
-        decrypt_config: &Option<&str>,
-        meta_store: Arc<Mutex<MetaStore>>,
-    ) -> Result<Vec<LayerMeta>> {
-        let layer_metas = layer_descs.into_iter().enumerate().map(|(i, layer)| {
-            let client = &self.client;
-            let reference = &self.reference;
-            let ms = meta_store.clone();
-
-            async move {
-                let mut layer_data: Vec<u8> = Vec::new();
-
-                client
-                    .pull_blob(reference, &layer.digest, &mut layer_data)
-                    .await?;
-
-                self.handle_layer(layer, diff_ids[i].clone(), decrypt_config, layer_data, ms)
-                    .await
-            }
-        });
-
-        let layer_metas = future::join_all(layer_metas)
-            .await
-            .into_iter()
-            .filter_map(|v| v.ok())
-            .collect();
-
-        Ok(layer_metas)
-    }
-
     /// pull_bootstrap pulls a nydus image's bootstrap layer.
     pub async fn pull_bootstrap(
         &self,
@@ -123,105 +81,6 @@ impl<'a> PullClient<'a> {
             Some(b) => Ok(b.clone()),
             None => Err(anyhow!("Failed to  download this bootstrap layer")),
         }
-    }
-
-    async fn handle_layer(
-        &self,
-        layer: OciDescriptor,
-        diff_id: String,
-        decrypt_config: &Option<&str>,
-        layer_data: Vec<u8>,
-        ms: Arc<Mutex<MetaStore>>,
-    ) -> Result<LayerMeta> {
-        let mut out: Vec<u8> = Vec::new();
-        let plaintext_layer: Vec<u8>;
-
-        let mut layer_meta = LayerMeta::default();
-        let mut media_type_str: &str = layer.media_type.as_str();
-
-        let decryptor = Decryptor::from_media_type(&layer.media_type);
-
-        if decryptor.is_encrypted() {
-            if let Some(dc) = decrypt_config {
-                plaintext_layer = decryptor.get_plaintext_layer(&layer, layer_data, dc)?;
-                media_type_str = decryptor.media_type.as_str();
-                layer_meta.encrypted = true;
-            } else {
-                bail!(ERR_NO_DECRYPT_CFG);
-            }
-        } else {
-            plaintext_layer = layer_data;
-        }
-
-        let layer_db = &ms.lock().await.layer_db;
-
-        if let Some(layer_meta) = layer_db.get(&layer.digest) {
-            return Ok(layer_meta.clone());
-        }
-
-        layer_meta.decoder = Compression::try_from(media_type_str)?;
-
-        if layer_meta.decoder == Compression::Uncompressed {
-            let digest = if diff_id.starts_with(DIGEST_SHA256_PREFIX) {
-                format!(
-                    "{}{:x}",
-                    DIGEST_SHA256_PREFIX,
-                    sha2::Sha256::digest(plaintext_layer.as_slice())
-                )
-            } else if diff_id.starts_with(DIGEST_SHA512_PREFIX) {
-                format!(
-                    "{}{:x}",
-                    DIGEST_SHA512_PREFIX,
-                    sha2::Sha512::digest(plaintext_layer.as_slice())
-                )
-            } else {
-                bail!("{}: {:?}", ERR_BAD_UNCOMPRESSED_DIGEST, diff_id);
-            };
-
-            layer_meta.uncompressed_digest = digest.clone();
-            layer_meta.compressed_digest = digest;
-        } else {
-            layer_meta.compressed_digest = layer.digest.clone();
-            layer_meta
-                .decoder
-                .decompress(plaintext_layer.as_slice(), &mut out)?;
-
-            if diff_id.starts_with(DIGEST_SHA256_PREFIX) {
-                layer_meta.uncompressed_digest =
-                    format!("{DIGEST_SHA256_PREFIX}{:x}", sha2::Sha256::digest(&out));
-            } else if diff_id.starts_with(DIGEST_SHA512_PREFIX) {
-                layer_meta.uncompressed_digest =
-                    format!("{DIGEST_SHA512_PREFIX}{:x}", sha2::Sha512::digest(&out));
-            } else {
-                bail!("{}: {:?}", ERR_BAD_COMPRESSED_DIGEST, diff_id);
-            }
-        }
-
-        // uncompressed digest should equal to the diff_ids in image_config.
-        if layer_meta.uncompressed_digest != diff_id {
-            bail!(
-                "unequal uncompressed digest {:?} config diff_id {:?}",
-                layer_meta.uncompressed_digest,
-                diff_id
-            );
-        }
-
-        let store_path = format!(
-            "{}/{}",
-            self.data_dir.display(),
-            &layer.digest.to_string().replace(':', "_")
-        );
-
-        let destination = Path::new(&store_path);
-
-        if let Err(e) = unpack(out.as_slice(), destination) {
-            fs::remove_dir_all(destination).context("Failed to roll back when unpacking")?;
-            return Err(e);
-        }
-
-        layer_meta.store_path = destination.display().to_string();
-
-        Ok(layer_meta)
     }
 
     /// async_pull_layers pulls an image layers and do ondemand decrypt/decompress.
@@ -347,6 +206,7 @@ mod tests {
     use super::*;
     use crate::config::DEFAULT_MAX_CONCURRENT_DOWNLOAD;
     use crate::decoder::ERR_BAD_MEDIA_TYPE;
+    use crate::ERR_BAD_UNCOMPRESSED_DIGEST;
     use flate2::write::GzEncoder;
     use oci_distribution::manifest::IMAGE_CONFIG_MEDIA_TYPE;
     use oci_spec::image::{ImageConfiguration, MediaType};
@@ -379,7 +239,7 @@ mod tests {
             let diff_ids = image_config.rootfs().diff_ids();
 
             client
-                .pull_layers(
+                .async_pull_layers(
                     image_manifest.layers.clone(),
                     diff_ids,
                     &None,
@@ -421,7 +281,7 @@ mod tests {
             std::env::set_var("OCICRYPT_KEYPROVIDER_CONFIG", keyprovider_config);
 
             assert!(client
-                .pull_layers(
+                .async_pull_layers(
                     image_manifest.layers.clone(),
                     diff_ids,
                     &Some(decrypt_config.to_str().unwrap()),
@@ -508,125 +368,6 @@ mod tests {
             {
                 panic!("failed to download encrypted image, {}", e);
             }
-        }
-    }
-
-    #[tokio::test]
-    async fn test_handle_layer() {
-        let oci_image = Reference::try_from("docker.io/arronwang/busybox_gzip")
-            .expect("create reference failed");
-
-        let bad_media_err = format!("{}: {}", ERR_BAD_MEDIA_TYPE, IMAGE_CONFIG_MEDIA_TYPE);
-
-        let empty_diff_id = "";
-
-        let default_layer = OciDescriptor::default();
-
-        let uncompressed_layer = OciDescriptor {
-            media_type: MediaType::ImageLayer.to_string(),
-            ..Default::default()
-        };
-
-        let data: Vec<u8> = b"This is some text!".to_vec();
-
-        let mut gzip_encoder = GzEncoder::new(Vec::new(), flate2::Compression::default());
-        gzip_encoder.write_all(&data).unwrap();
-        let gzip_compressed_bytes = gzip_encoder.finish().unwrap();
-
-        let compressed_layer = OciDescriptor {
-            media_type: MediaType::ImageLayerGzip.to_string(),
-            ..Default::default()
-        };
-
-        let tempdir = tempfile::tempdir().unwrap();
-        let mut client = PullClient::new(
-            oci_image,
-            tempdir.path(),
-            &RegistryAuth::Anonymous,
-            DEFAULT_MAX_CONCURRENT_DOWNLOAD,
-        )
-        .unwrap();
-
-        let (_image_manifest, _image_digest, _image_config) = client.pull_manifest().await.unwrap();
-
-        let meta_store = MetaStore::default();
-        let ms = Arc::new(Mutex::new(meta_store));
-
-        #[derive(Debug)]
-        struct TestData<'a> {
-            layer: OciDescriptor,
-            diff_id: &'a str,
-            decrypt_config: Option<&'a str>,
-            layer_data: Vec<u8>,
-            result: Result<LayerMeta>,
-        }
-
-        let tests = &[
-            TestData {
-                layer: default_layer.clone(),
-                diff_id: empty_diff_id,
-                decrypt_config: None,
-                layer_data: Vec::<u8>::new(),
-                result: Err(anyhow!(bad_media_err.clone())),
-            },
-            TestData {
-                layer: default_layer.clone(),
-                diff_id: "foo",
-                decrypt_config: None,
-                layer_data: Vec::<u8>::new(),
-                result: Err(anyhow!(bad_media_err.clone())),
-            },
-            #[cfg(all(feature = "encryption", feature = "keywrap-grpc"))]
-            TestData {
-                layer: OciDescriptor {
-                    media_type: ocicrypt_rs::spec::MEDIA_TYPE_LAYER_ENC.to_string(),
-                    ..Default::default()
-                },
-                diff_id: empty_diff_id,
-                decrypt_config: None,
-                layer_data: Vec::<u8>::new(),
-                result: Err(anyhow!(ERR_NO_DECRYPT_CFG)),
-            },
-            TestData {
-                layer: uncompressed_layer,
-                diff_id: empty_diff_id,
-                decrypt_config: None,
-                layer_data: Vec::<u8>::new(),
-                result: Err(anyhow!(
-                    "{}: {:?}",
-                    ERR_BAD_UNCOMPRESSED_DIGEST,
-                    empty_diff_id
-                )),
-            },
-            TestData {
-                layer: compressed_layer,
-                diff_id: empty_diff_id,
-                decrypt_config: None,
-                layer_data: gzip_compressed_bytes,
-                result: Err(anyhow!(
-                    "{}: {:?}",
-                    ERR_BAD_COMPRESSED_DIGEST,
-                    empty_diff_id
-                )),
-            },
-        ];
-
-        for (i, d) in tests.iter().enumerate() {
-            let msg = format!("test[{}]: {:?}", i, d);
-
-            let result = client
-                .handle_layer(
-                    d.layer.clone(),
-                    d.diff_id.to_string(),
-                    &d.decrypt_config,
-                    d.layer_data.clone(),
-                    ms.clone(),
-                )
-                .await;
-
-            let msg = format!("{}: result: {:?}", msg, result);
-
-            assert_result!(d.result, result, msg);
         }
     }
 

--- a/image-rs/src/pull.rs
+++ b/image-rs/src/pull.rs
@@ -29,7 +29,7 @@ const ERR_BAD_COMPRESSED_DIGEST: &str = "unsupported compressed digest format";
 /// The PullClient connects to remote OCI registry, pulls the container image,
 /// and save the image layers under data_dir and return the layer meta info.
 pub struct PullClient<'a> {
-    /// `oci-distribuion` client to talk with remote OCI registry.
+    /// `oci-distribution` client to talk with remote OCI registry.
     pub client: Client,
 
     /// OCI registry auth info.
@@ -115,12 +115,12 @@ impl<'a> PullClient<'a> {
         diff_id: String,
         decrypt_config: &Option<&str>,
         meta_store: Arc<Mutex<MetaStore>>,
-    ) -> Result<Vec<LayerMeta>> {
+    ) -> Result<LayerMeta> {
         let layer_metas = self
-            .pull_layers(vec![bootstrap_desc], &[diff_id], decrypt_config, meta_store)
+            .async_pull_layers(vec![bootstrap_desc], &[diff_id], decrypt_config, meta_store)
             .await?;
         match layer_metas.get(0) {
-            Some(b) => Ok(vec![b.clone()]),
+            Some(b) => Ok(b.clone()),
             None => Err(anyhow!("Failed to  download this bootstrap layer")),
         }
     }

--- a/image-rs/src/stream.rs
+++ b/image-rs/src/stream.rs
@@ -12,9 +12,9 @@ use tokio::io::{AsyncRead, AsyncReadExt};
 
 use crate::digest::{DigestHasher, LayerDigestHasher, DIGEST_SHA256_PREFIX, DIGEST_SHA512_PREFIX};
 use crate::unpack::unpack;
+use crate::ERR_BAD_UNCOMPRESSED_DIGEST;
 
 const CAPACITY: usize = 32768;
-const ERR_BAD_UNCOMPRESSED_DIGEST: &str = "unsupported uncompressed digest format";
 
 // Wrap a channel with [`Read`](std::io::Read) support.
 // This can bridge the [`AsyncRead`](tokio::io::AsyncRead) from


### PR DESCRIPTION
Optimize implementation of image-rs/pull by:
1) simplify implementation of async_pull_layers()
2) remove pull_layers()
3) simplify definition of pull_bootstrap()