### PR TITLE
ci: Fix integration test for image-rs

### DIFF
--- a/.github/workflows/image_rs_build.yml
+++ b/.github/workflows/image_rs_build.yml
@@ -66,15 +66,15 @@ jobs:
 
       - name: Run cargo test - default
         run: |
-          sudo -E PATH=$PATH -s cargo test --all --features default
+          sudo -E PATH=$PATH -s cargo test -p image-rs --features default
 
       - name: Run cargo test - kata-cc (rust-tls version) with keywrap-grpc + keywrap-jwe
         run: |
-          sudo -E PATH=$PATH -s cargo test --all --no-default-features --features=encryption-ring,keywrap-grpc,snapshot-overlayfs,signature-cosign-rustls,signature-simple,getresource,oci-distribution/rustls-tls,keywrap-jwe
+          sudo -E PATH=$PATH -s cargo test -p image-rs --no-default-features --features=encryption-ring,keywrap-grpc,snapshot-overlayfs,signature-cosign-rustls,signature-simple,getresource,oci-distribution/rustls-tls,keywrap-jwe
 
       - name: Run cargo test - kata-cc (native-tls version) with keywrap-grpc + keywrap-jwe
         run: |
-          sudo -E PATH=$PATH -s cargo test --all --no-default-features --features=encryption-openssl,keywrap-grpc,snapshot-overlayfs,signature-cosign-native,signature-simple,getresource,oci-distribution/native-tls,keywrap-jwe
+          sudo -E PATH=$PATH -s cargo test -p image-rs --no-default-features --features=encryption-openssl,keywrap-grpc,snapshot-overlayfs,signature-cosign-native,signature-simple,getresource,oci-distribution/native-tls,keywrap-jwe
 
       - name: Prepare for ttrpc test
         run: |
@@ -83,8 +83,8 @@ jobs:
 
       - name: Run cargo test - kata-cc (rust-tls version) with keywrap-ttrpc (default) + keywrap-jwe
         run: |
-          sudo -E PATH=$PATH -s cargo test --all --no-default-features --features=kata-cc-rustls-tls,keywrap-jwe
+          sudo -E PATH=$PATH -s cargo test -p image-rs --no-default-features --features=kata-cc-rustls-tls,keywrap-jwe
 
       - name: Run cargo test - kata-cc (native-tls version) with keywrap-ttrpc (default) + keywrap-jwe
         run: |
-          sudo -E PATH=$PATH -s cargo test --all --no-default-features --features=kata-cc-native-tls,keywrap-jwe
+          sudo -E PATH=$PATH -s cargo test -p image-rs --no-default-features --features=kata-cc-native-tls,keywrap-jwe

--- a/image-rs/scripts/build_attestation_agent.sh
+++ b/image-rs/scripts/build_attestation_agent.sh
@@ -17,10 +17,8 @@ parameters="KBC=offline_fs_kbc"
 source $HOME/.cargo/env
 
 SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
-AA_DIR=$SCRIPT_DIR/attestation_agent
+AA_DIR=$SCRIPT_DIR/../../attestation-agent
 
-pushd $SCRIPT_DIR
-git clone "https://github.com/confidential-containers/attestation-agent.git" $AA_DIR
 pushd $AA_DIR
 
 make $parameters

--- a/image-rs/scripts/build_attestation_agent.sh
+++ b/image-rs/scripts/build_attestation_agent.sh
@@ -24,9 +24,3 @@ pushd $AA_DIR
 make $parameters
 make DESTDIR="$SCRIPT_DIR" install
 popd
-
-cleanup() {
-  rm -rf "$AA_DIR"
-}
-
-trap cleanup EXIT


### PR DESCRIPTION
After merging attestation-agent into image-rs, we do not need to pull attestation-agent separately when doing the integration test. It is only needed to build the attestation-agent inside the current workspace.

cc @taoohong 