### PR TITLE
Added two security enhancements to AA

### DIFF
--- a/attestation-agent/attester/src/lib.rs
+++ b/attestation-agent/attester/src/lib.rs
@@ -28,7 +28,7 @@ pub mod snp;
 /// - AzSnpVtpm: SEV-SNP TEE for Azure CVMs.
 /// - Snp: SEV-SNP TEE.
 /// - Sample: A dummy TEE that used to test/demo the KBC functionalities.
-#[derive(Debug, EnumString, Display)]
+#[derive(Debug, EnumString, Display, Clone, Copy)]
 #[strum(ascii_case_insensitive, serialize_all = "lowercase")]
 pub enum Tee {
     Tdx,

--- a/attestation-agent/deps/crypto/src/teekey.rs
+++ b/attestation-agent/deps/crypto/src/teekey.rs
@@ -6,13 +6,11 @@
 //! Implementations of the TeeKey
 
 use anyhow::*;
+use base64::engine::general_purpose::STANDARD;
 use base64::Engine;
 use kbs_types::TeePubKey;
 use rsa::pkcs1::DecodeRsaPublicKey;
-use rsa::{
-    traits::PublicKeyParts, PaddingScheme, Pkcs1v15Encrypt, PublicKeyParts, RsaPrivateKey,
-    RsaPublicKey,
-};
+use rsa::{traits::PublicKeyParts, Pkcs1v15Encrypt, RsaPrivateKey, RsaPublicKey};
 use sha2::{Digest, Sha384};
 
 const RSA_PUBKEY_LENGTH: usize = 2048;
@@ -77,8 +75,8 @@ pub fn hash_chunks(chunks: Vec<Vec<u8>>) -> Vec<u8> {
 // Convert PKCS#1 PEM public key to TeePubKey
 pub fn pkcs1_pem_to_teepubkey(pem: String) -> Result<TeePubKey> {
     let public_key = RsaPublicKey::from_pkcs1_pem(&pem)?;
-    let k_mod = base64::encode(public_key.n().to_bytes_be());
-    let k_exp = base64::encode(public_key.e().to_bytes_be());
+    let k_mod = STANDARD.encode(public_key.n().to_bytes_be());
+    let k_exp = STANDARD.encode(public_key.e().to_bytes_be());
     let tee_pubkey = TeePubKey {
         kty: RSA_KEY_TYPE.to_string(),
         alg: RSA_ALGORITHM.to_string(),

--- a/attestation-agent/kbc/src/cc_kbc/mod.rs
+++ b/attestation-agent/kbc/src/cc_kbc/mod.rs
@@ -62,7 +62,7 @@ impl Kbc {
         Ok(Kbc {
             kbs_uri: url,
             token: None,
-            kbs_protocol_wrapper: KbsProtocolWrapper::new().unwrap(),
+            kbs_protocol_wrapper: KbsProtocolWrapper::new(vec![]).unwrap(),
         })
     }
 


### PR DESCRIPTION
1. Update TEE key when generate evidence
We should not use the same pair of RSA keys for a long time, as this will bring forward security issues.
This change alleviates this issue by updating the TEE key every time the attestation is redone.

2. Allow setting custom KBS certificates to enable TLS
Add parameters for setting customized KBS Root certificate when creating HTTP client, so that TLS communication can be enabled in various deployment scenarios.