### PR TITLE
image-rs: improve AA build and output

### DIFF
--- a/.github/workflows/image_rs_build.yml
+++ b/.github/workflows/image_rs_build.yml
@@ -76,11 +76,6 @@ jobs:
         run: |
           sudo -E PATH=$PATH -s cargo test -p image-rs --no-default-features --features=encryption-openssl,keywrap-grpc,snapshot-overlayfs,signature-cosign-native,signature-simple,getresource,oci-distribution/native-tls,keywrap-jwe
 
-      - name: Prepare for ttrpc test
-        run: |
-          sudo mkdir -p /opt/confidential-containers/attestation-agent/
-          if test -f "scripts/attestation-agent"; then rm scripts/attestation-agent; fi
-
       - name: Run cargo test - kata-cc (rust-tls version) with keywrap-ttrpc (default) + keywrap-jwe
         run: |
           sudo -E PATH=$PATH -s cargo test -p image-rs --no-default-features --features=kata-cc-rustls-tls,keywrap-jwe

--- a/attestation-agent/Makefile
+++ b/attestation-agent/Makefile
@@ -127,7 +127,7 @@ build:
 TARGET := $(TARGET_DIR)/$(BIN_NAME)
 
 install: 
-	install -D -m0755 $(TARGET) $(DESTDIR)
+	install -D -m0755 $(TARGET) $(DESTDIR)/$(BIN_NAME)
 
 uninstall:
 	rm -f $(DESTDIR)/$(BIN_NAME)

--- a/image-rs/scripts/build_attestation_agent.sh
+++ b/image-rs/scripts/build_attestation_agent.sh
@@ -9,11 +9,17 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-parameters="KBC=offline_fs_kbc"
+parameters=("KBC=offline_fs_kbc")
 
 [ -n "${BASH_VERSION:-}" ] && set -o errtrace
 [ -n "${DEBUG:-}" ] && set -o xtrace
-[ -n "${TTRPC:-}" ] && parameters+=" ttrpc=true"
+if [[ -n "${TTRPC:-}" ]]; then
+    parameters+=("ttrpc=true")
+    dest_dir_suffix="ttrpc"
+else
+    dest_dir_suffix="grpc"
+fi
+
 source $HOME/.cargo/env
 
 SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
@@ -21,6 +27,8 @@ AA_DIR=$SCRIPT_DIR/../../attestation-agent
 
 pushd $AA_DIR
 
-make $parameters
-make DESTDIR="$SCRIPT_DIR" install
+make "${parameters[@]}"
+make DESTDIR="${SCRIPT_DIR}/${dest_dir_suffix}" install
+
+file "${SCRIPT_DIR}/${dest_dir_suffix}/attestation-agent"
 popd


### PR DESCRIPTION
Improving output when building and starting AA.
Placing gRPC and ttRPC binaries in different directories, so both can be cached and it is clear what feature the binary supports.

Test itself was already fixed in #271.