### PR TITLE
ci: refactor workflows

### DIFF
--- a/.github/workflows/aa_basic.yml
+++ b/.github/workflows/aa_basic.yml
@@ -11,10 +11,6 @@ on:
       - '.github/workflows/aa_**.yml'
       - 'Cargo.toml'
   create:
-    paths:
-      - 'attestation-agent/**'
-      - '.github/workflows/aa_**.yml'
-      - 'Cargo.toml'
 
 jobs:
   basic_ci:
@@ -22,7 +18,7 @@ jobs:
     name: Check
     defaults:
       run:
-        working-directory: ./attestation-agent      
+        working-directory: ./attestation-agent
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -66,7 +62,7 @@ jobs:
       - name: Musl build with default features
         run: |
           make LIBC=musl
-      
+
       - name: s390x build with offline_fs_kbc feature
         run:
           make ARCH=s390x KBC=offline_fs_kbc
@@ -89,4 +85,3 @@ jobs:
           command: clippy
           # We are getting error in generated code due to derive_partial_eq_without_eq check, so ignore it for now
           args: --workspace -- -D warnings -A clippy::derive-partial-eq-without-eq
-

--- a/.github/workflows/aa_basic.yml
+++ b/.github/workflows/aa_basic.yml
@@ -16,7 +16,6 @@ on:
 
 jobs:
   basic_ci:
-    if: github.event_name == 'pull_request'
     name: Check
     defaults:
       run:

--- a/.github/workflows/aa_basic.yml
+++ b/.github/workflows/aa_basic.yml
@@ -1,16 +1,17 @@
 name: attestation-agent basic build and unit tests
+
 on:
   push:
     branches:
       - "main"
     paths:
       - 'attestation-agent/**'
-      - '.github/workflows/aa_**.yml'
+      - '.github/workflows/aa_basic.yml'
       - 'Cargo.toml'
   pull_request:
     paths:
       - 'attestation-agent/**'
-      - '.github/workflows/aa_**.yml'
+      - '.github/workflows/aa_basic.yml'
       - 'Cargo.toml'
   create:
 

--- a/.github/workflows/aa_basic.yml
+++ b/.github/workflows/aa_basic.yml
@@ -1,6 +1,8 @@
 name: attestation-agent basic build and unit tests
 on:
   push:
+    branches:
+      - "main"
     paths:
       - 'attestation-agent/**'
       - '.github/workflows/aa_**.yml'

--- a/.github/workflows/aa_basic.yml
+++ b/.github/workflows/aa_basic.yml
@@ -14,6 +14,7 @@ on:
       - '.github/workflows/aa_basic.yml'
       - 'Cargo.toml'
   create:
+  workflow_dispatch:
 
 jobs:
   basic_ci:

--- a/.github/workflows/aa_cc_kbc.yml
+++ b/.github/workflows/aa_cc_kbc.yml
@@ -1,4 +1,5 @@
-name: CC kbc build CI
+name: attestation-agent cc_kbc tests
+
 on:
   push:
     branches:

--- a/.github/workflows/aa_cc_kbc.yml
+++ b/.github/workflows/aa_cc_kbc.yml
@@ -1,6 +1,8 @@
 name: CC kbc build CI
 on:
   push:
+    branches:
+      - 'main'
     paths:
       - 'attestation-agent/kbc/cc_kbc/**'
       - 'attestation-agent/kbs_protocol/**'

--- a/.github/workflows/aa_cc_kbc.yml
+++ b/.github/workflows/aa_cc_kbc.yml
@@ -14,6 +14,7 @@ on:
       - 'attestation-agent/kbs_protocol/**'
       - '.github/workflows/aa_cc_kbc.yml'
   create:
+  workflow_dispatch:
 
 jobs:
   cc_kbc_ci:

--- a/.github/workflows/aa_cc_kbc.yml
+++ b/.github/workflows/aa_cc_kbc.yml
@@ -16,7 +16,6 @@ on:
 
 jobs:
   cc_kbc_ci:
-    if: github.event_name == 'pull_request'
     name: Check
     defaults:
       run:

--- a/.github/workflows/aa_cc_kbc.yml
+++ b/.github/workflows/aa_cc_kbc.yml
@@ -11,9 +11,6 @@ on:
       - 'attestation-agent/kbs_protocol/**'
       - '.github/workflows/aa_cc_kbc.yml'
   create:
-    paths:
-      - 'attestation-agent/kbc/cc_kbc/**'
-      - 'attestation-agent/kbs_protocol/**'
 
 jobs:
   cc_kbc_ci:

--- a/.github/workflows/aa_crypto.yml
+++ b/.github/workflows/aa_crypto.yml
@@ -1,6 +1,8 @@
 name: Crypto CI
 on:
   push:
+    branches:
+      - 'main'
     paths:
       - 'attestation-agent/deps/crypto/**'
       - '.github/workflows/aa_crypto.yml'

--- a/.github/workflows/aa_crypto.yml
+++ b/.github/workflows/aa_crypto.yml
@@ -12,6 +12,7 @@ on:
       - 'attestation-agent/deps/crypto/**'
       - '.github/workflows/aa_crypto.yml'
   create:
+  workflow_dispatch:
 
 jobs:
   crypto_ci:

--- a/.github/workflows/aa_crypto.yml
+++ b/.github/workflows/aa_crypto.yml
@@ -14,7 +14,6 @@ on:
 
 jobs:
   crypto_ci:
-    if: github.event_name == 'pull_request'
     name: Check
     defaults:
       run:

--- a/.github/workflows/aa_crypto.yml
+++ b/.github/workflows/aa_crypto.yml
@@ -1,4 +1,5 @@
-name: Crypto CI
+name: attestation-agent crypto tests
+
 on:
   push:
     branches:

--- a/.github/workflows/aa_crypto.yml
+++ b/.github/workflows/aa_crypto.yml
@@ -9,9 +9,6 @@ on:
       - 'attestation-agent/deps/crypto/**'
       - '.github/workflows/aa_crypto.yml'
   create:
-    paths:
-      - 'attestation-agent/deps/crypto/**'
-      - '.github/workflows/aa_crypto.yml'
 
 jobs:
   crypto_ci:
@@ -54,10 +51,9 @@ jobs:
           command: clippy
           # We are getting error in generated code due to derive_partial_eq_without_eq check, so ignore it for now
           args: -p crypto --no-default-features --features ${{ matrix.suites }} -- -D warnings -A clippy::derive_partial_eq_without_eq
-      
+
       - name: Run cargo test (${{ matrix.suites }})
         uses: actions-rs/cargo@v1
         with:
           command: test
           args: -p crypto --no-default-features --features ${{ matrix.suites }}
-

--- a/.github/workflows/aa_eaa_kbc.yml
+++ b/.github/workflows/aa_eaa_kbc.yml
@@ -14,7 +14,6 @@ on:
 
 jobs:
   eaa_kbc_ci:
-    if: github.event_name == 'pull_request'
     name: Check
     defaults:
       run:

--- a/.github/workflows/aa_eaa_kbc.yml
+++ b/.github/workflows/aa_eaa_kbc.yml
@@ -1,4 +1,5 @@
-name: EAA kbc build CI
+name: attestation-agent eaa_kbc tests
+
 on:
   push:
     branches:

--- a/.github/workflows/aa_eaa_kbc.yml
+++ b/.github/workflows/aa_eaa_kbc.yml
@@ -12,6 +12,7 @@ on:
       - 'attestation-agent/kbc/eaa_kbc/**'
       - '.github/workflows/aa_eaa_kbc.yml'
   create:
+  workflow_dispatch:
 
 jobs:
   eaa_kbc_ci:

--- a/.github/workflows/aa_eaa_kbc.yml
+++ b/.github/workflows/aa_eaa_kbc.yml
@@ -9,8 +9,6 @@ on:
       - 'attestation-agent/kbc/eaa_kbc/**'
       - '.github/workflows/aa_eaa_kbc.yml'
   create:
-    paths:
-      - 'attestation-agent/kbc/eaa_kbc/**'
 
 jobs:
   eaa_kbc_ci:
@@ -27,7 +25,7 @@ jobs:
           - stable
 
     container: runetest/compilation-testing:ubuntu18.04
-          
+
     steps:
       - name: Code checkout
         uses: actions/checkout@v2
@@ -42,14 +40,14 @@ jobs:
           rustup default stable
 
       - name: install dependencies
-        run: | 
+        run: |
           echo 'deb [arch=amd64] http://mirrors.openanolis.cn/inclavare-containers/ubuntu20.04 focal main' | tee /etc/apt/sources.list.d/inclavare-containers.list
           curl -L http://mirrors.openanolis.cn/inclavare-containers/ubuntu20.04/DEB-GPG-KEY.key | apt-key add -
           echo 'deb [arch=amd64] https://download.01.org/intel-sgx/sgx_repo/ubuntu focal main' | tee /etc/apt/sources.list.d/intel-sgx.list
           curl -L https://download.01.org/intel-sgx/sgx_repo/ubuntu/intel-sgx-deb.key | apt-key add -
           apt-get update
           apt-get install -y rats-tls-tdx libtdx-attest=1.15\*
-      
+
       - name: Build AA with EAA KBC
         run: |
           make KBC=eaa_kbc && make install
@@ -57,4 +55,3 @@ jobs:
       - name: Run cargo test with eaa_kbc feature
         run: |
           RUSTFLAGS="-C link-args=-Wl,-rpath,/usr/local/lib/rats-tls" cargo test --manifest-path kbc/Cargo.toml --features eaa_kbc
-

--- a/.github/workflows/aa_eaa_kbc.yml
+++ b/.github/workflows/aa_eaa_kbc.yml
@@ -1,6 +1,8 @@
 name: EAA kbc build CI
 on:
   push:
+    branches:
+      - 'main'
     paths:
       - 'attestation-agent/kbc/eaa_kbc/**'
       - '.github/workflows/aa_eaa_kbc.yml'

--- a/.github/workflows/aa_occlum_sgx.yml
+++ b/.github/workflows/aa_occlum_sgx.yml
@@ -13,6 +13,7 @@ on:
       - 'attestation-agent/ci/occlum**'
       - '.github/workflows/aa_occlum_sgx.yml'
   create:
+  workflow_dispatch:
 
 jobs:
   occlum_sgx_ci:

--- a/.github/workflows/aa_occlum_sgx.yml
+++ b/.github/workflows/aa_occlum_sgx.yml
@@ -1,4 +1,4 @@
-name: CC kbc build CI
+name: attestation-agent occlum_sgx tests
 on:
   push:
     branches:
@@ -15,7 +15,7 @@ on:
   create:
 
 jobs:
-  build-and-run-occlum:
+  occlum_sgx_ci:
     runs-on: self-hosted
     container:
       image: occlum/occlum:latest-ubuntu20.04

--- a/.github/workflows/aa_occlum_sgx.yml
+++ b/.github/workflows/aa_occlum_sgx.yml
@@ -1,6 +1,8 @@
 name: CC kbc build CI
 on:
   push:
+    branches:
+      - 'main'
     paths:
       - 'attestation-agent/attester/src/sgx_occlum'
       - 'attestation-agent/ci/occlum**'

--- a/.github/workflows/aa_occlum_sgx.yml
+++ b/.github/workflows/aa_occlum_sgx.yml
@@ -11,10 +11,6 @@ on:
       - 'attestation-agent/ci/occlum**'
       - '.github/workflows/aa_occlum_sgx.yml'
   create:
-    paths:
-      - 'attestation-agent/attester/src/sgx_occlum'
-      - 'attestation-agent/ci/occlum**'
-      - '.github/workflows/aa_occlum_sgx.yml'
 
 jobs:
   build-and-run-occlum:
@@ -34,7 +30,7 @@ jobs:
 
       - name: Configure Cargo
         run: rustup default stable
- 
+
       - name: Compile Occlum Example
         run: cargo build --bin occlum-attester --no-default-features --features occlum
 

--- a/.github/workflows/aa_release.yml
+++ b/.github/workflows/aa_release.yml
@@ -8,18 +8,17 @@ jobs:
   build-and-push-images:
     runs-on: ubuntu-latest
     steps:
-      -
-        name: Checkout
+      - name: Checkout
         uses: actions/checkout@v3
-      -
-        name: Login to Docker Hub
+
+      - name: Login to Docker Hub
         uses: docker/login-action@v2
         with:
           registry: ghcr.io
           username: ${{github.actor}}
           password: ${{secrets.GITHUB_TOKEN}}
-      -
-        name: Build and push coco-key-provider
+
+      - name: Build and push coco-key-provider
         uses: docker/build-push-action@v4
         with:
           context: .

--- a/.github/workflows/aa_sample_keyprovider.yml
+++ b/.github/workflows/aa_sample_keyprovider.yml
@@ -12,7 +12,6 @@ on:
 
 jobs:
   coco_keyprovider_ci:
-    if: github.event_name == 'pull_request'
     name: Check
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/aa_sample_keyprovider.yml
+++ b/.github/workflows/aa_sample_keyprovider.yml
@@ -1,13 +1,15 @@
-name: Coco Keyprovider CI
+name: attestation-agent coco_keyprovider tests
 on:
   push:
     branches:
       - 'main'
     paths:
       - 'attestation-agent/coco_keyprovider/**'
+      - '.github/workflows/aa_sample_keyprovider.yml'
   pull_request:
     paths:
       - 'attestation-agent/coco_keyprovider/**'
+      - '.github/workflows/aa_sample_keyprovider.yml'
   create:
 
 jobs:

--- a/.github/workflows/aa_sample_keyprovider.yml
+++ b/.github/workflows/aa_sample_keyprovider.yml
@@ -1,6 +1,8 @@
 name: Coco Keyprovider CI
 on:
   push:
+    branches:
+      - 'main'
     paths:
       - 'attestation-agent/coco_keyprovider/**'
   pull_request:

--- a/.github/workflows/aa_sample_keyprovider.yml
+++ b/.github/workflows/aa_sample_keyprovider.yml
@@ -7,8 +7,6 @@ on:
     paths:
       - 'attestation-agent/coco_keyprovider/**'
   create:
-    paths:
-      - 'attestation-agent/coco_keyprovider/**'
 
 jobs:
   coco_keyprovider_ci:
@@ -41,7 +39,7 @@ jobs:
         with:
           command: fmt
           args: --check --manifest-path attestation-agent/coco_keyprovider/Cargo.toml
-        
+
       - name: Rust clippy check
         uses: actions-rs/cargo@v1
         with:

--- a/.github/workflows/aa_sample_keyprovider.yml
+++ b/.github/workflows/aa_sample_keyprovider.yml
@@ -11,6 +11,7 @@ on:
       - 'attestation-agent/coco_keyprovider/**'
       - '.github/workflows/aa_sample_keyprovider.yml'
   create:
+  workflow_dispatch:
 
 jobs:
   coco_keyprovider_ci:

--- a/.github/workflows/aa_sev_kbc.yml
+++ b/.github/workflows/aa_sev_kbc.yml
@@ -1,6 +1,8 @@
 name: offline_sev_kbc build CI
 on:
   push:
+    branches:
+      - 'main'
     paths:
       - 'attestation-agent/kbc/offline_sev_kbc/**'
       - 'attestation-agent/kbc/online_sev_kbc/**'

--- a/.github/workflows/aa_sev_kbc.yml
+++ b/.github/workflows/aa_sev_kbc.yml
@@ -9,9 +9,6 @@ on:
       - 'attestation-agent/kbc/offline_sev_kbc/**'
       - 'attestation-agent/kbc/online_sev_kbc/**'
   create:
-    paths:
-      - 'attestation-agent/kbc/offline_sev_kbc/**'
-      - 'attestation-agent/kbc/online_sev_kbc/**'
 
 jobs:
   offline_sev_kbc_ci:

--- a/.github/workflows/aa_sev_kbc.yml
+++ b/.github/workflows/aa_sev_kbc.yml
@@ -11,6 +11,7 @@ on:
       - 'attestation-agent/kbc/offline_sev_kbc/**'
       - 'attestation-agent/kbc/online_sev_kbc/**'
   create:
+  workflow_dispatch:
 
 jobs:
   offline_sev_kbc_ci:

--- a/.github/workflows/aa_sev_kbc.yml
+++ b/.github/workflows/aa_sev_kbc.yml
@@ -1,4 +1,4 @@
-name: offline_sev_kbc build CI
+name: attestation-agent offline_sev_kbc tests
 on:
   push:
     branches:

--- a/.github/workflows/aa_sev_kbc.yml
+++ b/.github/workflows/aa_sev_kbc.yml
@@ -14,7 +14,6 @@ on:
 
 jobs:
   offline_sev_kbc_ci:
-    if: github.event_name == 'pull_request'
     name: Check
     defaults:
       run:

--- a/.github/workflows/image_rs_build.yml
+++ b/.github/workflows/image_rs_build.yml
@@ -1,5 +1,16 @@
 name: image-rs build
-on: [push, pull_request, create]
+on:
+  push:
+    branches:
+      - 'main'
+    paths:
+      - 'image-rs/**'
+      - '.github/workflows/image_rs_build.yml'
+  pull_request:
+    paths:
+      - 'image-rs/**'
+      - '.github/workflows/image_rs_build.yml'
+  create:
 
 jobs:
   ci:

--- a/.github/workflows/image_rs_build.yml
+++ b/.github/workflows/image_rs_build.yml
@@ -11,6 +11,7 @@ on:
       - 'image-rs/**'
       - '.github/workflows/image_rs_build.yml'
   create:
+  workflow_dispatch:
 
 jobs:
   ci:

--- a/.github/workflows/image_rs_build.yml
+++ b/.github/workflows/image_rs_build.yml
@@ -14,7 +14,6 @@ on:
 
 jobs:
   ci:
-    if: github.event_name == 'pull_request' || github.event_name == 'push'
     name: Check
     defaults:
       run:

--- a/.github/workflows/ocicrypt_rs_build.yml
+++ b/.github/workflows/ocicrypt_rs_build.yml
@@ -1,5 +1,16 @@
 name: ocicrypt-rs build
-on: [push, pull_request, create]
+on:
+  push:
+    branches:
+      - 'main'
+    paths:
+      - 'ocicrypt-rs/**'
+      - '.github/workflows/ocicrypt_rs_build.yml'
+  pull_request:
+    paths:
+      - 'ocicrypt-rs/**'
+      - '.github/workflows/ocicrypt_rs_build.yml'
+  create:
 
 jobs:
   ci:
@@ -42,7 +53,7 @@ jobs:
           apt install -y protobuf-compiler libprotobuf-dev
 
       - name: Build and install rats-tls
-        run: | 
+        run: |
           PWD=$(pwd)
           cd /tmp
           apt-get install -y libcurl4-openssl-dev
@@ -166,4 +177,3 @@ jobs:
         with:
           command: clippy
           args: -p ocicrypt-rs --all-targets --all-features -- -D warnings -A clippy::derive_partial_eq_without_eq
-

--- a/.github/workflows/ocicrypt_rs_build.yml
+++ b/.github/workflows/ocicrypt_rs_build.yml
@@ -14,7 +14,6 @@ on:
 
 jobs:
   ci:
-    if: github.event_name == 'pull_request'
     name: Check
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/ocicrypt_rs_build.yml
+++ b/.github/workflows/ocicrypt_rs_build.yml
@@ -11,6 +11,7 @@ on:
       - 'ocicrypt-rs/**'
       - '.github/workflows/ocicrypt_rs_build.yml'
   create:
+  workflow_dispatch:
 
 jobs:
   ci:

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ Cargo.lock
 .DS_Store
 
 image-rs/scripts/attestation-agent
+shell.nix


### PR DESCRIPTION
Some refactoring of workflows:

- Remove invalid filter on create trigger. This trigger doesn't allow filters.
- Only use push trigger on main (wasn't used before anyway, as there was an if statement on most jobs).
- Adding path filters to image-rs and ocicrypt-rs workflows.
- Removing if statements on jobs. The workflow triggers control when a job run, no need to filter with an if statement on a single job.
- Trying to unify naming a bit, fixing white space issues.
- Adding `workflow_dispatch` trigger to every test workflow, so they can be triggered manually where needed (like on forks).