### PR TITLE
Tidy up the warnings from integration tests

### DIFF
--- a/image-rs/tests/common/mod.rs
+++ b/image-rs/tests/common/mod.rs
@@ -71,7 +71,7 @@ pub async fn start_attestation_agent() -> Result<Child> {
                     .await
                     .expect("Failed to build attestation-agent");
             } else {
-                let output = Command::new(script_path)
+                let _output = Command::new(script_path)
                     .output()
                     .await
                     .expect("Failed to build attestation-agent");

--- a/image-rs/tests/credential.rs
+++ b/image-rs/tests/credential.rs
@@ -3,11 +3,14 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+#[cfg(feature = "getresource")]
 use image_rs::image::ImageClient;
+#[cfg(feature = "getresource")]
 use rstest::rstest;
+#[cfg(feature = "getresource")]
 use serial_test::serial;
 
-mod common;
+pub mod common;
 
 #[cfg(feature = "getresource")]
 #[rstest]

--- a/image-rs/tests/image_decryption.rs
+++ b/image-rs/tests/image_decryption.rs
@@ -6,16 +6,20 @@
 
 //! Test for decryption of image layers.
 
+#[cfg(all(feature = "getresource", feature = "encryption"))]
 use image_rs::image::ImageClient;
+#[cfg(all(feature = "getresource", feature = "encryption"))]
 use serial_test::serial;
 
-mod common;
+pub mod common;
 
 /// Ocicrypt-rs config for grpc
+#[cfg(all(feature = "getresource", feature = "encryption"))]
 #[cfg(not(feature = "keywrap-ttrpc"))]
 const OCICRYPT_CONFIG: &str = "test_data/ocicrypt_keyprovider_grpc.conf";
 
 /// Ocicrypt-rs config for ttrpc
+#[cfg(all(feature = "getresource", feature = "encryption"))]
 #[cfg(feature = "keywrap-ttrpc")]
 const OCICRYPT_CONFIG: &str = "test_data/ocicrypt_keyprovider_ttrpc.conf";
 

--- a/image-rs/tests/signature_verification.rs
+++ b/image-rs/tests/signature_verification.rs
@@ -6,11 +6,13 @@
 
 //! Test for signature verification.
 
+#[cfg(feature = "getresource")]
 use image_rs::image::ImageClient;
+#[cfg(feature = "getresource")]
 use serial_test::serial;
 use strum_macros::{Display, EnumString};
 
-mod common;
+pub mod common;
 
 /// Name of different signing schemes.
 #[derive(EnumString, Display, Debug, PartialEq)]
@@ -78,8 +80,10 @@ const _TESTS: [_TestItem; _TEST_ITEMS] = [
     },
 ];
 
+#[cfg(feature = "getresource")]
 const POLICY_URI: &str = "kbs:///default/security-policy/test";
 
+#[cfg(feature = "getresource")]
 const SIGSTORE_CONFIG_URI: &str = "kbs:///default/sigstore-config/test";
 
 /// image-rs built without support for cosign image signing cannot use a policy that includes a type that


### PR DESCRIPTION
When looking at the "Files changed" in recent PRs, there are many extraneous warnings in image-rs/tests (e.g. "unused import"). The two main causes seem to be:
(1) the appropriate annotation for an integration test is not always applied to the respective import statement, variable, etc.
(2) not all integration tests use all of the common support from image-rs/tests/common/mod.rs

This PR tries to resolve the warnings. Annotations are added to solve (1). For (2), I've added `pub mod common` to the integration tests, which could lead to actual dead code that won't get caught by warnings. This seems to be a reasonable workaround, however, due to [this issue](https://github.com/rust-lang/rust/issues/46379).
