### PR TITLE
image-rs: Fix the rust lint warning

### DIFF
--- a/image-rs/src/image.rs
+++ b/image-rs/src/image.rs
@@ -384,7 +384,7 @@ impl ImageClient {
                 self.meta_store.clone(),
             )
             .await?;
-        image_data.layer_metas = layer_metas;
+        image_data.layer_metas = vec![layer_metas];
         let layer_db: HashMap<String, LayerMeta> = image_data
             .layer_metas
             .iter()
@@ -511,10 +511,10 @@ mod tests {
     #[tokio::test]
     async fn test_pull_image() {
         let work_dir = tempfile::tempdir().unwrap();
-        std::env::set_var("CC_IMAGE_WORK_DIR", &work_dir.path());
+        std::env::set_var("CC_IMAGE_WORK_DIR", work_dir.path());
 
         // TODO test with more OCI image registries and fix broken registries.
-        let oci_images = vec![
+        let oci_images = [
             // image with duplicated layers
             "gcr.io/k8s-staging-cloud-provider-ibm/ibm-vpc-block-csi-driver:master",
             // Alibaba Container Registry
@@ -554,9 +554,9 @@ mod tests {
     #[tokio::test]
     async fn test_nydus_image() {
         let work_dir = tempfile::tempdir().unwrap();
-        std::env::set_var("CC_IMAGE_WORK_DIR", &work_dir.path());
+        std::env::set_var("CC_IMAGE_WORK_DIR", work_dir.path());
 
-        let nydus_images = vec![
+        let nydus_images = [
             "eci-nydus-registry.cn-hangzhou.cr.aliyuncs.com/v6/java:latest-test_nydus",
             //"eci-nydus-registry.cn-hangzhou.cr.aliyuncs.com/test/ubuntu:latest_nydus",
             //"eci-nydus-registry.cn-hangzhou.cr.aliyuncs.com/test/python:latest_nydus",
@@ -581,7 +581,7 @@ mod tests {
     #[tokio::test]
     async fn test_image_reuse() {
         let work_dir = tempfile::tempdir().unwrap();
-        std::env::set_var("CC_IMAGE_WORK_DIR", &work_dir.path());
+        std::env::set_var("CC_IMAGE_WORK_DIR", work_dir.path());
 
         let image = "mcr.microsoft.com/hello-world";
 

--- a/image-rs/src/pull.rs
+++ b/image-rs/src/pull.rs
@@ -217,14 +217,15 @@ mod tests {
 
     #[tokio::test]
     async fn test_pull_client() {
-        let oci_images = vec![
+        let oci_images = [
             "docker.io/arronwang/busybox_gzip",
             "docker.io/arronwang/busybox_zstd",
         ];
 
         for image_url in oci_images.iter() {
             let tempdir = tempfile::tempdir().unwrap();
-            let image = Reference::try_from(image_url.clone()).expect("create reference failed");
+            let image =
+                Reference::try_from(image_url.to_string()).expect("create reference failed");
             let mut client = PullClient::new(
                 image,
                 tempdir.path(),
@@ -253,11 +254,12 @@ mod tests {
     #[cfg(all(feature = "encryption", feature = "keywrap-grpc"))]
     #[tokio::test]
     async fn test_pull_client_encrypted() {
-        let oci_images = vec!["docker.io/arronwang/busybox_encrypted"];
+        let oci_images = ["docker.io/arronwang/busybox_encrypted"];
 
         for image_url in oci_images.iter() {
             let tempdir = tempfile::tempdir().unwrap();
-            let image = Reference::try_from(image_url.clone()).expect("create reference failed");
+            let image =
+                Reference::try_from(image_url.to_string()).expect("create reference failed");
             let mut client = PullClient::new(
                 image,
                 tempdir.path(),
@@ -294,14 +296,15 @@ mod tests {
 
     #[tokio::test]
     async fn test_async_pull_client() {
-        let oci_images = vec![
+        let oci_images = [
             "docker.io/arronwang/busybox_gzip",
             "docker.io/arronwang/busybox_zstd",
         ];
 
         for image_url in oci_images.iter() {
             let tempdir = tempfile::tempdir().unwrap();
-            let image = Reference::try_from(image_url.clone()).expect("create reference failed");
+            let image =
+                Reference::try_from(image_url.to_string()).expect("create reference failed");
             let mut client = PullClient::new(
                 image,
                 tempdir.path(),
@@ -330,11 +333,12 @@ mod tests {
     #[cfg(all(feature = "encryption", feature = "keywrap-jwe"))]
     #[tokio::test]
     async fn test_async_pull_client_encrypted() {
-        let oci_images = vec!["docker.io/arronwang/busybox_encrypted"];
+        let oci_images = ["docker.io/arronwang/busybox_encrypted"];
 
         for image_url in oci_images.iter() {
             let tempdir = tempfile::tempdir().unwrap();
-            let image = Reference::try_from(image_url.clone()).expect("create reference failed");
+            let image =
+                Reference::try_from(image_url.to_string()).expect("create reference failed");
             let mut client = PullClient::new(
                 image,
                 tempdir.path(),
@@ -494,7 +498,7 @@ mod tests {
     #[tokio::test]
     async fn test_pull_nydus_bootstrap() {
         let nydus_images =
-            vec!["eci-nydus-registry.cn-hangzhou.cr.aliyuncs.com/v6/java:latest-test_nydus"];
+            ["eci-nydus-registry.cn-hangzhou.cr.aliyuncs.com/v6/java:latest-test_nydus"];
 
         for image_url in nydus_images.iter() {
             let tempdir = tempfile::tempdir().unwrap();

--- a/image-rs/src/resource/kbs/mod.rs
+++ b/image-rs/src/resource/kbs/mod.rs
@@ -15,7 +15,7 @@
 
 use std::path::Path;
 
-#[cfg(not(features = "keywrap-native"))]
+#[cfg(not(feature = "keywrap-native"))]
 use anyhow::Context;
 use anyhow::{bail, Result};
 use async_trait::async_trait;
@@ -78,19 +78,19 @@ impl SecureChannel {
 
             let client: Box<dyn Client> = {
                 cfg_if::cfg_if! {
-                    if #[cfg(feature = "keywrap-grpc")] {
-                        info!("secure channel uses gRPC");
-                        Box::new(grpc::Grpc::new().await.context("grpc client init failed")?)
-                    } else if #[cfg(feature = "keywrap-ttrpc")] {
-                        info!("secure channel uses ttrpc");
-                        Box::new(ttrpc::Ttrpc::new().context("ttrpc client init failed")?)
-                    } else if #[cfg(feature = "keywrap-native")] {
-                        info!("secure channel uses native-aa");
-                        Box::new(native::Native::default())
-                    } else {
-                        compile_error!("At last one feature of `keywrap-grpc`, `keywrap-ttrpc`, and `keywrap-native` must be enabled.");
+                        if #[cfg(feature = "keywrap-grpc")] {
+                            info!("secure channel uses gRPC");
+                            Box::new(grpc::Grpc::new().await.context("grpc client init failed")?)
+                        } else if #[cfg(feature = "keywrap-ttrpc")] {
+                            info!("secure channel uses ttrpc");
+                            Box::new(ttrpc::Ttrpc::new().context("ttrpc client init failed")?)
+                        } else if #[cfg(feature = "keywrap-native")] {
+                            info!("secure channel uses native-aa");
+                Box::<native::Native>::default()
+                        } else {
+                            compile_error!("At last one feature of `keywrap-grpc`, `keywrap-ttrpc`, and `keywrap-native` must be enabled.");
+                        }
                     }
-                }
             };
 
             fs::create_dir_all(STORAGE_PATH).await?;

--- a/image-rs/src/signature/mechanism/simple/verify.rs
+++ b/image-rs/src/signature/mechanism/simple/verify.rs
@@ -255,7 +255,7 @@ mod tests {
         let sig_payload_verified =
             verify_sig_and_extract_payload(&keyring_bytes_case_1, sig_bytes_case_1).unwrap();
 
-        let sig_payload_verified = serde_json::to_value(&sig_payload_verified).unwrap();
+        let sig_payload_verified = serde_json::to_value(sig_payload_verified).unwrap();
 
         assert_eq!(sig_payload_parsed, sig_payload_verified);
     }

--- a/image-rs/src/signature/payload/simple_signing.rs
+++ b/image-rs/src/signature/payload/simple_signing.rs
@@ -165,7 +165,7 @@ mod tests {
             }),
         };
 
-        let payload_serialize = serde_json::to_value(&payload).unwrap();
+        let payload_serialize = serde_json::to_value(payload).unwrap();
         assert_eq!(payload_serialize, json);
     }
 

--- a/image-rs/src/snapshots/occlum/unionfs.rs
+++ b/image-rs/src/snapshots/occlum/unionfs.rs
@@ -39,9 +39,9 @@ fn clear_path(mount_path: &Path) -> Result<()> {
     Ok(())
 }
 
-fn create_dir(create_path: &PathBuf) -> Result<()> {
+fn create_dir(create_path: &Path) -> Result<()> {
     if !create_path.exists() {
-        fs::create_dir_all(create_path.as_path())?;
+        fs::create_dir_all(create_path)?;
     }
 
     Ok(())
@@ -56,7 +56,7 @@ fn create_environment(mount_path: &Path) -> Result<()> {
     let path_lib64 = mount_path.join("lib64");
     create_dir(&path_lib64)?;
 
-    let lib64_libs = vec![LD_LIB];
+    let lib64_libs = [LD_LIB];
     let ori_path_lib64 = Path::new("/lib64");
     for lib in lib64_libs.iter() {
         from_paths.push(ori_path_lib64.join(lib));
@@ -80,7 +80,7 @@ fn create_environment(mount_path: &Path) -> Result<()> {
         .join("lib");
     fs::create_dir_all(&path_opt)?;
 
-    let occlum_lib = vec![
+    let occlum_lib = [
         "libc.so.6",
         "libdl.so.2",
         "libm.so.6",
@@ -100,7 +100,7 @@ fn create_environment(mount_path: &Path) -> Result<()> {
     fs_extra::copy_items(&from_paths, &path_opt, &copy_options)?;
     from_paths.clear();
 
-    let sys_path = vec!["dev", "etc", "host", "lib", "proc", "root", "sys", "tmp"];
+    let sys_path = ["dev", "etc", "host", "lib", "proc", "root", "sys", "tmp"];
     for path in sys_path.iter() {
         create_dir(&mount_path.join(path))?;
     }
@@ -168,7 +168,7 @@ impl Snapshotter for Unionfs {
             let layer = layer_path_vec
                 .pop()
                 .ok_or(anyhow!("Pop() failed from Vec"))?;
-            CopyBuilder::new(layer, &mount_path).overwrite(true).run()?;
+            CopyBuilder::new(layer, mount_path).overwrite(true).run()?;
         }
 
         // create environment for Occlum
@@ -261,6 +261,6 @@ mod tests {
             path_2.path().to_str().unwrap(),
         ];
 
-        assert!(!occlum_unionfs.mount(layer_path, mnt_path.as_ref()).is_ok());
+        assert!(occlum_unionfs.mount(layer_path, mnt_path.as_ref()).is_err());
     }
 }

--- a/image-rs/src/unpack.rs
+++ b/image-rs/src/unpack.rs
@@ -123,12 +123,12 @@ mod tests {
         assert!(unpack(data.as_slice(), destination).is_ok());
 
         let path = destination.join("file.txt");
-        let metadata = fs::metadata(&path).unwrap();
+        let metadata = fs::metadata(path).unwrap();
         let new_mtime = filetime::FileTime::from_last_modification_time(&metadata);
         assert_eq!(mtime, new_mtime);
 
         let path = destination.join("dir");
-        let metadata = fs::metadata(&path).unwrap();
+        let metadata = fs::metadata(path).unwrap();
         let new_mtime = filetime::FileTime::from_last_modification_time(&metadata);
         assert_eq!(mtime, new_mtime);
 

--- a/image-rs/tests/common/mod.rs
+++ b/image-rs/tests/common/mod.rs
@@ -80,7 +80,7 @@ pub async fn start_attestation_agent() -> Result<Child> {
                     .expect("Failed to build attestation-agent");
                 println!("build ttrpc attestation-agent: {:?}", output);
             } else {
-                let _output = Command::new(script_path)
+                let output = Command::new(script_path)
                     .output()
                     .await
                     .expect("Failed to build attestation-agent");
@@ -93,7 +93,7 @@ pub async fn start_attestation_agent() -> Result<Child> {
         if #[cfg(feature = "keywrap-ttrpc")] {
             let mut aa = Command::new(aa_path)
                 .kill_on_drop(true)
-                .args(&[
+                .args([
                     "--keyprovider_sock",
                     "unix:///run/confidential-containers/attestation-agent/keyprovider.sock",
                     "--getresource_sock",
@@ -104,7 +104,7 @@ pub async fn start_attestation_agent() -> Result<Child> {
         } else {
             let mut aa = Command::new(aa_path)
                 .kill_on_drop(true)
-                .args(&[
+                .args([
                     "--keyprovider_sock",
                     "127.0.0.1:50000",
                     "--getresource_sock",
@@ -117,7 +117,7 @@ pub async fn start_attestation_agent() -> Result<Child> {
 
     // Leave some time to let fork-ed AA process to be ready
     tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
-    if let Some(_) = aa.try_wait()? {
+    if (aa.try_wait()?).is_some() {
         panic!("Attestation Agent failed to start");
     }
     Ok(aa)

--- a/image-rs/tests/credential.rs
+++ b/image-rs/tests/credential.rs
@@ -36,7 +36,7 @@ async fn test_use_credential(#[case] image_ref: &str, #[case] auth_file_uri: &st
         .expect("Delete configs failed.");
 
     let work_dir = tempfile::tempdir().unwrap();
-    std::env::set_var("CC_IMAGE_WORK_DIR", &work_dir.path());
+    std::env::set_var("CC_IMAGE_WORK_DIR", work_dir.path());
 
     // a new client for every pulling, avoid effection
     // of cache of old client.
@@ -51,7 +51,7 @@ async fn test_use_credential(#[case] image_ref: &str, #[case] auth_file_uri: &st
     let bundle_dir = tempfile::tempdir().unwrap();
 
     let res = image_client
-        .pull_image(image_ref, bundle_dir.path(), &None, &Some(&aa_parameters))
+        .pull_image(image_ref, bundle_dir.path(), &None, &Some(aa_parameters))
         .await;
     if cfg!(all(feature = "snapshot-overlayfs",)) {
         assert!(res.is_ok(), "{:?}", res);

--- a/image-rs/tests/image_decryption.rs
+++ b/image-rs/tests/image_decryption.rs
@@ -42,7 +42,7 @@ async fn test_decrypt_layers(#[case] image: &str) {
     std::env::set_var("OCICRYPT_KEYPROVIDER_CONFIG", keyprovider_config);
 
     let work_dir = tempfile::tempdir().unwrap();
-    std::env::set_var("CC_IMAGE_WORK_DIR", &work_dir.path());
+    std::env::set_var("CC_IMAGE_WORK_DIR", work_dir.path());
     let bundle_dir = tempfile::tempdir().unwrap();
 
     // clean former test files, which is needed to prevent

--- a/image-rs/tests/signature_verification.rs
+++ b/image-rs/tests/signature_verification.rs
@@ -107,7 +107,7 @@ async fn signature_verification() {
 
         // Init tempdirs
         let work_dir = tempfile::tempdir().unwrap();
-        std::env::set_var("CC_IMAGE_WORK_DIR", &work_dir.path());
+        std::env::set_var("CC_IMAGE_WORK_DIR", work_dir.path());
 
         // a new client for every pulling, avoid effection
         // of cache of old client.


### PR DESCRIPTION
Verified with:
```
cargo clippy --all-targets --features=default  -- -D warnings
cargo clippy --all-targets --features=kata-cc-rustls-tls --no-default-features -- -D warnings
cargo clippy --all-targets --features=enclave-cc-eaakbc-rustls-tls --no-default-features -- -D warnings
cargo clippy --all-targets --features=kata-cc-native-tls --no-default-features -- -D warnings
cargo clippy --all-targets --features=enclave-cc-eaakbc-native-tls --no-default-features -- -D warnings
cargo clippy --all-targets --features=enclave-cc-cckbc-native-tls --no-default-features -- -D warnings
```
Will add to the CI once https://github.com/confidential-containers/guest-components/pull/275 is merged