### PR TITLE
attestation-agent/Attesters: refactor the trait of Attester

### DIFF
--- a/attestation-agent/attester/src/az_snp_vtpm/mod.rs
+++ b/attestation-agent/attester/src/az_snp_vtpm/mod.rs
@@ -28,10 +28,9 @@ struct Evidence {
 }
 
 impl Attester for AzSnpVtpmAttester {
-    fn get_evidence(&self, report_data: String) -> Result<String> {
+    fn get_evidence(&self, report_data: Vec<u8>) -> Result<String> {
         let report = vtpm::get_report()?;
-        let report_data_bin = base64::decode(report_data)?;
-        let quote = vtpm::get_quote(&report_data_bin)?;
+        let quote = vtpm::get_quote(&report_data)?;
         let certs = imds::get_certs()?;
         let vcek = certs.vcek;
 

--- a/attestation-agent/attester/src/lib.rs
+++ b/attestation-agent/attester/src/lib.rs
@@ -58,7 +58,10 @@ impl Tee {
 }
 
 pub trait Attester {
-    fn get_evidence(&self, report_data: String) -> Result<String>;
+    /// Call the hardware driver to get the Hardware specific evidence.
+    /// The parameter `report_data` will be used as the user input of the
+    /// evidence to avoid reply attack.
+    fn get_evidence(&self, report_data: Vec<u8>) -> Result<String>;
 }
 
 // Detect which TEE platform the KBC running environment is.

--- a/attestation-agent/attester/src/sample/mod.rs
+++ b/attestation-agent/attester/src/sample/mod.rs
@@ -25,10 +25,10 @@ struct SampleQuote {
 pub struct SampleAttester {}
 
 impl Attester for SampleAttester {
-    fn get_evidence(&self, report_data: String) -> Result<String> {
+    fn get_evidence(&self, report_data: Vec<u8>) -> Result<String> {
         let evidence = SampleQuote {
             svn: "1".to_string(),
-            report_data,
+            report_data: base64::encode(report_data),
         };
 
         serde_json::to_string(&evidence).map_err(|_| anyhow!("Serialize sample evidence failed"))

--- a/attestation-agent/attester/src/snp/mod.rs
+++ b/attestation-agent/attester/src/snp/mod.rs
@@ -25,17 +25,15 @@ struct SnpEvidence {
 pub struct SnpAttester {}
 
 impl Attester for SnpAttester {
-    fn get_evidence(&self, report_data: String) -> Result<String> {
-        let mut report_data_bin = base64::decode(report_data)?;
-
-        if report_data_bin.len() != 48 {
-            bail!("Malformed SNP Evidence");
+    fn get_evidence(&self, mut report_data: Vec<u8>) -> Result<String> {
+        if report_data.len() > 64 {
+            bail!("SNP Attester: Report data must be no more than 64 bytes");
         }
 
-        report_data_bin.extend([0; 16]);
+        report_data.resize(64, 0);
 
         let mut firmware = Firmware::open()?;
-        let data = report_data_bin.as_slice().try_into()?;
+        let data = report_data.as_slice().try_into()?;
 
         let (report, certs) = firmware
             .get_ext_report(None, Some(data), Some(0))

--- a/attestation-agent/deps/crypto/src/teekey.rs
+++ b/attestation-agent/deps/crypto/src/teekey.rs
@@ -62,15 +62,13 @@ impl TeeKey {
     }
 }
 
-// Returns a base64 of the sha384 of all chunks.
-pub fn hash_chunks(chunks: Vec<Vec<u8>>) -> String {
+// Returns a sha384 of all chunks.
+pub fn hash_chunks(chunks: Vec<Vec<u8>>) -> Vec<u8> {
     let mut hasher = Sha384::new();
 
     for chunk in chunks.iter() {
         hasher.update(chunk);
     }
 
-    let res = hasher.finalize();
-
-    base64::encode(res)
+    hasher.finalize().to_vec()
 }


### PR DESCRIPTION
Change the API of `get_evidence` function to just performing getting evidence via calling the underlying hardware drivers.

Fixes: #283

Please do not merge this until the v0.8.0 cycle.

cc @jialez0 @fitzthum @mkulke please take a look if these changes are good for the architecture/concrete attester implementation.