### PR TITLE
Fix kbs url in cc-kbc

### DIFF
--- a/.github/workflows/aa_cc_kbc.yml
+++ b/.github/workflows/aa_cc_kbc.yml
@@ -71,3 +71,8 @@ jobs:
           # We are getting error in generated code due to derive_partial_eq_without_eq check, so ignore it for now
           args: -p kbc --all-targets --features cc_kbc,all-attesters,rust-crypto -- -D warnings -A clippy::derive_partial_eq_without_eq
 
+      - name: Run cargo test
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --features cc_kbc,all-attesters,rust-crypto -p kbc

--- a/attestation-agent/kbc/src/cc_kbc/mod.rs
+++ b/attestation-agent/kbc/src/cc_kbc/mod.rs
@@ -66,7 +66,7 @@ impl Kbc {
     }
 
     fn kbs_uri(&self) -> &str {
-        self.kbs_uri.as_str()
+        self.kbs_uri.as_str().trim_end_matches('/')
     }
 
     fn kbs_protocol_wrapper(&mut self) -> &mut KbsProtocolWrapper {
@@ -93,7 +93,7 @@ impl Kbc {
             );
         }
 
-        let kbs_addr = &self.kbs_uri();
+        let kbs_addr = self.kbs_uri();
         let repo = &resource.repository;
         let r#type = &resource.r#type;
         let tag = &resource.tag;

--- a/attestation-agent/kbs_protocol/src/lib.rs
+++ b/attestation-agent/kbs_protocol/src/lib.rs
@@ -96,7 +96,7 @@ impl KbsProtocolWrapper {
     async fn attestation(&mut self, kbs_root_url: String) -> Result<String> {
         let challenge = self
             .http_client()
-            .post(format!("{kbs_root_url}/{KBS_PREFIX}/auth"))
+            .post(format!("{kbs_root_url}{KBS_PREFIX}/auth"))
             .header("Content-Type", "application/json")
             .json(&Request::new(self.tee().to_string()))
             .send()
@@ -107,7 +107,7 @@ impl KbsProtocolWrapper {
 
         let attest_response = self
             .http_client()
-            .post(format!("{kbs_root_url}/{KBS_PREFIX}/attest"))
+            .post(format!("{kbs_root_url}{KBS_PREFIX}/attest"))
             .header("Content-Type", "application/json")
             .json(&self.generate_evidence()?)
             .send()


### PR DESCRIPTION
In enclave-cc's CI https://github.com/confidential-containers/enclave-cc/pull/188 we met the following error 
```
E0717 18:20:17.225384 2897992 remote_image.go:238] "PullImage from image service failed" err=<
	rpc error: code = Internal desc = Security validate failed: error decoding response body: EOF while parsing a value at line 1 column 0
	
	Caused by:
	    EOF while parsing a value at line 1 column 0
 > image="ghcr.io/confidential-containers/test-container-enclave-cc:encrypted"
time="2023-07-[17](https://github.com/confidential-containers/enclave-cc/actions/runs/5573528817/jobs/10182945922?pr=188#step:16:18)T[18](https://github.com/confidential-containers/enclave-cc/actions/runs/5573528817/jobs/10182945922?pr=188#step:16:19):[20](https://github.com/confidential-containers/enclave-cc/actions/runs/5573528817/jobs/10182945922?pr=188#step:16:21):17+08:00" level=fatal msg="creating container: rpc error: code = Internal desc = Security validate failed: error decoding response body: EOF while parsing a value at line 1 column 0\n\nCaused by:\n    EOF while parsing a value at line 1 column 0"
Error: Process completed with exit code 1.
```

The logs of kbs shows
```
[2023-07-17T13:46:02Z INFO  actix_web::middleware::logger] 172.18.0.1 "POST ///kbs/v0/auth HTTP/1.1" 404 0 "-" "attestation-agent-kbs-client/0.1.0" 0.000034
```

Obviously, the requested url's path is wrong. Should be `/kbs/v0/auth` but was `///kbs/v0/auth`

This PR fixes this.