### PR TITLE
Add unit test case for unencrypted images

### DIFF
--- a/image-rs/test_data/offline-fs-kbc/aa-offline_fs_kbc-keys.json
+++ b/image-rs/test_data/offline-fs-kbc/aa-offline_fs_kbc-keys.json
@@ -8,5 +8,6 @@
   "default/key/7": "Y8jJ64qyDOV8+M2ZEyAAk58P6rDdnDGg3WNgn2ELdVU=",
   "default/key/8": "EfZNaUaszIjCgT6YtSLiaLDMdPBMtZNQXTrBf3DmiP0=",
   "default/key/9": "illVfAwybTUAazagcOy90wLzrMPQVm44fZWxyeigjxo=",
-  "default/key/10": "1g3KtvGfyIjq+HZmsKYJ1tMzuB8f1RjS6H0ieNBHLV0="
+  "default/key/10": "1g3KtvGfyIjq+HZmsKYJ1tMzuB8f1RjS6H0ieNBHLV0=",
+  "default/key/ssh-demo": "HUlOu8NWz8si11OZUzUJMnjiq/iZyHBJZMSD3BaqgMc="
 }

--- a/image-rs/tests/image_decryption.rs
+++ b/image-rs/tests/image_decryption.rs
@@ -25,7 +25,8 @@ const OCICRYPT_CONFIG: &str = "test_data/ocicrypt_keyprovider_ttrpc.conf";
 
 #[cfg(all(feature = "getresource", feature = "encryption"))]
 #[rstest::rstest]
-#[case("docker.io/xynnn007/busybox:encrypted-uri-key")]
+#[case("ghcr.io/confidential-containers/test-container:unencrypted")]
+#[case("ghcr.io/confidential-containers/test-container:encrypted")]
 #[tokio::test]
 #[serial]
 async fn test_decrypt_layers(#[case] image: &str) {


### PR DESCRIPTION
Addresses [issue 101](https://github.com/confidential-containers/guest-components/issues/101)
I added an unencrypted test case.

Also, I removed the previous encrypted test case, which was pulling from here:
    docker.io/xynnn007/busybox:encrypted-uri-key
And I replaced it with an encrypted test case, which pulls from here:
    ghcr.io/confidential-containers/test-container:encrypted
Reasoning: I assume we want to tie this to the CC project on GHCR while we're here and move it off of @Xynnn007's image.