### PR TITLE
Add panic with error msg when test-async-pull-client fails

### DIFF
--- a/image-rs/src/pull.rs
+++ b/image-rs/src/pull.rs
@@ -319,15 +319,17 @@ mod tests {
             let image_config = ImageConfiguration::from_reader(image_config.as_bytes()).unwrap();
             let diff_ids = image_config.rootfs().diff_ids();
 
-            assert!(client
+            if let Err(e) = client
                 .async_pull_layers(
                     image_manifest.layers.clone(),
                     diff_ids,
                     &None,
-                    Arc::new(Mutex::new(MetaStore::default()))
+                    Arc::new(Mutex::new(MetaStore::default())),
                 )
                 .await
-                .is_ok());
+            {
+                panic!("failed to download image: {}", e);
+            }
         }
     }
 


### PR DESCRIPTION
The CI fails intermittently at asserts in the unit tests, and the error message is lost.
This PR adds a log for one of the test cases that has this problem, namely pull.rs' `test_async_pull_client`

Partly addresses [Issue 156](https://github.com/confidential-containers/guest-components/issues/156)

Perusing CI failures, this test may be one of the more common failures, e.g. assuming logs are still available, [this pr288 failure](https://github.com/confidential-containers/guest-components/actions/runs/5607682567/job/15191900400?pr=288) or [this pr278 failure](https://github.com/confidential-containers/guest-components/actions/runs/5610473139/job/15200046088?pr=278).