### PR TITLE
image-rs: Fix the flaky CI with assert_retry

### DIFF
--- a/image-rs/src/signature/mechanism/cosign/mod.rs
+++ b/image-rs/src/signature/mechanism/cosign/mod.rs
@@ -123,7 +123,7 @@ impl CosignParameters {
     /// If succeeds, the payloads of the signature will be returned.
     async fn verify_signature_and_get_payload(
         &self,
-        image: &mut Image,
+        image: &Image,
         auth: &RegistryAuth,
     ) -> Result<Vec<SigPayload>> {
         // Get the pubkey
@@ -271,7 +271,7 @@ mod tests {
             .expect("Set manifest digest failed.");
         let res = parameter
             .verify_signature_and_get_payload(
-                &mut image,
+                &image,
                 &oci_distribution::secrets::RegistryAuth::Anonymous,
             )
             .await;

--- a/image-rs/src/signature/mechanism/simple/mod.rs
+++ b/image-rs/src/signature/mechanism/simple/mod.rs
@@ -197,7 +197,7 @@ impl SimpleParameters {
         Ok(())
     }
 
-    pub async fn get_signatures(&self, image: &mut Image) -> Result<Vec<Vec<u8>>> {
+    pub async fn get_signatures(&self, image: &Image) -> Result<Vec<Vec<u8>>> {
         // Get image digest (manifest digest)
         let image_digest = if !image.manifest_digest.is_empty() {
             image.manifest_digest.clone()


### PR DESCRIPTION
The pull operation will interactive with remote registry which may have network or rate limits issue, add the retry operation for related to avoid trigger the rebuild for CI with these issues.