### PR TITLE
kbs_protocol: use rusttls when rust-crypto feature is enabled

### DIFF
--- a/attestation-agent/kbs_protocol/src/lib.rs
+++ b/attestation-agent/kbs_protocol/src/lib.rs
@@ -285,6 +285,10 @@ fn build_http_client(kbs_root_certs_pem: Vec<String>) -> Result<reqwest::Client>
         client_builder = client_builder.add_root_certificate(cert);
     }
 
+    if cfg!(feature = "rust-crypto") {
+        client_builder = client_builder.use_rustls_tls();
+    }
+
     client_builder
         .build()
         .map_err(|e| anyhow!("Build KBS http client failed: {:?}", e))


### PR DESCRIPTION
reqwest uses the platform's native TLS stack by default, also when rusttls is enabled.

Force reqwest Client to use rustls TLS stack when rust-crypto feature is enabled. This is what users most likely expect to get.