### PR TITLE
image-rs: change fallback kbs_uri from localhost to http://localhost

### DIFF
--- a/image-rs/src/resource/kbs/mod.rs
+++ b/image-rs/src/resource/kbs/mod.rs
@@ -98,7 +98,7 @@ impl SecureChannel {
             let kbs_uri = match kbs_uri {
                 "null" => {
                     log::warn!("detected kbs uri `null`, use localhost to be placeholder");
-                    "localhost".into()
+                    "http://localhost".into()
                 }
                 uri => uri.into(),
             };


### PR DESCRIPTION
Eventually `localhost` will fail in this constructor, because it's not a valid URL.

https://github.com/confidential-containers/guest-components/blob/3eb25b1df25418f99140d11f9855e9ab5d0b0a13/attestation-agent/kbc/src/cc_kbc/mod.rs#L55-L57