### PR TITLE
Kbs protocol fix cargo toml

### DIFF
--- a/attestation-agent/kbs_protocol/Cargo.toml
+++ b/attestation-agent/kbs_protocol/Cargo.toml
@@ -31,11 +31,11 @@ testcontainers.workspace = true
 tokio = { workspace = true, features = [ "rt", "macros", "fs", "process" ]}
 
 [features]
-default = ["background_check", "passport", "rust-crypto"]
+default = ["background_check", "passport", "rust-crypto", "all-attesters"]
 
 passport = []
 
-background_check = ["all-attesters"]
+background_check = []
 all-attesters = ["attester/all-attesters"]
 tdx-attester = ["attester/tdx-attester"]
 sgx-attester = ["attester/sgx-attester"]

--- a/image-rs/Cargo.toml
+++ b/image-rs/Cargo.toml
@@ -101,7 +101,7 @@ keywrap-ttrpc = ["ocicrypt-rs/keywrap-keyprovider-ttrpc", "dep:ttrpc", "dep:prot
 keywrap-jwe = ["ocicrypt-rs/keywrap-jwe"]
 
 eaa-kbc = ["attestation_agent/eaa_kbc", "ocicrypt-rs/eaa_kbc"]
-cc-kbc-sgx = ["attestation_agent/cc_kbc", "ocicrypt-rs/cc_kbc_sgx"]
+cc-kbc-sgx = ["attestation_agent/cc_kbc", "attestation_agent/sgx-attester", "ocicrypt-rs/cc_kbc_sgx"]
 
 signature = ["hex"]
 signature-cosign = ["signature", "futures"]


### PR DESCRIPTION
This newly refactored `kbs_protocol` crate by default activate all attesters when background-check is enabled. This PR fixes this.

related to https://github.com/confidential-containers/enclave-cc/pull/180