### PR TITLE
New tee type: CCA (Confidential Compute Architecture)

### DIFF
--- a/attestation-agent/attester/Cargo.toml
+++ b/attestation-agent/attester/Cargo.toml
@@ -12,6 +12,7 @@ az-snp-vtpm = { git = "https://github.com/kinvolk/azure-cvm-tooling", rev = "2c2
 base64.workspace = true
 kbs-types.workspace = true
 log.workspace = true
+nix = {version = "0.26.2", optional = true }
 occlum_dcap = { git = "https://github.com/occlum/occlum", tag = "v0.29.7", optional = true }
 serde.workspace = true
 serde_json.workspace = true
@@ -30,10 +31,11 @@ tokio.workspace = true
 
 [features]
 default = ["all-attesters"]
-all-attesters = ["tdx-attester", "sgx-attester", "az-snp-vtpm-attester", "snp-attester", "csv-attester"]
+all-attesters = ["tdx-attester", "sgx-attester", "az-snp-vtpm-attester", "snp-attester", "csv-attester", "cca-attester"]
 
 tdx-attester = ["tdx-attest-rs"]
 sgx-attester = ["occlum_dcap"]
 az-snp-vtpm-attester = ["az-snp-vtpm"]
 snp-attester = ["sev"]
 csv-attester = ["csv-rs", "codicon", "hyper", "hyper-tls", "tokio"]
+cca-attester = ["nix"]

--- a/attestation-agent/attester/src/cca/mod.rs
+++ b/attestation-agent/attester/src/cca/mod.rs
@@ -1,0 +1,107 @@
+// Copyright (c) 2023 Arm Ltd.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+use super::Attester;
+use anyhow::*;
+use base64::Engine;
+use nix::fcntl::{open, OFlag};
+use nix::sys::stat::Mode;
+use nix::unistd::close;
+use serde::{Deserialize, Serialize};
+use std::path::Path;
+
+const CCA_DEVICE_PATH: &str = "/dev/cca_attestation";
+
+// NOTE: The path might be different when the CCA feature is public available, will come back to update the actual path if needed.
+pub fn detect_platform() -> bool {
+    Path::new(CCA_DEVICE_PATH).exists()
+}
+
+#[derive(Debug, Default)]
+pub struct CCAAttester {}
+
+#[derive(Serialize, Deserialize)]
+struct CcaEvidence {
+    /// CCA token
+    token: Vec<u8>,
+}
+
+#[allow(non_camel_case_types)]
+#[repr(C)]
+pub struct cca_ioctl_request {
+    challenge: [u8; 64],
+    token: [u8; 4096],
+    token_length: u64,
+}
+
+nix::ioctl_readwrite!(cca_attestation_request, b'A', 1, cca_ioctl_request);
+
+#[async_trait::async_trait]
+impl Attester for CCAAttester {
+    async fn get_evidence(&self, mut challenge: Vec<u8>) -> Result<String> {
+        challenge.resize(64, 0);
+        let token = attestation(challenge)?;
+        let evidence = CcaEvidence { token };
+        let ev = serde_json::to_string(&evidence).context("Serialize CCA evidence failed")?;
+        Ok(ev)
+    }
+}
+
+fn attestation(challenge: Vec<u8>) -> Result<Vec<u8>, Error> {
+    log::info!("cca_test::attestation started");
+
+    let challenge = challenge.as_slice().try_into()?;
+
+    match open(CCA_DEVICE_PATH, OFlag::empty(), Mode::empty()) {
+        Result::Ok(f) => {
+            log::info!("cca_test::attestation opening attestation succeeded");
+            let mut request = cca_ioctl_request {
+                challenge,
+                token: [0u8; 4096],
+                token_length: 0u64,
+            };
+
+            // this is unsafe code block since ioctl call `cca_attestation_request` has the unsafe signature.
+            match unsafe { cca_attestation_request(f, &mut request) } {
+                Result::Ok(c) => {
+                    log::info!("cca_test::attestation ioctl call succeeded ({})", c);
+                    log::info!(
+                        "cca_test::attestation token is {} bytes long",
+                        request.token_length
+                    );
+                    let base64 = base64::engine::general_purpose::STANDARD
+                        .encode(&request.token[0..(request.token_length as usize)]);
+                    log::info!("cca_test::attestation token = {:x?}", base64);
+                    let token = request.token[0..(request.token_length as usize)].to_vec();
+                    close(f)?;
+                    Ok(token)
+                }
+                Err(e) => {
+                    log::error!("cca_test::attestation ioctl failed! {}", e);
+                    close(f)?;
+                    bail!(e)
+                }
+            }
+        }
+        Err(err) => {
+            log::error!("cca_test::attestation opening attestation failed! {}", err);
+            bail!(err)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[ignore]
+    #[tokio::test]
+    async fn test_cca_get_evidence() {
+        let attester = CCAAttester::default();
+        let report_data: Vec<u8> = vec![0; 48];
+        let evidence = attester.get_evidence(report_data).await;
+        assert!(evidence.is_ok());
+    }
+}

--- a/attestation-agent/attester/src/lib.rs
+++ b/attestation-agent/attester/src/lib.rs
@@ -11,6 +11,9 @@ pub mod sample;
 #[cfg(feature = "az-snp-vtpm-attester")]
 pub mod az_snp_vtpm;
 
+#[cfg(feature = "cca-attester")]
+pub mod cca;
+
 #[cfg(feature = "tdx-attester")]
 pub mod tdx;
 
@@ -37,6 +40,8 @@ impl TryFrom<Tee> for BoxedAttester {
             Tee::Sgx => Box::<sgx_dcap::SgxDcapAttester>::default(),
             #[cfg(feature = "az-snp-vtpm-attester")]
             Tee::AzSnpVtpm => Box::<az_snp_vtpm::AzSnpVtpmAttester>::default(),
+            #[cfg(feature = "cca-attester")]
+            Tee::Cca => Box::<cca::CCAAttester>::default(),
             #[cfg(feature = "snp-attester")]
             Tee::Snp => Box::<snp::SnpAttester>::default(),
             #[cfg(feature = "csv-attester")]
@@ -85,6 +90,11 @@ pub fn detect_tee_type() -> Option<Tee> {
     #[cfg(feature = "csv-attester")]
     if csv::detect_platform() {
         return Some(Tee::Csv);
+    }
+
+    #[cfg(feature = "cca-attester")]
+    if cca::detect_platform() {
+        return Some(Tee::Cca);
     }
 
     None

--- a/attestation-agent/kbc/Cargo.toml
+++ b/attestation-agent/kbc/Cargo.toml
@@ -42,6 +42,7 @@ tdx-attester = ["kbs_protocol/tdx-attester"]
 sgx-attester = ["kbs_protocol/sgx-attester"]
 az-snp-vtpm-attester= ["kbs_protocol/az-snp-vtpm-attester"]
 snp-attester = ["kbs_protocol/snp-attester"]
+cca-attester = ["kbs_protocol/cca-attester"]
 
 sample_kbc = []
 eaa_kbc = ["foreign-types"]

--- a/attestation-agent/kbs_protocol/Cargo.toml
+++ b/attestation-agent/kbs_protocol/Cargo.toml
@@ -49,6 +49,7 @@ sgx-attester = ["attester/sgx-attester"]
 az-snp-vtpm-attester = ["attester/az-snp-vtpm-attester"]
 snp-attester = ["attester/snp-attester"]
 csv-attester = ["attester/csv-attester"]
+cca-attester = ["attester/cca-attester"]
 
 rust-crypto = ["reqwest/rustls-tls", "crypto/rust-crypto"]
 openssl = ["reqwest/native-tls-vendored", "crypto/openssl"]


### PR DESCRIPTION
Support to get the CCA token in the FVP(Fixed Virtual Platform) environment, it is currently implemented by an `ioctl` which read a device exported in the userspace.

Credit to Mathias Brossard, this PR is based on his POC.