### PR TITLE
cargo: Fix the build dependency for eaa_kbc

### DIFF
--- a/attestation-agent/kbc/Cargo.toml
+++ b/attestation-agent/kbc/Cargo.toml
@@ -37,7 +37,7 @@ tonic-build = { version = "0.9.2", optional = true }
 default = ["sample_kbc", "rust-crypto"]
 
 cc_kbc = ["kbs_protocol/background_check"]
-all-attesters = ["kbs_protocol/all-attesters"]
+all-attesters = ["kbs_protocol?/all-attesters"]
 tdx-attester = ["kbs_protocol/tdx-attester"]
 sgx-attester = ["kbs_protocol/sgx-attester"]
 az-snp-vtpm-attester= ["kbs_protocol/az-snp-vtpm-attester"]

--- a/attestation-agent/lib/Cargo.toml
+++ b/attestation-agent/lib/Cargo.toml
@@ -26,7 +26,7 @@ tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 default = ["sample_kbc", "rust-crypto", "all-attesters"]
 
 cc_kbc = ["kbc/cc_kbc", "kbs_protocol/background_check"]
-all-attesters = ["kbc/all-attesters", "kbs_protocol/all-attesters", "attester/all-attesters"]
+all-attesters = ["kbc/all-attesters", "kbs_protocol?/all-attesters", "attester/all-attesters"]
 tdx-attester = ["kbc/tdx-attester", "kbs_protocol/tdx-attester", "attester/tdx-attester"]
 sgx-attester = ["kbc/sgx-attester", "kbs_protocol/sgx-attester", "attester/sgx-attester"]
 az-snp-vtpm-attester = ["kbc/az-snp-vtpm-attester", "kbs_protocol/az-snp-vtpm-attester", "attester/az-snp-vtpm-attester"]
@@ -39,5 +39,5 @@ offline_sev_kbc = ["kbc/offline_sev_kbc"]
 online_sev_kbc = ["kbc/online_sev_kbc"]
 
 # Either `rust-crypto` or `openssl` should be enabled to work as underlying crypto module
-rust-crypto = ["kbc/rust-crypto", "kbs_protocol/rust-crypto"]
-openssl = ["kbc/openssl", "kbs_protocol/openssl"]
+rust-crypto = ["kbc/rust-crypto", "kbs_protocol?/rust-crypto"]
+openssl = ["kbc/openssl", "kbs_protocol?/openssl"]


### PR DESCRIPTION
kbs_protocol is not required by eaa_kbc

Fix the CI lint error:
Error:   --> attestation-agent/kbs_protocol/src/client/mod.rs:37:16
   |
32 | pub struct KbsClient<T> {
   |            --------- fields in this struct
...
37 |     pub(crate) tee_key: TeeKeyPair,
   |                ^^^^^^^
38 |
39 |     pub(crate) provider: T,
   |                ^^^^^^^^
...
42 |     pub(crate) http_client: reqwest::Client,
   |                ^^^^^^^^^^^
...
45 |     pub(crate) kbs_host_url: String,
   |                ^^^^^^^^^^^^
...
48 |     pub(crate) token: Option<Token>,
   |                ^^^^^
   |
   = note: `-D dead-code` implied by `-D warnings`