### PR TITLE
image-rs: Update loopdev to latest master

### DIFF
--- a/image-rs/Cargo.toml
+++ b/image-rs/Cargo.toml
@@ -25,7 +25,7 @@ hex = { workspace = true, optional = true }
 lazy_static = { workspace = true, optional = true }
 libc = "0.2"
 log = "0.4.14"
-loopdev ="0.4.0"
+loopdev = { git = "https://github.com/mdaffin/loopdev", rev = "c9f91e8f0326ce8a3364ac911e81eb32328a5f27"}
 nix = { version = "0.26", optional = true }
 oci-distribution = { git = "https://github.com/krustlet/oci-distribution.git", rev = "f44124c", default-features = false, optional = true }
 oci-spec = "0.6.2"


### PR DESCRIPTION
loopdev 0.4.0 uses older bingen version which fails to build on CentOS.

This will partially fix: https://github.com/confidential-containers/cloud-api-adaptor/issues/1358. I say partially because kata-containers repo has to be updated and then CAA will be able to get these latest bits.