### PR TITLE
Remove git reference for sev

### DIFF
--- a/attestation-agent/attester/Cargo.toml
+++ b/attestation-agent/attester/Cargo.toml
@@ -15,7 +15,7 @@ log.workspace = true
 occlum_dcap = { git = "https://github.com/occlum/occlum", tag = "v0.29.7", optional = true }
 serde.workspace = true
 serde_json.workspace = true
-sev = { git = "https://github.com/virtee/sev", version = "1.2", default-features = false, features = ["snp"], optional = true }
+sev = { version = "1.2.0", default-features = false, features = ["snp"], optional = true }
 strum.workspace = true
 tdx-attest-rs = { git = "https://github.com/intel/SGXDataCenterAttestationPrimitives", tag = "DCAP_1.16", optional = true }
 # TODO: change it to "0.1", once released.


### PR DESCRIPTION
Having the sev dependency come from GitHub instead of crates.io was causing errors when vendoring. This change fixes it, as it makes Cargo look for sev on crates.io.

Fixes [issue 333](https://github.com/confidential-containers/guest-components/issues/333).