### PR TITLE
versions: Downgrade clap

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ base64-serde = "0.7"
 bincode = "1.3.3"
 cfg-if = "1.0.0"
 chrono = "0.4.26"
-clap = "4"
+clap = "4.2.7"
 const_format = "0.2.30"
 ctr = "0.9.2"
 env_logger = "0.10.0"
@@ -68,4 +68,3 @@ zeroize = "1.5.7"
 
 [patch.crates-io]
 oci-distribution = { git = "https://github.com/krustlet/oci-distribution.git", rev = "f44124c" }
-


### PR DESCRIPTION
- Downgrade clap to get to a version that builds on rust 1.69
- clap 4.3 states that it requires rust 1.65, but it pulls in clap_lex 0.5 as a dependency, which requires rust 1.70. The newest version of clap_lex that will build on 1.69 is 0.4 and the newest version of clap that depends on 0.4 is currently 4.2.7, which is how I got to this version

Fixes: #336