### PR TITLE
ci: Use toolchain match the kata to replace the beta

### DIFF
--- a/.github/workflows/image_rs_build.yml
+++ b/.github/workflows/image_rs_build.yml
@@ -24,8 +24,8 @@ jobs:
       fail-fast: false
       matrix:
         rust:
+          - 1.69.0
           - stable
-          - beta
           - nightly
     steps:
       - name: Code checkout

--- a/.github/workflows/ocicrypt_rs_build.yml
+++ b/.github/workflows/ocicrypt_rs_build.yml
@@ -21,8 +21,8 @@ jobs:
       fail-fast: false
       matrix:
         rust:
+          - 1.69.0
           - stable
-          - beta
           - nightly
 
     # Run all steps in the compilation testing containers


### PR DESCRIPTION
Current Kata main/CCv0 use rust toolchain version 1.69:

  rust:
    description: "Rust language"
    notes: "'version' is the default minimum version used by this project."
    version: "1.69.0"
    meta:
      description: |
        'newest-version' is the latest version known to work when
        building Kata
      newest-version: "1.69.0"

Fixes: #330