### PR TITLE
Verity: Redefine functions to support kata

### DIFF
--- a/image-rs/src/verity/dmverity.rs
+++ b/image-rs/src/verity/dmverity.rs
@@ -193,9 +193,9 @@ pub fn create_verity_device(
 }
 
 /// Destroy a DmVerity device with specified name.
-pub fn destroy_verity_device(verity_device_name: String) -> Result<()> {
+pub fn destroy_verity_device(verity_device_name: &str) -> Result<()> {
     let dm = devicemapper::DM::new()?;
-    let name = devicemapper::DmName::new(&verity_device_name)?;
+    let name = devicemapper::DmName::new(verity_device_name)?;
 
     dm.device_remove(
         &devicemapper::DevId::Name(name),
@@ -421,7 +421,7 @@ mod tests {
             let verity_device_path =
                 create_verity_device(d, &loop_device_path).unwrap_or_else(|err| panic!("{}", err));
             assert_eq!(verity_device_path, format!("/dev/mapper/{}", d.hash));
-            destroy_verity_device(d.hash.clone()).unwrap();
+            destroy_verity_device(&d.hash).unwrap();
         }
     }
 }

--- a/image-rs/src/verity/mod.rs
+++ b/image-rs/src/verity/mod.rs
@@ -19,8 +19,7 @@ pub fn mount_image_block_with_integrity(
     mount_path: &Path,
     mount_type: &str,
 ) -> Result<String> {
-    let parsed_data = DmVerityOption::try_from(verity_options)?;
-    let verity_device_path = create_verity_device(&parsed_data, source_device_path)?;
+    let verity_device_path = create_dmverity_device(verity_options, source_device_path)?;
 
     nix::mount::mount(
         Some(verity_device_path.as_str()),
@@ -49,6 +48,10 @@ pub fn get_image_name_from_remote(image_url: &str) -> Result<String> {
     Ok(String::from_utf8_lossy(&decoded).to_string())
 }
 
+pub fn create_dmverity_device(verity_options: &str, source_device_path: &Path) -> Result<String> {
+    let parsed_data = DmVerityOption::try_from(verity_options)?;
+    create_verity_device(&parsed_data, source_device_path)
+}
 pub fn destroy_dmverity_device(verity_device_name: &str) -> Result<()> {
     destroy_verity_device(verity_device_name)
 }

--- a/image-rs/src/verity/mod.rs
+++ b/image-rs/src/verity/mod.rs
@@ -38,7 +38,7 @@ pub fn umount_image_block_with_integrity(
     verity_device_name: String,
 ) -> Result<()> {
     nix::mount::umount(mount_path)?;
-    cleanup_verity_device(verity_device_name)?;
+    destroy_dmverity_device(&verity_device_name)?;
     Ok(())
 }
 
@@ -49,7 +49,7 @@ pub fn get_image_name_from_remote(image_url: &str) -> Result<String> {
     Ok(String::from_utf8_lossy(&decoded).to_string())
 }
 
-pub fn cleanup_verity_device(verity_device_name: String) -> Result<()> {
+pub fn destroy_dmverity_device(verity_device_name: &str) -> Result<()> {
     destroy_verity_device(verity_device_name)
 }
 


### PR DESCRIPTION
Redefine functions to support kata:
1) change input parameters of function `destroy_verity_device` and `destroy_dmverity_device` from `String` type  to `&str`.
2) add a function `create_dmverity_device` to call `create_verity_device`.