### PR TITLE
Update `az-snp-vtpm` version to avoid vendor openssl

### DIFF
--- a/attestation-agent/attester/Cargo.toml
+++ b/attestation-agent/attester/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 [dependencies]
 anyhow.workspace = true
 async-trait.workspace = true
-az-snp-vtpm = { git = "https://github.com/kinvolk/azure-cvm-tooling", rev = "2c2e411", default-features = false, features = ["attester"], optional = true }
+az-snp-vtpm = { git = "https://github.com/kinvolk/azure-cvm-tooling", rev = "09a8a0d", default-features = false, features = ["attester"], optional = true }
 base64.workspace = true
 kbs-types.workspace = true
 log.workspace = true


### PR DESCRIPTION
Fix #346 