### PR TITLE
ci: install DCAP packages from Jammy repo

### DIFF
--- a/.github/workflows/aa_basic.yml
+++ b/.github/workflows/aa_basic.yml
@@ -24,7 +24,7 @@ jobs:
     defaults:
       run:
         working-directory: ./attestation-agent
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:
@@ -50,10 +50,10 @@ jobs:
 
       - name: Install TDX dependencies
         run: |
-          sudo curl -L https://download.01.org/intel-sgx/sgx_repo/ubuntu/intel-sgx-deb.key | sudo apt-key add -
-          sudo echo 'deb [arch=amd64] https://download.01.org/intel-sgx/sgx_repo/ubuntu focal main' | sudo tee /etc/apt/sources.list.d/intel-sgx.list
+          sudo curl -sL https://download.01.org/intel-sgx/sgx_repo/ubuntu/intel-sgx-deb.key | sudo gpg --dearmor --output /usr/share/keyrings/intel-sgx.gpg
+          sudo echo 'deb [arch=amd64 signed-by=/usr/share/keyrings/intel-sgx.gpg] https://download.01.org/intel-sgx/sgx_repo/ubuntu jammy main' | sudo tee /etc/apt/sources.list.d/intel-sgx.list
           sudo apt-get update
-          sudo apt-get install -y libtdx-attest-dev
+          sudo apt-get install -y --no-install-recommends libtdx-attest-dev
 
       - name: Install TPM dependencies
         run: |

--- a/.github/workflows/aa_cc_kbc.yml
+++ b/.github/workflows/aa_cc_kbc.yml
@@ -52,10 +52,10 @@ jobs:
 
       - name: Install TDX dependencies
         run: |
-          sudo curl -L https://download.01.org/intel-sgx/sgx_repo/ubuntu/intel-sgx-deb.key | sudo apt-key add -
-          sudo echo 'deb [arch=amd64] https://download.01.org/intel-sgx/sgx_repo/ubuntu focal main' | sudo tee /etc/apt/sources.list.d/intel-sgx.list
+          sudo curl -sL https://download.01.org/intel-sgx/sgx_repo/ubuntu/intel-sgx-deb.key | sudo gpg --dearmor --output /usr/share/keyrings/intel-sgx.gpg
+          sudo echo 'deb [arch=amd64 signed-by=/usr/share/keyrings/intel-sgx.gpg] https://download.01.org/intel-sgx/sgx_repo/ubuntu jammy main' | sudo tee /etc/apt/sources.list.d/intel-sgx.list
           sudo apt-get update
-          sudo apt-get install -y libtdx-attest-dev
+          sudo apt-get install -y --no-install-recommends libtdx-attest-dev
 
       - name: Install TPM dependencies
         run: |

--- a/.github/workflows/image_rs_build.yml
+++ b/.github/workflows/image_rs_build.yml
@@ -23,7 +23,7 @@ jobs:
     defaults:
       run:
         working-directory: ./image-rs
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:
@@ -51,10 +51,10 @@ jobs:
 
       - name: Install TDX dependencies
         run: |
-          sudo curl -L https://download.01.org/intel-sgx/sgx_repo/ubuntu/intel-sgx-deb.key | sudo apt-key add -
-          sudo echo 'deb [arch=amd64] https://download.01.org/intel-sgx/sgx_repo/ubuntu focal main' | sudo tee /etc/apt/sources.list.d/intel-sgx.list
+          sudo curl -sL https://download.01.org/intel-sgx/sgx_repo/ubuntu/intel-sgx-deb.key | sudo gpg --dearmor --output /usr/share/keyrings/intel-sgx.gpg
+          sudo echo 'deb [arch=amd64 signed-by=/usr/share/keyrings/intel-sgx.gpg] https://download.01.org/intel-sgx/sgx_repo/ubuntu jammy main' | sudo tee /etc/apt/sources.list.d/intel-sgx.list
           sudo apt-get update
-          sudo apt-get install -y libtdx-attest-dev
+          sudo apt-get install -y --no-install-recommends libtdx-attest-dev
 
       - name: Install TPM dependencies
         run: |


### PR DESCRIPTION
The workflows use ubuntu-22.04 (ubuntu-latest) but install DCAP packages from focal.

While fixing that, also move away from deprecated apt-key usage and install recommended packages only.