### PR TITLE
workflows: Bump to rust 1.72

### DIFF
--- a/.github/workflows/image_rs_build.yml
+++ b/.github/workflows/image_rs_build.yml
@@ -24,7 +24,7 @@ jobs:
       fail-fast: false
       matrix:
         rust:
-          - 1.69.0
+          - 1.72.0
           - stable
           - nightly
     steps:

--- a/.github/workflows/ocicrypt_rs_build.yml
+++ b/.github/workflows/ocicrypt_rs_build.yml
@@ -21,7 +21,7 @@ jobs:
       fail-fast: false
       matrix:
         rust:
-          - 1.69.0
+          - 1.72.0
           - stable
           - nightly
 


### PR DESCRIPTION
Now we've gone to v1.72 in kata-containers, we can bump the versions we test against to stay in sync. At the moment there is a bit of duplication as 1.72 is the stable version, but that will change soon