### PR TITLE
Fix cc kbc aa param config file parsing

### DIFF
--- a/.github/workflows/aa_cc_kbc.yml
+++ b/.github/workflows/aa_cc_kbc.yml
@@ -7,11 +7,13 @@ on:
     paths:
       - 'attestation-agent/kbc/cc_kbc/**'
       - 'attestation-agent/kbs_protocol/**'
+      - 'attestation-agent/lib/**'
       - '.github/workflows/aa_cc_kbc.yml'
   pull_request:
     paths:
       - 'attestation-agent/kbc/cc_kbc/**'
       - 'attestation-agent/kbs_protocol/**'
+      - 'attestation-agent/lib/**'
       - '.github/workflows/aa_cc_kbc.yml'
   create:
   workflow_dispatch:

--- a/attestation-agent/lib/src/token.rs
+++ b/attestation-agent/lib/src/token.rs
@@ -3,9 +3,10 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-use anyhow::{anyhow, Context, Result};
+use anyhow::{anyhow, Result};
 use kbs_protocol::{evidence_provider::NativeEvidenceProvider, KbsClientBuilder};
 use serde::{Deserialize, Serialize};
+use std::path::Path;
 use tokio::fs;
 
 const PEER_POD_CONFIG_PATH: &str = "/peerpod/daemon.json";
@@ -66,10 +67,11 @@ pub(crate) async fn get_kbs_host_from_config_file() -> Result<String> {
 
     // Hard-code agent config path to "/etc/agent-config.toml" as a workaround
     let agent_config_str = fs::read_to_string("/etc/agent-config.toml")
-        .context("Failed to read /etc/agent-config.toml file")?;
+        .await
+        .map_err(|e| anyhow!("Failed to read /etc/agent-config.toml file: {e}"))?;
 
     let agent_config: AgentConfig = toml::from_str(&agent_config_str)
-        .context("Failed to deserialize /etc/agent-config.toml")?;
+        .map_err(|e| anyhow!("Failed to deserialize /etc/agent-config.toml: {e}"))?;
 
     agent_config.aa_kbc_params.ok_or(anyhow!(
         "no `aa_kbc_params` found in /etc/agent-config.toml!",


### PR DESCRIPTION
Sorry, this is my-bad. I blindly copy-pasted the fixes from cdh into AA without paying enough attention and then just testing building it with the offline_fs_kbc and assumed that the workflows would run it for the others. It turns out that it doesn't, so I've tried to correct that and fix the code so that:
```
~/cc-guest-components/attestation-agent# make KBC=cc_kbc
DEBIANOS is: true
cd app &&  cargo build --release --no-default-features --features "cc_kbc grpc,rust-crypto" --target x86_64-unknown-linux-gnu
warning: skipping duplicate package `init` found at `/root/.cargo/git/checkouts/occlum-09e22bc8c2a4bfe1/b5a32a8/demos/runtime_boot/init`
warning: skipping duplicate package `init` found at `/root/.cargo/git/checkouts/occlum-09e22bc8c2a4bfe1/b5a32a8/tools/init`
warning: skipping duplicate package `app` found at `/root/.cargo/git/checkouts/sgxdatacenterattestationprimitives-d6934a418e6beae0/71557c7/SampleCode/RustTDQuoteGenerationSample`
    Finished release [optimized] target(s) in 0.49
```
works now.