### PR TITLE
api-server-rest: fix aa_addr cli param

### DIFF
--- a/api-server-rest/src/main.rs
+++ b/api-server-rest/src/main.rs
@@ -47,7 +47,7 @@ struct Args {
     cdh_addr: String,
 
     /// Listen address of attestation-agent TTRPC Service
-    #[arg(default_value_t = AA_ADDR.to_string(), short, long = "cdh_addr")]
+    #[arg(default_value_t = AA_ADDR.to_string(), short, long = "aa_addr")]
     aa_addr: String,
 }
 


### PR DESCRIPTION
There is a typo in the param eval code