### PR TITLE
cdh/kms/kbs: raise warning when failed to read file for offline-fs-kbc

### DIFF
--- a/confidential-data-hub/kms/src/plugins/kbs/offline_fs.rs
+++ b/confidential-data-hub/kms/src/plugins/kbs/offline_fs.rs
@@ -50,9 +50,14 @@ impl OfflineFsKbc {
     }
 
     async fn init_with_file(&mut self, path: &str) -> Result<()> {
-        let file = fs::read(path).await.map_err(|e| {
-            Error::KbsClientError(format!("offline-fs-kbc: read {path} failed: {e}"))
-        })?;
+        let file = match fs::read(path).await {
+            Ok(f) => f,
+            Err(e) => {
+                warn!("Failed to read file {path} to init offline-fs-kbc: {e}");
+                return Ok(());
+            }
+        };
+
         let map: HashMap<String, String> = serde_json::from_slice(&file).map_err(|e| {
             Error::KbsClientError(format!("offline-fs-kbc: illegal resource file {path}: {e}"))
         })?;


### PR DESCRIPTION
Before this commit, if the given offline-fs-kbc file is not abled to be read when offline-fs-kbc is being initialized, an error will be raised. This will cause the whole CDH process to exit.

In real scenarios, this would require a user to embed an empty aa-offline_fs_kbc-resources.json and aa-offline_fs_kbc-keys.json to the guest image, which is meaningless.

This patch fixes this.

@stevenhorsman