### PR TITLE
Attester: Update CSV evidence format

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -881,11 +881,13 @@ dependencies = [
  "async-trait",
  "base64 0.21.4",
  "clap 4.2.7",
+ "image",
  "kms",
  "lazy_static",
  "log",
  "protobuf 3.2.0",
  "secret",
+ "serde",
  "serde_json",
  "sev 0.1.0",
  "thiserror",
@@ -1141,13 +1143,14 @@ dependencies = [
 [[package]]
 name = "csv-rs"
 version = "0.1.0"
-source = "git+https://gitee.com/anolis/csv-rs?rev=05fbacd#05fbacd8ffff3d48bb19319da1c9a84b763d9302"
+source = "git+https://gitee.com/anolis/csv-rs?rev=9d8882e#9d8882e005ab0f64f4e3802a37aebfc61bc4fe32"
 dependencies = [
  "bitfield",
  "codicon",
  "hyper",
  "hyper-tls",
  "iocuddle",
+ "libc",
  "openssl",
  "openssl-sys",
  "rand 0.8.5",
@@ -2440,6 +2443,21 @@ checksum = "7d20d6b07bfbc108882d88ed8e37d39636dcc260e15e30c45e6ba089610b917c"
 dependencies = [
  "unicode-bidi",
  "unicode-normalization",
+]
+
+[[package]]
+name = "image"
+version = "0.1.0"
+dependencies = [
+ "assert-json-diff",
+ "base64 0.21.4",
+ "crypto",
+ "kms",
+ "resource_uri",
+ "rstest",
+ "serde",
+ "serde_json",
+ "thiserror",
 ]
 
 [[package]]

--- a/attestation-agent/attester/src/csv/mod.rs
+++ b/attestation-agent/attester/src/csv/mod.rs
@@ -32,6 +32,8 @@ struct CertificateChain {
 struct CsvEvidence {
     attestation_report: AttestationReport,
     cert_chain: CertificateChain,
+    // Base64 Encoded CSV Serial Number (Used to identify HYGON chip ID)
+    serial_number: Vec<u8>,
 }
 
 #[derive(Debug, Default)]
@@ -59,6 +61,7 @@ impl Attester for CsvAttester {
         let evidence = CsvEvidence {
             attestation_report,
             cert_chain: CertificateChain { hsk, cek, pek },
+            serial_number: report_signer.sn.to_vec(),
         };
         serde_json::to_string(&evidence).context("Serialize CSV evidence failed")
     }


### PR DESCRIPTION
 Add a serial number to the evidence content to identify the HYGON chip ID. This field improves the completeness of CSV evidence, allowing for different release logic to be set for different HYGON chips when setting AS policies. This modification comes from the needs of scene users.


cc @BaoshunFang @Xynnn007 