### PR TITLE
Decode key used for image decryption

### DIFF
--- a/attestation-agent/kbc/src/cc_kbc/mod.rs
+++ b/attestation-agent/kbc/src/cc_kbc/mod.rs
@@ -31,8 +31,8 @@ impl KbcInterface for Kbc {
 
     async fn decrypt_payload(&mut self, annotation_packet: AnnotationPacket) -> Result<Vec<u8>> {
         let key_data = self.kbs_client.get_resource(annotation_packet.kid).await?;
-        let key = Zeroizing::new(key_data);
-
+        let decoded_key = base64::engine::general_purpose::STANDARD.decode(key_data)?;
+        let key = Zeroizing::new(decoded_key);
         let wrap_type = WrapType::try_from(&annotation_packet.wrap_type[..])?;
         decrypt(
             key,


### PR DESCRIPTION
The key should be base64 encoded if it's from a kbs repository, KMS or file system instead of plain text.

This align with other KBC module, suh as `offline_fs_kbc`.

https://github.com/confidential-containers/guest-components/blob/dec7f10ec2ab1e715c49741188d48065ab6c0feb/attestation-agent/kbc/src/offline_fs_kbc/common.rs#L17-L26