### PR TITLE
AA/kbs_protocol: fix RCAR handshake protocol

### DIFF
--- a/attestation-agent/kbs_protocol/test/kbs-config.toml
+++ b/attestation-agent/kbs_protocol/test/kbs-config.toml
@@ -1,0 +1,3 @@
+insecure_http = true
+insecure_api = true
+sockets = ["0.0.0.0:8085"]

--- a/attestation-agent/kbs_protocol/test/start_kbs.sh
+++ b/attestation-agent/kbs_protocol/test/start_kbs.sh
@@ -1,2 +1,2 @@
 #! /bin/bash
-kbs --socket 0.0.0.0:8085 --insecure-api --insecure-http
+kbs --config-file /etc/kbs-config.toml


### PR DESCRIPTION
Before this commit, the tee-pubkey is not fully integrity-protected by binding the digest into the evidence. The update of this commit is aligned with the KBS side.

Fixes #366

cc @mythi 