### PR TITLE
Makefile: add platform Makefile to quickly build guest component binaries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,56 @@
+TEE_PLATFORM ?= test
+ARCH ?= $(shell uname -m)
+
+DESTDIR ?= /usr/local/bin
+
+LIBC ?= musl
+KBC ?=
+RESOURCE_PROVIDER ?= kbs
+
+ifeq ($(TEE_PLATFORM), test)
+  KBC = offline_fs_kbc
+else ifeq ($(TEE_PLATFORM), tdx)
+  LIBC = gnu
+  KBC = cc_kbc_tdx
+else ifeq ($(TEE_PLATFORM), sev)
+  KBC = online_sev_kbc
+  RESOURCE_PROVIDER = sev
+endif
+# TODO: Add support for SNP, Az-snp-vtpm, CCA, CSV
+
+ifeq ($(ARCH), $(filter $(ARCH), s390x powerpc64le))
+  LIBC = gnu
+endif
+
+CDH := confidential-data-hub
+AA := attestation-agent
+ASR := api-server-rest
+
+BUILD_DIR := target/$(ARCH)-unknown-linux-$(LIBC)/release
+
+CDH_BINARY := $(BUILD_DIR)/$(CDH)
+AA_BINARY := $(BUILD_DIR)/$(AA)
+ASR_BINARY := $(BUILD_DIR)/$(ASR)
+
+build: $(CDH_BINARY) $(ASR_BINARY) $(AA_BINARY)
+	@echo guest components built for $(TEE_PLATFORM) succeeded!
+
+$(CDH_BINARY):
+	@echo build $(CDH) for $(TEE_PLATFORM)
+	cd $(CDH) && $(MAKE) RESOURCE_PROVIDER=$(RESOURCE_PROVIDER) LIBC=$(LIBC)
+
+$(AA_BINARY):
+	@echo build $(AA) for $(TEE_PLATFORM)
+	cd $(AA) && $(MAKE) ttrpc=true ARCH=$(ARCH) LIBC=$(LIBC) KBC=$(KBC)
+
+$(ASR_BINARY):
+	@echo build $(ASR) for $(TEE_PLATFORM)
+	cd $(ASR) && $(MAKE) ARCH=$(ARCH) LIBC=$(LIBC)
+
+install: $(CDH_BINARY) $(ASR_BINARY) $(AA_BINARY)
+	install -D -m0755 $(CDH_BINARY) $(DESTDIR)/$(CDH)
+	install -D -m0755 $(AA_BINARY) $(DESTDIR)/$(AA)
+	install -D -m0755 $(ASR_BINARY) $(DESTDIR)/$(ASR)
+
+clean:
+	rm -rf target

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 This repository includes tools and components for confidential container images.
 
-## 
+## Components
 
 [Attestation Agent](attestation-agent)
 An agent for facilitating attestation protocols.
@@ -17,6 +17,23 @@ Rust implementation of the OCI image encryption library.
 
 [api-server-rest](api-server-rest)
 CoCo Restful API server.
+
+[coco-keyprovider](attestation-agent/coco_keyprovider/)
+CoCo Keyprovider. Used to encrypt the container images.
+
+## Build
+
+A `Makefile` is provided to quickly build Attestation Agent/Api Server Rest/Confidential Data Hub of a given platform.
+
+```shell
+make build TEE_PLATFORM=$(TEE_PLATFORM)
+make install DESTDIR=/usr/local/bin
+```
+
+The `TEE_PLATFORM` parameter can be
+- `test`: for test
+- `tdx`: for Intel TDX
+- `sev`: for AMD SEV
 
 ## License
 [![FOSSA Status](https://app.fossa.com/api/projects/git%2Bgithub.com%2Fconfidential-containers%2Fimage-rs.svg?type=large)](https://app.fossa.com/projects/git%2Bgithub.com%2Fconfidential-containers%2Fimage-rs?ref=badge_large)


### PR DESCRIPTION
Currently we are building AA/CDH/ASR with different and complex compiling parameters controls. To make it simpler for default cases, this commit adds a Makefile with the following assumption:

test: libc=musl, KBC=offline_fs_kbc
tdx: libc=gnu, KBC=cc_kbc_tdx
sev: libc=musl, KBC=online_sev_kbc

Fixes #373

Hi @stevenhorsman @Alex-Carter01 @fidencio @arronwy Please check if it is as expected.