### PR TITLE
image-rs: Redefine constructions of ImageClient and ImageConfig

### DIFF
--- a/image-rs/src/image.rs
+++ b/image-rs/src/image.rs
@@ -11,7 +11,7 @@ use oci_spec::image::{ImageConfiguration, Os};
 use serde::Deserialize;
 use std::collections::{BTreeSet, HashMap};
 use std::convert::TryFrom;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use tokio::sync::Mutex;
@@ -99,8 +99,22 @@ impl Default for ImageClient {
     fn default() -> ImageClient {
         let config = ImageConfig::try_from(Path::new(CONFIGURATION_FILE_PATH)).unwrap_or_default();
         let meta_store = MetaStore::try_from(Path::new(METAFILE)).unwrap_or_default();
+        let snapshots = Self::init_snapshots(&config, &meta_store);
 
-        #[allow(unused_mut)]
+        ImageClient {
+            config,
+            meta_store: Arc::new(Mutex::new(meta_store)),
+            snapshots,
+        }
+    }
+}
+
+impl ImageClient {
+    ///Initialize metadata database and supported snapshots.
+    pub fn init_snapshots(
+        config: &ImageConfig,
+        meta_store: &MetaStore,
+    ) -> HashMap<SnapshotType, Box<dyn Snapshotter>> {
         let mut snapshots = HashMap::new();
 
         #[cfg(feature = "snapshot-overlayfs")]
@@ -119,7 +133,6 @@ impl Default for ImageClient {
                 Box::new(overlayfs) as Box<dyn Snapshotter>,
             );
         }
-
         #[cfg(feature = "snapshot-unionfs")]
         {
             let occlum_unionfs_index = meta_store
@@ -137,16 +150,22 @@ impl Default for ImageClient {
                 Box::new(occlum_unionfs) as Box<dyn Snapshotter>,
             );
         }
+        snapshots
+    }
 
-        ImageClient {
+    /// Create an ImageClient instance with specific work directory.
+    pub fn new(image_work_dir: PathBuf) -> Self {
+        let config = ImageConfig::new(image_work_dir);
+        let meta_store = MetaStore::try_from(Path::new(METAFILE)).unwrap_or_default();
+        let snapshots = Self::init_snapshots(&config, &meta_store);
+
+        Self {
             config,
             meta_store: Arc::new(Mutex::new(meta_store)),
             snapshots,
         }
     }
-}
 
-impl ImageClient {
     /// pull_image pulls an image with optional auth info and decrypt config
     /// and store the pulled data under user defined work_dir/layers.
     /// It will return the image ID with prepeared bundle: a rootfs directory,
@@ -512,7 +531,6 @@ mod tests {
     #[tokio::test]
     async fn test_pull_image() {
         let work_dir = tempfile::tempdir().unwrap();
-        std::env::set_var("CC_IMAGE_WORK_DIR", work_dir.path());
 
         // TODO test with more OCI image registries and fix broken registries.
         let oci_images = [
@@ -533,7 +551,7 @@ mod tests {
             // "releases-docker.jfrog.io/reg2/busybox:1.33.1"
         ];
 
-        let mut image_client = ImageClient::default();
+        let mut image_client = ImageClient::new(work_dir.path().to_path_buf());
         for image in oci_images.iter() {
             let bundle_dir = tempfile::tempdir().unwrap();
 
@@ -559,7 +577,6 @@ mod tests {
     #[tokio::test]
     async fn test_nydus_image() {
         let work_dir = tempfile::tempdir().unwrap();
-        std::env::set_var("CC_IMAGE_WORK_DIR", work_dir.path());
 
         let nydus_images = [
             "eci-nydus-registry.cn-hangzhou.cr.aliyuncs.com/v6/java:latest-test_nydus",
@@ -567,7 +584,7 @@ mod tests {
             //"eci-nydus-registry.cn-hangzhou.cr.aliyuncs.com/test/python:latest_nydus",
         ];
 
-        let mut image_client = ImageClient::default();
+        let mut image_client = ImageClient::new(work_dir.path().to_path_buf());
 
         for image in nydus_images.iter() {
             let bundle_dir = tempfile::tempdir().unwrap();
@@ -593,11 +610,10 @@ mod tests {
     #[tokio::test]
     async fn test_image_reuse() {
         let work_dir = tempfile::tempdir().unwrap();
-        std::env::set_var("CC_IMAGE_WORK_DIR", work_dir.path());
 
         let image = "mcr.microsoft.com/hello-world";
 
-        let mut image_client = ImageClient::default();
+        let mut image_client = ImageClient::new(work_dir.path().to_path_buf());
 
         let bundle1_dir = tempfile::tempdir().unwrap();
         if let Err(e) = image_client

--- a/image-rs/src/lib.rs
+++ b/image-rs/src/lib.rs
@@ -2,9 +2,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-/// Environment macro for `image-rs` work dir.
-pub const CC_IMAGE_WORK_DIR: &str = "CC_IMAGE_WORK_DIR";
-
 pub const ERR_BAD_UNCOMPRESSED_DIGEST: &str = "unsupported uncompressed digest format";
 
 pub mod auth;

--- a/image-rs/tests/credential.rs
+++ b/image-rs/tests/credential.rs
@@ -36,11 +36,10 @@ async fn test_use_credential(#[case] image_ref: &str, #[case] auth_file_uri: &st
         .expect("Delete configs failed.");
 
     let work_dir = tempfile::tempdir().unwrap();
-    std::env::set_var("CC_IMAGE_WORK_DIR", work_dir.path());
 
     // a new client for every pulling, avoid effection
     // of cache of old client.
-    let mut image_client = ImageClient::default();
+    let mut image_client = ImageClient::new(work_dir.path().to_path_buf());
 
     // enable container auth
     image_client.config.auth = true;

--- a/image-rs/tests/image_decryption.rs
+++ b/image-rs/tests/image_decryption.rs
@@ -43,7 +43,6 @@ async fn test_decrypt_layers(#[case] image: &str) {
     std::env::set_var("OCICRYPT_KEYPROVIDER_CONFIG", keyprovider_config);
 
     let work_dir = tempfile::tempdir().unwrap();
-    std::env::set_var("CC_IMAGE_WORK_DIR", work_dir.path());
     let bundle_dir = tempfile::tempdir().unwrap();
 
     // clean former test files, which is needed to prevent
@@ -51,7 +50,7 @@ async fn test_decrypt_layers(#[case] image: &str) {
     common::clean_configs()
         .await
         .expect("Delete configs failed.");
-    let mut image_client = ImageClient::default();
+    let mut image_client = ImageClient::new(work_dir.path().to_path_buf());
     if cfg!(feature = "snapshot-overlayfs") {
         image_client
             .pull_image(image, bundle_dir.path(), &None, &Some(common::AA_PARAMETER))

--- a/image-rs/tests/signature_verification.rs
+++ b/image-rs/tests/signature_verification.rs
@@ -172,11 +172,10 @@ async fn do_signature_verification_tests(
 
         // Init tempdirs
         let work_dir = tempfile::tempdir().unwrap();
-        std::env::set_var("CC_IMAGE_WORK_DIR", work_dir.path());
 
         // a new client for every pulling, avoid effection
         // of cache of old client.
-        let mut image_client = ImageClient::default();
+        let mut image_client = ImageClient::new(work_dir.path().to_path_buf());
 
         // enable signature verification
         image_client.config.security_validate = true;


### PR DESCRIPTION
To enable guest pulling within the kata-agent, it is imperative to configure `CC_IMAGE_WORK_DIR` variable within kata-agent before call image-rs to pull image. However, the use of `CC_IMAGE_WORK_DIR` may cause confusion in the context of kata-containers. Therefore, we can redefine constructions of `ImageConfig` and `ImageClient` that accept the image work directory as a parameter and construct instances of `ImageConfig` and `ImageClient`.

Fixes #415