### PR TITLE
attester: add evidence_getter binary

### DIFF
--- a/attestation-agent/attester/Cargo.toml
+++ b/attestation-agent/attester/Cargo.toml
@@ -29,6 +29,10 @@ tokio = { version = "1", features = ["full"], optional = true }
 [dev-dependencies]
 tokio.workspace = true
 
+[[bin]]
+name = "evidence_getter"
+required-features = [ "bin" ]
+
 [features]
 default = ["all-attesters"]
 all-attesters = ["tdx-attester", "sgx-attester", "az-snp-vtpm-attester", "snp-attester", "csv-attester", "cca-attester"]
@@ -39,3 +43,5 @@ az-snp-vtpm-attester = ["az-snp-vtpm"]
 snp-attester = ["sev"]
 csv-attester = ["csv-rs", "codicon", "hyper", "hyper-tls", "tokio"]
 cca-attester = ["nix"]
+
+bin = ["tokio/rt", "tokio/macros", "all-attesters"]

--- a/attestation-agent/attester/src/bin/evidence_getter.rs
+++ b/attestation-agent/attester/src/bin/evidence_getter.rs
@@ -1,0 +1,24 @@
+// Copyright (c) 2023 Alibaba Cloud
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+use attester::*;
+use codicon::Read;
+
+#[tokio::main]
+async fn main() {
+    // report_data on all platforms is 64 bytes length.
+    let mut report_data = vec![0; 64];
+    std::io::stdin()
+        .read(&mut report_data)
+        .expect("read input failed");
+
+    let tee = detect_tee_type().expect("unknown tee type");
+    let attester: BoxedAttester = tee.try_into().expect("create attester failed");
+    let evidence = attester
+        .get_evidence(report_data)
+        .await
+        .expect("get evidence failed");
+    println!("{evidence}");
+}


### PR DESCRIPTION
This tool would help to get evidence in a tee environment, which would help to do tests.