### PR TITLE
AA: fix CI failure

### DIFF
--- a/attestation-agent/coco_keyprovider/src/enc_mods/mod.rs
+++ b/attestation-agent/coco_keyprovider/src/enc_mods/mod.rs
@@ -74,7 +74,6 @@ fn parse_input_params(input: &str) -> Result<InputParams> {
         .collect::<Vec<&str>>()
         .iter()
         .filter_map(|field| field.split_once('='))
-        .map(|(k, v)| (k, v))
         .collect();
     debug!("Get new request: {:?}", map);
     let sample = map


### PR DESCRIPTION
CI failure is caused by new cargo clippy rule in rustc 1.75.0. Refer to [this link](https://rust-lang.github.io/rust-clippy/master/index.html#map_identity).