### PR TITLE
Makefile: add more platforms to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-TEE_PLATFORM ?= test
+TEE_PLATFORM ?= fs
 ARCH ?= $(shell uname -m)
 
 DESTDIR ?= /usr/local/bin
@@ -7,16 +7,24 @@ LIBC ?= musl
 KBC ?=
 RESOURCE_PROVIDER ?= kbs
 
-ifeq ($(TEE_PLATFORM), test)
+ifeq ($(TEE_PLATFORM), none)
+  KBC = cc_kbc
+else ifeq ($(TEE_PLATFORM), fs)
   KBC = offline_fs_kbc
 else ifeq ($(TEE_PLATFORM), tdx)
   LIBC = gnu
   KBC = cc_kbc_tdx
+else ifeq ($(TEE_PLATFORM), az-tdx-vtpm)
+  KBC = cc_kbc_az_tdx_vtpm
 else ifeq ($(TEE_PLATFORM), sev)
   KBC = online_sev_kbc
   RESOURCE_PROVIDER = sev
+else ifeq ($(TEE_PLATFORM), snp)
+  KBC = cc_kbc_snp
+else ifeq ($(TEE_PLATFORM), az-snp-vtpm)
+  KBC = cc_kbc_az_snp_vtpm
 endif
-# TODO: Add support for SNP, Az-snp-vtpm, CCA, CSV
+# TODO: Add support for CCA and CSV
 
 ifeq ($(ARCH), $(filter $(ARCH), s390x powerpc64le))
   LIBC = gnu

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ CoCo Keyprovider. Used to encrypt the container images.
 
 ## Build
 
-A `Makefile` is provided to quickly build Attestation Agent/Api Server Rest/Confidential Data Hub of a given platform.
+A `Makefile` is provided to quickly build Attestation Agent/Api Server Rest/Confidential Data Hub for a given platform.
 
 ```shell
 make build TEE_PLATFORM=$(TEE_PLATFORM)
@@ -31,9 +31,13 @@ make install DESTDIR=/usr/local/bin
 ```
 
 The `TEE_PLATFORM` parameter can be
-- `test`: for test
+- `none`: for tests with non-confidential guests
+- `fs`: for platforms with encrypted root filesystems (i.e. s390x)
 - `tdx`: for Intel TDX
-- `sev`: for AMD SEV
+- `az-tdx-vtpm`: for Intel TDX with Azure vTPM
+- `sev`: for AMD SEV(-ES)
+- `snp`: for AMD SEV-SNP
+- `az-snp-vtpm`: for AMD SEV-SNP with Azure vTPM
 
 ## License
 [![FOSSA Status](https://app.fossa.com/api/projects/git%2Bgithub.com%2Fconfidential-containers%2Fimage-rs.svg?type=large)](https://app.fossa.com/projects/git%2Bgithub.com%2Fconfidential-containers%2Fimage-rs?ref=badge_large)


### PR DESCRIPTION
Adds SNP, AZ-SNP-vTPM, and AZ-TDX-vTPM to the
top-level Makefile.

@mkulke can you double-check that I did the AZ features correctly?

Also changes the name of the offline_fs_kbc flag
to fs rather than test. See https://github.com/confidential-containers/confidential-containers/issues/184 for reasoning behind this change.