### PR TITLE
sample: always enable sample attester

### DIFF
--- a/attestation-agent/attester/src/bin/evidence_getter.rs
+++ b/attestation-agent/attester/src/bin/evidence_getter.rs
@@ -14,7 +14,7 @@ async fn main() {
         .read(&mut report_data)
         .expect("read input failed");
 
-    let tee = detect_tee_type().expect("unknown tee type");
+    let tee = detect_tee_type();
     let attester: BoxedAttester = tee.try_into().expect("create attester failed");
     let evidence = attester
         .get_evidence(report_data)

--- a/attestation-agent/attester/src/lib.rs
+++ b/attestation-agent/attester/src/lib.rs
@@ -77,45 +77,42 @@ pub trait Attester {
 }
 
 // Detect which TEE platform the KBC running environment is.
-pub fn detect_tee_type() -> Option<Tee> {
-    if sample::detect_platform() {
-        return Some(Tee::Sample);
-    }
-
+pub fn detect_tee_type() -> Tee {
     #[cfg(feature = "tdx-attester")]
     if tdx::detect_platform() {
-        return Some(Tee::Tdx);
+        return Tee::Tdx;
     }
 
     #[cfg(feature = "sgx-attester")]
     if sgx_dcap::detect_platform() {
-        return Some(Tee::Sgx);
+        return Tee::Sgx;
     }
 
     #[cfg(feature = "az-tdx-vtpm-attester")]
     if az_tdx_vtpm::detect_platform() {
-        return Some(Tee::AzTdxVtpm);
+        return Tee::AzTdxVtpm;
     }
 
     #[cfg(feature = "az-snp-vtpm-attester")]
     if az_snp_vtpm::detect_platform() {
-        return Some(Tee::AzSnpVtpm);
+        return Tee::AzSnpVtpm;
     }
 
     #[cfg(feature = "snp-attester")]
     if snp::detect_platform() {
-        return Some(Tee::Snp);
+        return Tee::Snp;
     }
 
     #[cfg(feature = "csv-attester")]
     if csv::detect_platform() {
-        return Some(Tee::Csv);
+        return Tee::Csv;
     }
 
     #[cfg(feature = "cca-attester")]
     if cca::detect_platform() {
-        return Some(Tee::Cca);
+        return Tee::Cca;
     }
 
-    None
+    log::warn!("No TEE platform detected. Sample Attester will be used.");
+    Tee::Sample
 }

--- a/attestation-agent/attester/src/sample/mod.rs
+++ b/attestation-agent/attester/src/sample/mod.rs
@@ -7,12 +7,10 @@ use super::Attester;
 use anyhow::*;
 use base64::Engine;
 use serde::{Deserialize, Serialize};
-use std::env;
 
-// If the environment variable "AA_SAMPLE_ATTESTER_TEST" is set,
-// the TEE platform is considered as "sample".
+// Sample attester is always supported
 pub fn detect_platform() -> bool {
-    env::var("AA_SAMPLE_ATTESTER_TEST").is_ok()
+    true
 }
 
 // A simple example of TEE evidence.

--- a/attestation-agent/kbs_protocol/src/error.rs
+++ b/attestation-agent/kbs_protocol/src/error.rs
@@ -24,9 +24,6 @@ pub enum Error {
     #[error("get token failed: {0}")]
     GetTokenFailed(String),
 
-    #[error("get tee type failed: {0}")]
-    GetTeeTypeFailed(String),
-
     #[error("http request failed: {0}")]
     HttpError(String),
 

--- a/attestation-agent/kbs_protocol/src/evidence_provider/native.rs
+++ b/attestation-agent/kbs_protocol/src/evidence_provider/native.rs
@@ -15,12 +15,9 @@ pub struct NativeEvidenceProvider(BoxedAttester);
 
 impl NativeEvidenceProvider {
     pub fn new() -> Result<Self> {
-        let tee = detect_tee_type()
-            .ok_or_else(|| Error::GetTeeTypeFailed("no supported Tee type detected.".into()))?
-            .try_into()
-            .map_err(|e| {
-                Error::NativeEvidenceProvider(format!("failed to initialize tee driver: {e}"))
-            })?;
+        let tee = detect_tee_type().try_into().map_err(|e| {
+            Error::NativeEvidenceProvider(format!("failed to initialize tee driver: {e}"))
+        })?;
         Ok(Self(tee))
     }
 }
@@ -35,7 +32,6 @@ impl EvidenceProvider for NativeEvidenceProvider {
     }
 
     async fn get_tee_type(&self) -> Result<Tee> {
-        detect_tee_type()
-            .ok_or_else(|| Error::GetTeeTypeFailed("no supported Tee type detected.".into()))
+        Ok(detect_tee_type())
     }
 }

--- a/attestation-agent/lib/src/lib.rs
+++ b/attestation-agent/lib/src/lib.rs
@@ -195,7 +195,7 @@ impl AttestationAPIs for AttestationAgent {
 
     /// Get TEE hardware signed evidence that includes the runtime data.
     async fn get_evidence(&mut self, runtime_data: &[u8]) -> Result<Vec<u8>> {
-        let tee_type = detect_tee_type().ok_or(anyhow!("no supported tee type found!"))?;
+        let tee_type = detect_tee_type();
         let attester = TryInto::<BoxedAttester>::try_into(tee_type)?;
         let evidence = attester.get_evidence(runtime_data.to_vec()).await?;
         Ok(evidence.into_bytes())
@@ -207,7 +207,7 @@ impl AttestationAPIs for AttestationAgent {
         events: Vec<Vec<u8>>,
         register_index: Option<u64>,
     ) -> Result<()> {
-        let tee_type = detect_tee_type().ok_or(anyhow!("no supported tee type found!"))?;
+        let tee_type = detect_tee_type();
         let attester = TryInto::<BoxedAttester>::try_into(tee_type)?;
         attester
             .extend_runtime_measurement(events, register_index)


### PR DESCRIPTION
Rather than setting an environment variable to enable the sample attester, always enable it as a fallback.

See https://github.com/confidential-containers/confidential-containers/issues/184 for reasons 

I don't think it makes much sense to enable the sample attester based on an environment variable. Having it always available as a fallback shouldn't cause any security problems. The KBS/AS shouldn't be fooled by the sample evidence in a real deployment.