### PR TITLE
build: Rename the feature flag and set default

### DIFF
--- a/confidential-data-hub/Makefile
+++ b/confidential-data-hub/Makefile
@@ -19,8 +19,8 @@ SOURCE_ARCH := $(shell uname -m)
 ARCH ?= $(shell uname -m)
 DEBUG ?=
 LIBC ?= gnu
-RESOURCE_PROVIDER ?=
-PROVIDER ?=
+RESOURCE_PROVIDER ?= kbs,sev
+KMS_PROVIDER ?= aliyun,ehsm
 DESTDIR ?= $(PREFIX)/bin
 RUSTFLAGS_ARGS ?=
 features ?=
@@ -29,17 +29,12 @@ ifeq ($(SOURCE_ARCH), ppc64le)
   ARCH=powerpc64le
 endif
 
-ifdef RESOURCE_PROVIDER
+ifneq ($(RESOURCE_PROVIDER), none)
     features += $(RESOURCE_PROVIDER)
 endif
 
-ifdef PROVIDER
-    features += $(PROVIDER)
-else
-    ifneq ($(ARCH), s390x)
-        $(info INFO: All plugins will be built in by default)
-        features += aliyun,ehsm
-    endif
+ifneq ($(KMS_PROVIDER), none)
+    features += $(KMS_PROVIDER)
 endif
 
 ifeq ($(LIBC), musl)
@@ -105,5 +100,5 @@ clean:
 
 help:
 	@echo "==========================Help========================================="
-	@echo "build: make [DEBUG=1] [LIBC=(musl)] [ARCH=(x86_64/s390x/ppc64le)] [RESOURCE_PROVIDER=(kbs/sev)] [PROVIDER=aliyun]"
+	@echo "build: make [DEBUG=1] [LIBC=(musl)] [ARCH=(x86_64/s390x/ppc64le)] [RESOURCE_PROVIDER=(kbs/sev)] [KMS_PROVIDER=aliyun/ehsm]"
 	@echo "install: make install [DESTDIR=/path/to/target] [LIBC=(musl)]"

--- a/confidential-data-hub/README.md
+++ b/confidential-data-hub/README.md
@@ -1,26 +1,39 @@
 # Confidential Data Hub
 
-Confidential Data Hub is a service running inside guest to provide resource related
+Confidential Data Hub (`CDH`) is a service running inside the guest to provide resource related
 APIs.
 
 
 
 ### Build
 
-Build and install with default KBC modules:
+Build and install with default features:
 
 ```shell
 git clone https://github.com/confidential-containers/guest-components
 cd guest-components/confidential-data-hub
 make
 ```
+This will build CDH with `RESOURCE_PROVIDER=kbs,sev` and `KMS_PROVIDER=aliyun,ehsm`
 
-or explicitly specify the confidential resource provider and KMS plugin, please refer to
-[Supported Features](#supported-features)
+You can explicitly specify the confidential resource provider and KMS_PROVIDER plugin during the build.
+For example if you only want to include `aliyun` KMS_PROVIDER: 
 
 ```shell
-make RESOURCE_PROVIDER=kbs PROVIDER=aliyun
+make KMS_PROVIDER=aliyun
 ```
+
+If you don't want to include any KMS_PROVIDER(s) and want to use only `kbs` as the resource provider:
+```shell
+make RESOURCE_PROVIDER=kbs KMS_PROVIDER=none
+```
+
+If you don't want to include any RESOURCE_PROVIDER(s):
+```shell
+make RESOURCE_PROVIDER=none
+```
+
+Please refer to [Supported Features](#supported-features) for the options.
 
 ### Supported Features
 
@@ -31,14 +44,15 @@ Confidential resource providers (flag `RESOURCE_PROVIDER`)
 | kbs                 | For TDX/SNP/Azure-SNP-vTPM based on KBS Attestation Protocol       |
 | sev                 | For SEV based on efi secret pre-attestation                        |
 
-Note: `offline-fs` is built-in, we do not need to manually enable. If no `RESOURCE_PROVIDER`
-is given, all features will be enabled.
+Note:
+- If no `RESOURCE_PROVIDER` flag is given, then all the resource providers will be enabled by default
 
-KMS plugins (flag `PROVIDER`)
+KMS_PROVIDER plugins (flag `KMS_PROVIDER`)
 
 | Feature name        |           Note                                                     |
 | ------------------- | -----------------------------------------------------------------  |
-| aliyun              | Use aliyun KMS suites to unseal secrets, etc.                      |
-| ehsm                | Use Intel eHSM KMS suites to unseal secrets, etc.                  |
+| aliyun              | Use aliyun KMS_PROVIDER suites to unseal secrets, etc.                      |
+| ehsm                | Use Intel eHSM KMS_PROVIDER suites to unseal secrets, etc.                  |
 
-Note:  If no `PROVIDER` is given, all features will be enabled.
+Note:
+- If no `KMS_PROVIDER` flag is given, then all the KMS providers will be enabled by default.


### PR DESCRIPTION
Rename the feature flag to align with the feature and provide for build time customisations of the options

Fixes: #435