### PR TITLE
AA/kbs_protocol: fix the RCAR handshake unit test

### DIFF
--- a/attestation-agent/kbs_protocol/test/kbs-config.toml
+++ b/attestation-agent/kbs_protocol/test/kbs-config.toml
@@ -1,3 +1,6 @@
 insecure_http = true
 insecure_api = true
 sockets = ["0.0.0.0:8085"]
+
+[attestation_token_config]
+attestation_token_type = "CoCo"

--- a/attestation-agent/kbs_protocol/test/policy.rego
+++ b/attestation-agent/kbs_protocol/test/policy.rego
@@ -1,0 +1,7 @@
+package policy
+
+default allow = false
+
+allow {
+	input["tee"] == "sample"
+}


### PR DESCRIPTION
There are some changes upon KBS side.

https://github.com/confidential-containers/kbs/pull/265/files#diff-88f80dee1e5f367cb319573b2d524906c5631100a0a3ce6cc62bf2ebf62fb251L95 replaces token type to a token config, and we do not have a default token config builder thus we need to explicitly add the attestation_token_config.

Also, the commit
https://github.com/confidential-containers/kbs/commit/43d56f3a4a92a1cc691f63a8e1311bcc0d2b3fc8 will block the sample_attester by the default policy of KBS when verifying the CoCoAS token. This is due to security. But in this test, we leverage sample-attester, so we need a policy that allows this.

The commit
https://github.com/confidential-containers/guest-components/pull/426/commits/006e1ffe69f2216c30eadb3094ee49fa209e6b2a enables sample_attester without setting environment variable.

This PR will resolve the blocker in #434 and #436

cc @fitzthum