### PR TITLE
image-rs: fix integration test

### DIFF
--- a/image-rs/scripts/build_confidential_data_hub.sh
+++ b/image-rs/scripts/build_confidential_data_hub.sh
@@ -24,7 +24,7 @@ CDH_DIR=$SCRIPT_DIR/../../confidential-data-hub
 
 pushd $CDH_DIR
 
-make
+make RESOURCE_PROVIDER=none KMS_PROVIDER=none
 make DESTDIR="${SCRIPT_DIR}/${dest_dir_suffix}" install
 
 file "${SCRIPT_DIR}/${dest_dir_suffix}/confidential-data-hub"


### PR DESCRIPTION
We now use a explicit `none` for KMS_PROVIDER and RESOURCE_PROVIDER in the make file to tell no one will be builtin. In image-rs' integration test, only offline-fs-kbc will be used and that is builtin by default. Thus we do not need to add any extra KMS_PROVIDER or RESOURCE_PROVIDER.

See the context in
https://github.com/confidential-containers/guest-components/pull/437/commits/4e087429216a4806086d006835ca20a87b448a8a