### PR TITLE
keyprovider: extend docker image and documentation

### DIFF
--- a/attestation-agent/docker/Dockerfile.keyprovider
+++ b/attestation-agent/docker/Dockerfile.keyprovider
@@ -1,26 +1,54 @@
 # Copyright (c) 2023 by Alibaba.
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-
-FROM rust:1.67 as builder
-
-WORKDIR /usr/src/coco-keyprovider
-
-RUN apt-get update && apt-get install protobuf-compiler -y && \
-    rustup component add rustfmt
-
-COPY . .
+FROM rust:1.75-slim-bookworm as builder
 
 LABEL org.opencontainers.image.source="https://github.com/confidential-containers/guest-components/blob/main/attestation-agent/docker/Dockerfile.keyprovider"
 
-RUN cd attestation-agent/coco_keyprovider && cargo install --path .
+RUN apt-get update && apt-get install -y \
+	build-essential \
+	git \
+	libssl-dev \
+	pkg-config \
+	protobuf-compiler
+WORKDIR /build
+COPY . .
+RUN cargo build --release -p coco_keyprovider
+RUN mv target/release/coco_keyprovider .
 
-FROM ubuntu:20.04
+FROM golang:1.21.6-bookworm as skopeo
+RUN apt-get update && apt-get install -y \
+	make\
+	libgpgme-dev \
+	libassuan-dev \
+	libbtrfs-dev \
+	libdevmapper-dev \
+	pkg-config
+RUN git clone https://github.com/containers/skopeo $GOPATH/src/github.com/containers/skopeo 
+WORKDIR $GOPATH/src/github.com/containers/skopeo
+RUN git checkout v1.14.1
+ENV DISABLE_DOCS=1
+RUN make bin/skopeo
+RUN make install
 
-RUN apt-get update && apt install openssl -y && rm -rf /var/lib/apt/lists/*
-
-COPY --from=builder /usr/local/cargo/bin/coco_keyprovider /usr/local/bin/coco_keyprovider
-
+FROM debian:bookworm-slim
+RUN apt-get update && apt-get install -y \
+	ca-certificates \
+	libdevmapper1.02.1 \
+	libgpgme11 \
+	--no-install-recommends
+COPY --from=builder /build/coco_keyprovider /usr/local/bin/coco_keyprovider
+COPY --from=skopeo /usr/local/bin/skopeo /usr/local/bin/skopeo
+COPY <<EOF /etc/ocicrypt.conf
+{
+	"key-providers": {
+		"attestation-agent": {
+			"grpc": "localhost:50000"
+		}
+	}
+}
+EOF
+COPY attestation-agent/hack/encrypt-image.sh /encrypt.sh
+ENV OCICRYPT_KEYPROVIDER_CONFIG="/etc/ocicrypt.conf"
 CMD ["coco_keyprovider", "--socket", "0.0.0.0:50000"]
-
 EXPOSE 50000

--- a/attestation-agent/hack/encrypt-image.sh
+++ b/attestation-agent/hack/encrypt-image.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+set -euo pipefail
+
+usage="usage: $0 [-k <b64-encoded key>] [-i <key id>] [-s <source>] [-d <destination>]"
+
+while getopts ":k:i:s:d:h" o; do
+	case "${o}" in
+	k)
+		key=${OPTARG}
+		if [ "$(echo "$key" | base64 -d | wc --bytes)" != "32" ]; then
+			echo "key should be a b64-encoded 32 byte key" 1>&2; exit 1
+		fi
+		;;
+	i)
+		key_id=${OPTARG}
+		;;
+	s)
+		src=${OPTARG}
+		;;
+	d)
+		dst=${OPTARG}
+		;;
+	h)
+		echo "$usage"; exit 0
+		;;
+	*)
+		echo "$usage" 1>&2; exit 1
+		;;
+	esac
+done
+shift $((OPTIND-1))
+
+if [ -z "${key-}" ] || [ -z "${key_id-}" ] || [ -z "${src-}" ] || [ -z "${dst-}" ]; then
+	echo "$usage" 1>&2; exit 1
+fi
+
+key_path=/key
+echo "$key" | base64 -d > "$key_path"
+
+coco_keyprovider --socket 127.0.0.1:50000 &
+sleep 1
+
+params="provider:attestation-agent:keypath=${key_path}::keyid=${key_id}::algorithm=A256GCM"
+skopeo copy --insecure-policy --encryption-key "$params" "$src" "$dst"


### PR DESCRIPTION
The keyprovider docker image has been extended to bundle a keyprovider-capable skopeo and include a convenience script that simplifies the creation of encrypted images for usage in CoCo.

Documentation has been added to use the image.