### PR TITLE
Makefile: support to build components for all platforms and amd

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -945,6 +945,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "attestation_agent",
  "base64 0.21.5",
  "clap 4.2.7",
  "env_logger 0.10.1",

--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,14 @@ else ifeq ($(TEE_PLATFORM), all)
   else
     RESOURCE_PROVIDER = sev,kbs
   endif
+else ifeq ($(TEE_PLATFORM), amd)
+  LIBC = gnu
+  KBC = cc_kbc_snp,online_sev_kbc
+  ifeq ($(NO_RESOURCE_PROVIDER), true)
+    RESOURCE_PROVIDER :=
+  else
+    RESOURCE_PROVIDER = sev,kbs
+  endif
 endif
 # TODO: Add support for CCA and CSV
 

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,9 @@ ARCH ?= $(shell uname -m)
 DESTDIR ?= /usr/local/bin
 
 LIBC ?= musl
+
+# TODO: delete `KBC` parameter once KBC related functionalities are
+# all deprecated in code.
 KBC ?=
 
 NO_RESOURCE_PROVIDER ?=
@@ -34,6 +37,14 @@ else ifeq ($(TEE_PLATFORM), snp)
   KBC = cc_kbc_snp
 else ifeq ($(TEE_PLATFORM), az-snp-vtpm)
   KBC = cc_kbc_az_snp_vtpm
+else ifeq ($(TEE_PLATFORM), all)
+  LIBC = gnu
+  KBC = cc_kbc_all_attesters
+  ifeq ($(NO_RESOURCE_PROVIDER), true)
+    RESOURCE_PROVIDER :=
+  else
+    RESOURCE_PROVIDER = sev,kbs
+  endif
 endif
 # TODO: Add support for CCA and CSV
 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ The `TEE_PLATFORM` parameter can be
 - `az-tdx-vtpm`: for Intel TDX with Azure vTPM
 - `sev`: for AMD SEV(-ES)
 - `snp`: for AMD SEV-SNP
+- `amd`: for both AMD SEV(-ES) and AMD SEV-SNP
 - `az-snp-vtpm`: for AMD SEV-SNP with Azure vTPM
 
 by default, `kbs`/`sev` as a resource provider will be built in Confidential Data Hub. If you do not want enable any

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ make install DESTDIR=/usr/local/bin
 
 The `TEE_PLATFORM` parameter can be
 - `none`: for tests with non-confidential guests
+- `all`: for all following platforms
 - `fs`: for platforms with encrypted root filesystems (i.e. s390x)
 - `tdx`: for Intel TDX
 - `az-tdx-vtpm`: for Intel TDX with Azure vTPM

--- a/confidential-data-hub/hub/Cargo.toml
+++ b/confidential-data-hub/hub/Cargo.toml
@@ -13,6 +13,7 @@ required-features = ["bin"]
 [dependencies]
 anyhow = { workspace = true, optional = true }
 async-trait.workspace = true
+attestation_agent = { path = "../../attestation-agent/lib", default-features = false, optional = true }
 base64.workspace = true
 clap = { workspace = true, features = [ "derive" ], optional = true }
 env_logger = { workspace = true, optional = true }
@@ -43,7 +44,7 @@ aliyun = ["image/aliyun", "secret/aliyun"]
 kbs = ["image/kbs", "kms/kbs", "secret/kbs"]
 
 # support sev to provide confidential resources
-sev = ["image/sev", "kms/sev", "dep:sev", "secret/sev"]
+sev = ["attestation_agent", "image/sev", "kms/sev", "dep:sev", "secret/sev"]
 
 # support eHSM stacks (KMS, ...)
 ehsm = ["image/ehsm", "secret/ehsm"]

--- a/confidential-data-hub/hub/src/auth/mod.rs
+++ b/confidential-data-hub/hub/src/auth/mod.rs
@@ -15,7 +15,16 @@ impl Hub {
     pub(crate) async fn init(&mut self) -> Result<()> {
         #[cfg(feature = "sev")]
         {
-            Self::init_sev().await?;
+            use log::{info, warn};
+            match attestation_agent::aa_kbc_params::get_params().await {
+                Ok(aa_kbc_params) => {
+                    if aa_kbc_params.kbc() == "online_sev_kbc" {
+                        info!("online_sev_kbc used. Start to initialize sev.");
+                        Self::init_sev().await?;
+                    }
+                }
+                Err(e) => warn!("Get `aa_kbc_params` failed. Skip initialize sev. {e:?}"),
+            };
         }
 
         #[cfg(feature = "kbs")]


### PR DESCRIPTION
`TEE_PLATFORM=all` to support a easy mode for users to build all guest components with all features enabled (including the attester plugins, etc)

`TEE_PLATFORM=amd` supports to build components of sev & snp.

Also, fixed a bug in CDH when both kbs and sev features are enabled. We not will initialize sev when `aa_kbc_param` is set to `sev`.

