### PR TITLE
cdh/kms: add default value for "AliSecretAnnotations"

### DIFF
--- a/confidential-data-hub/kms/src/plugins/aliyun/annotations.rs
+++ b/confidential-data-hub/kms/src/plugins/aliyun/annotations.rs
@@ -14,6 +14,11 @@ pub struct AliCryptAnnotations {
 /// Serialized [`crate::Annotations`]
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct AliSecretAnnotations {
+    // set to empty string to get newest version of secret
+    #[serde(default)]
     pub version_stage: String,
+
+    // set to empty string to get newest version of secret
+    #[serde(default)]
     pub version_id: String,
 }


### PR DESCRIPTION
`AliSecretAnnotations` is some optional input parameters for `get_secret()` function of `Getter` in cdh/kms. With default value added, those who do not these parameters can pay no attention to them.