### PR TITLE
Replace unsafe NonNull::new_unchecked with NonNull:new

### DIFF
--- a/attestation-agent/kbc/src/eaa_kbc/rats_tls/mod.rs
+++ b/attestation-agent/kbc/src/eaa_kbc/rats_tls/mod.rs
@@ -31,7 +31,7 @@ unsafe impl ForeignType for RatsTls {
     type Ref = RatsTlsRef;
 
     unsafe fn from_ptr(ptr: *mut rats_tls_handle) -> RatsTls {
-        RatsTls(NonNull::new_unchecked(ptr))
+        RatsTls(NonNull::new(ptr).expect("rats_tls_handle ptr is null!"))
     }
 
     fn as_ptr(&self) -> *mut rats_tls_handle {


### PR DESCRIPTION
rats_tls_handle ptr should be correct initialized by extern C func rats_tls_set_verification_callback