### PR TITLE
AA: Add API of CheckInitData

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -287,11 +287,13 @@ dependencies = [
  "log",
  "nix 0.26.4",
  "occlum_dcap",
+ "scroll",
  "serde",
  "serde_json",
  "sev 1.2.1",
  "strum",
  "tdx-attest-rs",
+ "thiserror",
  "tokio",
 ]
 
@@ -4805,6 +4807,26 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "scroll"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04c565b551bafbef4157586fa379538366e4385d42082f255bfd96e4fe8519da"
+dependencies = [
+ "scroll_derive",
+]
+
+[[package]]
+name = "scroll_derive"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1db149f81d46d2deba7cd3c50772474707729550221e69588478ebf9ada425ae"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.43",
+]
 
 [[package]]
 name = "scrypt"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -262,6 +262,7 @@ dependencies = [
  "resource_uri",
  "serde",
  "serde_json",
+ "sha2 0.10.8",
  "strum",
  "thiserror",
  "tokio",

--- a/attestation-agent/attester/Cargo.toml
+++ b/attestation-agent/attester/Cargo.toml
@@ -19,6 +19,7 @@ kbs-types.workspace = true
 log.workspace = true
 nix = { version = "0.26.2", optional = true }
 occlum_dcap = { git = "https://github.com/occlum/occlum", tag = "v0.29.7", optional = true }
+scroll = { version = "0.11.0", default-features = false, features = ["derive"], optional = true }
 serde.workspace = true
 serde_json.workspace = true
 sev = { version = "1.2.0", default-features = false, features = [
@@ -26,6 +27,7 @@ sev = { version = "1.2.0", default-features = false, features = [
 ], optional = true }
 strum.workspace = true
 tdx-attest-rs = { git = "https://github.com/intel/SGXDataCenterAttestationPrimitives", tag = "DCAP_1.16", optional = true }
+thiserror.workspace = true
 # TODO: change it to "0.1", once released.
 csv-rs = { git = "https://github.com/openanolis/csv-rs", rev = "b74aa8c", optional = true }
 codicon = { version = "3.0", optional = true }
@@ -52,7 +54,7 @@ all-attesters = [
     "cca-attester",
 ]
 
-tdx-attester = ["tdx-attest-rs"]
+tdx-attester = ["scroll", "tdx-attest-rs"]
 sgx-attester = ["occlum_dcap"]
 az-snp-vtpm-attester = ["az-snp-vtpm"]
 az-tdx-vtpm-attester = ["az-tdx-vtpm"]

--- a/attestation-agent/attester/src/lib.rs
+++ b/attestation-agent/attester/src/lib.rs
@@ -74,6 +74,10 @@ pub trait Attester {
     ) -> Result<()> {
         bail!("Unimplemented")
     }
+
+    async fn check_init_data(&self, _init_data: &[u8]) -> Result<()> {
+        bail!("Unimplemented");
+    }
 }
 
 // Detect which TEE platform the KBC running environment is.

--- a/attestation-agent/attester/src/lib.rs
+++ b/attestation-agent/attester/src/lib.rs
@@ -7,6 +7,7 @@ use anyhow::*;
 use kbs_types::Tee;
 
 pub mod sample;
+pub mod utils;
 
 #[cfg(feature = "az-snp-vtpm-attester")]
 pub mod az_snp_vtpm;

--- a/attestation-agent/attester/src/snp/hostdata.rs
+++ b/attestation-agent/attester/src/snp/hostdata.rs
@@ -1,0 +1,24 @@
+// Copyright (c) 2024 Microsoft Corporation
+// Copyright (c) 2024 Alibaba Cloud
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum GetHostDataError {
+    #[error("Open Sev guest firmware failed: {0}")]
+    OpenSevGuestFirmware(#[from] std::io::Error),
+
+    #[error("Get report failed: {0}")]
+    GetReportError(#[from] sev::error::UserApiError),
+}
+
+pub fn get_snp_host_data() -> Result<[u8; 32], GetHostDataError> {
+    let mut firmware = sev::firmware::guest::Firmware::open()?;
+    let report_data: [u8; 64] = [0; 64];
+    let report = firmware.get_report(None, Some(report_data), Some(0))?;
+
+    Ok(report.host_data)
+}

--- a/attestation-agent/attester/src/tdx/report.rs
+++ b/attestation-agent/attester/src/tdx/report.rs
@@ -1,0 +1,99 @@
+// Copyright (c) 2024 Microsoft Corporation
+// Copyright (c) 2024 Alibaba Cloud
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+use scroll::Pread;
+
+#[repr(C)]
+#[derive(Pread)]
+/// Type header of TDREPORT_STRUCT.
+pub struct TdTransportType {
+    /// Type of the TDREPORT (0 - SGX, 81 - TDX, rest are reserved).
+    pub type_: u8,
+
+    /// Subtype of the TDREPORT (Default value is 0).
+    pub sub_type: u8,
+
+    /// TDREPORT version (Default value is 0).
+    pub version: u8,
+
+    /// Added for future extension.
+    pub reserved: u8,
+}
+
+#[repr(C)]
+#[derive(Pread)]
+/// TDX guest report data, MAC and TEE hashes.
+pub struct ReportMac {
+    /// TDREPORT type header.
+    pub type_: TdTransportType,
+
+    /// Reserved for future extension.
+    pub reserved1: [u8; 12],
+
+    /// CPU security version.
+    pub cpu_svn: [u8; 16],
+
+    /// SHA384 hash of TEE TCB INFO.
+    pub tee_tcb_info_hash: [u8; 48],
+
+    /// SHA384 hash of TDINFO_STRUCT.
+    pub tee_td_info_hash: [u8; 48],
+
+    /// User defined unique data passed in TDG.MR.REPORT request.
+    pub reportdata: [u8; 64],
+
+    /// Reserved for future extension.
+    pub reserved2: [u8; 32],
+
+    /// CPU MAC ID.
+    pub mac: [u8; 32],
+}
+
+#[repr(C)]
+#[derive(Pread)]
+/// TDX guest measurements and configuration.
+pub struct TdInfo {
+    /// TDX Guest attributes (like debug, spet_disable, etc).
+    pub attr: [u8; 8],
+
+    /// Extended features allowed mask.
+    pub xfam: u64,
+
+    /// Build time measurement register.
+    pub mrtd: [u64; 6],
+
+    /// Software-defined ID for non-owner-defined configuration of the guest - e.g., run-time or OS configuration.
+    pub mrconfigid: [u8; 48],
+
+    /// Software-defined ID for the guest owner.
+    pub mrowner: [u64; 6],
+
+    /// Software-defined ID for owner-defined configuration of the guest - e.g., specific to the workload.
+    pub mrownerconfig: [u64; 6],
+
+    /// Run time measurement registers.
+    pub rtmr: [u64; 24],
+
+    /// For future extension.
+    pub reserved: [u64; 14],
+}
+
+#[repr(C)]
+#[derive(Pread)]
+/// Output of TDCALL[TDG.MR.REPORT].
+pub struct TdReport {
+    /// Mac protected header of size 256 bytes.
+    pub report_mac: ReportMac,
+
+    /// Additional attestable elements in the TCB are not reflected in the report_mac.
+    pub tee_tcb_info: [u8; 239],
+
+    /// Added for future extension.
+    pub reserved: [u8; 17],
+
+    /// Measurements and configuration data of size 512 bytes.
+    pub tdinfo: TdInfo,
+}

--- a/attestation-agent/attester/src/utils.rs
+++ b/attestation-agent/attester/src/utils.rs
@@ -1,0 +1,15 @@
+// Copyright (c) 2024 Microsoft Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+pub fn pad<const T: usize>(input: &[u8]) -> [u8; T] {
+    let mut output = [0; T];
+    let len = input.len();
+    if len > T {
+        output.copy_from_slice(&input[..T]);
+    } else {
+        output[..len].copy_from_slice(input);
+    }
+    output
+}

--- a/attestation-agent/kbs_protocol/src/token_provider/aa/attestation_agent.rs
+++ b/attestation-agent/kbs_protocol/src/token_provider/aa/attestation_agent.rs
@@ -756,6 +756,371 @@ impl ::protobuf::reflect::ProtobufValue for ExtendRuntimeMeasurementResponse {
     type RuntimeType = ::protobuf::reflect::rt::RuntimeTypeMessage<Self>;
 }
 
+// @@protoc_insertion_point(message:attestation_agent.InitDataPlaintext)
+#[derive(PartialEq,Clone,Default,Debug)]
+pub struct InitDataPlaintext {
+    // message fields
+    // @@protoc_insertion_point(field:attestation_agent.InitDataPlaintext.Content)
+    pub Content: ::std::vec::Vec<u8>,
+    // @@protoc_insertion_point(field:attestation_agent.InitDataPlaintext.Algorithm)
+    pub Algorithm: ::std::string::String,
+    // special fields
+    // @@protoc_insertion_point(special_field:attestation_agent.InitDataPlaintext.special_fields)
+    pub special_fields: ::protobuf::SpecialFields,
+}
+
+impl<'a> ::std::default::Default for &'a InitDataPlaintext {
+    fn default() -> &'a InitDataPlaintext {
+        <InitDataPlaintext as ::protobuf::Message>::default_instance()
+    }
+}
+
+impl InitDataPlaintext {
+    pub fn new() -> InitDataPlaintext {
+        ::std::default::Default::default()
+    }
+
+    fn generated_message_descriptor_data() -> ::protobuf::reflect::GeneratedMessageDescriptorData {
+        let mut fields = ::std::vec::Vec::with_capacity(2);
+        let mut oneofs = ::std::vec::Vec::with_capacity(0);
+        fields.push(::protobuf::reflect::rt::v2::make_simpler_field_accessor::<_, _>(
+            "Content",
+            |m: &InitDataPlaintext| { &m.Content },
+            |m: &mut InitDataPlaintext| { &mut m.Content },
+        ));
+        fields.push(::protobuf::reflect::rt::v2::make_simpler_field_accessor::<_, _>(
+            "Algorithm",
+            |m: &InitDataPlaintext| { &m.Algorithm },
+            |m: &mut InitDataPlaintext| { &mut m.Algorithm },
+        ));
+        ::protobuf::reflect::GeneratedMessageDescriptorData::new_2::<InitDataPlaintext>(
+            "InitDataPlaintext",
+            fields,
+            oneofs,
+        )
+    }
+}
+
+impl ::protobuf::Message for InitDataPlaintext {
+    const NAME: &'static str = "InitDataPlaintext";
+
+    fn is_initialized(&self) -> bool {
+        true
+    }
+
+    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream<'_>) -> ::protobuf::Result<()> {
+        while let Some(tag) = is.read_raw_tag_or_eof()? {
+            match tag {
+                10 => {
+                    self.Content = is.read_bytes()?;
+                },
+                18 => {
+                    self.Algorithm = is.read_string()?;
+                },
+                tag => {
+                    ::protobuf::rt::read_unknown_or_skip_group(tag, is, self.special_fields.mut_unknown_fields())?;
+                },
+            };
+        }
+        ::std::result::Result::Ok(())
+    }
+
+    // Compute sizes of nested messages
+    #[allow(unused_variables)]
+    fn compute_size(&self) -> u64 {
+        let mut my_size = 0;
+        if !self.Content.is_empty() {
+            my_size += ::protobuf::rt::bytes_size(1, &self.Content);
+        }
+        if !self.Algorithm.is_empty() {
+            my_size += ::protobuf::rt::string_size(2, &self.Algorithm);
+        }
+        my_size += ::protobuf::rt::unknown_fields_size(self.special_fields.unknown_fields());
+        self.special_fields.cached_size().set(my_size as u32);
+        my_size
+    }
+
+    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream<'_>) -> ::protobuf::Result<()> {
+        if !self.Content.is_empty() {
+            os.write_bytes(1, &self.Content)?;
+        }
+        if !self.Algorithm.is_empty() {
+            os.write_string(2, &self.Algorithm)?;
+        }
+        os.write_unknown_fields(self.special_fields.unknown_fields())?;
+        ::std::result::Result::Ok(())
+    }
+
+    fn special_fields(&self) -> &::protobuf::SpecialFields {
+        &self.special_fields
+    }
+
+    fn mut_special_fields(&mut self) -> &mut ::protobuf::SpecialFields {
+        &mut self.special_fields
+    }
+
+    fn new() -> InitDataPlaintext {
+        InitDataPlaintext::new()
+    }
+
+    fn clear(&mut self) {
+        self.Content.clear();
+        self.Algorithm.clear();
+        self.special_fields.clear();
+    }
+
+    fn default_instance() -> &'static InitDataPlaintext {
+        static instance: InitDataPlaintext = InitDataPlaintext {
+            Content: ::std::vec::Vec::new(),
+            Algorithm: ::std::string::String::new(),
+            special_fields: ::protobuf::SpecialFields::new(),
+        };
+        &instance
+    }
+}
+
+impl ::protobuf::MessageFull for InitDataPlaintext {
+    fn descriptor() -> ::protobuf::reflect::MessageDescriptor {
+        static descriptor: ::protobuf::rt::Lazy<::protobuf::reflect::MessageDescriptor> = ::protobuf::rt::Lazy::new();
+        descriptor.get(|| file_descriptor().message_by_package_relative_name("InitDataPlaintext").unwrap()).clone()
+    }
+}
+
+impl ::std::fmt::Display for InitDataPlaintext {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+        ::protobuf::text_format::fmt(self, f)
+    }
+}
+
+impl ::protobuf::reflect::ProtobufValue for InitDataPlaintext {
+    type RuntimeType = ::protobuf::reflect::rt::RuntimeTypeMessage<Self>;
+}
+
+// @@protoc_insertion_point(message:attestation_agent.CheckInitDataRequest)
+#[derive(PartialEq,Clone,Default,Debug)]
+pub struct CheckInitDataRequest {
+    // message fields
+    // @@protoc_insertion_point(field:attestation_agent.CheckInitDataRequest.Digest)
+    pub Digest: ::std::vec::Vec<u8>,
+    // special fields
+    // @@protoc_insertion_point(special_field:attestation_agent.CheckInitDataRequest.special_fields)
+    pub special_fields: ::protobuf::SpecialFields,
+}
+
+impl<'a> ::std::default::Default for &'a CheckInitDataRequest {
+    fn default() -> &'a CheckInitDataRequest {
+        <CheckInitDataRequest as ::protobuf::Message>::default_instance()
+    }
+}
+
+impl CheckInitDataRequest {
+    pub fn new() -> CheckInitDataRequest {
+        ::std::default::Default::default()
+    }
+
+    fn generated_message_descriptor_data() -> ::protobuf::reflect::GeneratedMessageDescriptorData {
+        let mut fields = ::std::vec::Vec::with_capacity(1);
+        let mut oneofs = ::std::vec::Vec::with_capacity(0);
+        fields.push(::protobuf::reflect::rt::v2::make_simpler_field_accessor::<_, _>(
+            "Digest",
+            |m: &CheckInitDataRequest| { &m.Digest },
+            |m: &mut CheckInitDataRequest| { &mut m.Digest },
+        ));
+        ::protobuf::reflect::GeneratedMessageDescriptorData::new_2::<CheckInitDataRequest>(
+            "CheckInitDataRequest",
+            fields,
+            oneofs,
+        )
+    }
+}
+
+impl ::protobuf::Message for CheckInitDataRequest {
+    const NAME: &'static str = "CheckInitDataRequest";
+
+    fn is_initialized(&self) -> bool {
+        true
+    }
+
+    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream<'_>) -> ::protobuf::Result<()> {
+        while let Some(tag) = is.read_raw_tag_or_eof()? {
+            match tag {
+                10 => {
+                    self.Digest = is.read_bytes()?;
+                },
+                tag => {
+                    ::protobuf::rt::read_unknown_or_skip_group(tag, is, self.special_fields.mut_unknown_fields())?;
+                },
+            };
+        }
+        ::std::result::Result::Ok(())
+    }
+
+    // Compute sizes of nested messages
+    #[allow(unused_variables)]
+    fn compute_size(&self) -> u64 {
+        let mut my_size = 0;
+        if !self.Digest.is_empty() {
+            my_size += ::protobuf::rt::bytes_size(1, &self.Digest);
+        }
+        my_size += ::protobuf::rt::unknown_fields_size(self.special_fields.unknown_fields());
+        self.special_fields.cached_size().set(my_size as u32);
+        my_size
+    }
+
+    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream<'_>) -> ::protobuf::Result<()> {
+        if !self.Digest.is_empty() {
+            os.write_bytes(1, &self.Digest)?;
+        }
+        os.write_unknown_fields(self.special_fields.unknown_fields())?;
+        ::std::result::Result::Ok(())
+    }
+
+    fn special_fields(&self) -> &::protobuf::SpecialFields {
+        &self.special_fields
+    }
+
+    fn mut_special_fields(&mut self) -> &mut ::protobuf::SpecialFields {
+        &mut self.special_fields
+    }
+
+    fn new() -> CheckInitDataRequest {
+        CheckInitDataRequest::new()
+    }
+
+    fn clear(&mut self) {
+        self.Digest.clear();
+        self.special_fields.clear();
+    }
+
+    fn default_instance() -> &'static CheckInitDataRequest {
+        static instance: CheckInitDataRequest = CheckInitDataRequest {
+            Digest: ::std::vec::Vec::new(),
+            special_fields: ::protobuf::SpecialFields::new(),
+        };
+        &instance
+    }
+}
+
+impl ::protobuf::MessageFull for CheckInitDataRequest {
+    fn descriptor() -> ::protobuf::reflect::MessageDescriptor {
+        static descriptor: ::protobuf::rt::Lazy<::protobuf::reflect::MessageDescriptor> = ::protobuf::rt::Lazy::new();
+        descriptor.get(|| file_descriptor().message_by_package_relative_name("CheckInitDataRequest").unwrap()).clone()
+    }
+}
+
+impl ::std::fmt::Display for CheckInitDataRequest {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+        ::protobuf::text_format::fmt(self, f)
+    }
+}
+
+impl ::protobuf::reflect::ProtobufValue for CheckInitDataRequest {
+    type RuntimeType = ::protobuf::reflect::rt::RuntimeTypeMessage<Self>;
+}
+
+// @@protoc_insertion_point(message:attestation_agent.CheckInitDataResponse)
+#[derive(PartialEq,Clone,Default,Debug)]
+pub struct CheckInitDataResponse {
+    // special fields
+    // @@protoc_insertion_point(special_field:attestation_agent.CheckInitDataResponse.special_fields)
+    pub special_fields: ::protobuf::SpecialFields,
+}
+
+impl<'a> ::std::default::Default for &'a CheckInitDataResponse {
+    fn default() -> &'a CheckInitDataResponse {
+        <CheckInitDataResponse as ::protobuf::Message>::default_instance()
+    }
+}
+
+impl CheckInitDataResponse {
+    pub fn new() -> CheckInitDataResponse {
+        ::std::default::Default::default()
+    }
+
+    fn generated_message_descriptor_data() -> ::protobuf::reflect::GeneratedMessageDescriptorData {
+        let mut fields = ::std::vec::Vec::with_capacity(0);
+        let mut oneofs = ::std::vec::Vec::with_capacity(0);
+        ::protobuf::reflect::GeneratedMessageDescriptorData::new_2::<CheckInitDataResponse>(
+            "CheckInitDataResponse",
+            fields,
+            oneofs,
+        )
+    }
+}
+
+impl ::protobuf::Message for CheckInitDataResponse {
+    const NAME: &'static str = "CheckInitDataResponse";
+
+    fn is_initialized(&self) -> bool {
+        true
+    }
+
+    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream<'_>) -> ::protobuf::Result<()> {
+        while let Some(tag) = is.read_raw_tag_or_eof()? {
+            match tag {
+                tag => {
+                    ::protobuf::rt::read_unknown_or_skip_group(tag, is, self.special_fields.mut_unknown_fields())?;
+                },
+            };
+        }
+        ::std::result::Result::Ok(())
+    }
+
+    // Compute sizes of nested messages
+    #[allow(unused_variables)]
+    fn compute_size(&self) -> u64 {
+        let mut my_size = 0;
+        my_size += ::protobuf::rt::unknown_fields_size(self.special_fields.unknown_fields());
+        self.special_fields.cached_size().set(my_size as u32);
+        my_size
+    }
+
+    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream<'_>) -> ::protobuf::Result<()> {
+        os.write_unknown_fields(self.special_fields.unknown_fields())?;
+        ::std::result::Result::Ok(())
+    }
+
+    fn special_fields(&self) -> &::protobuf::SpecialFields {
+        &self.special_fields
+    }
+
+    fn mut_special_fields(&mut self) -> &mut ::protobuf::SpecialFields {
+        &mut self.special_fields
+    }
+
+    fn new() -> CheckInitDataResponse {
+        CheckInitDataResponse::new()
+    }
+
+    fn clear(&mut self) {
+        self.special_fields.clear();
+    }
+
+    fn default_instance() -> &'static CheckInitDataResponse {
+        static instance: CheckInitDataResponse = CheckInitDataResponse {
+            special_fields: ::protobuf::SpecialFields::new(),
+        };
+        &instance
+    }
+}
+
+impl ::protobuf::MessageFull for CheckInitDataResponse {
+    fn descriptor() -> ::protobuf::reflect::MessageDescriptor {
+        static descriptor: ::protobuf::rt::Lazy<::protobuf::reflect::MessageDescriptor> = ::protobuf::rt::Lazy::new();
+        descriptor.get(|| file_descriptor().message_by_package_relative_name("CheckInitDataResponse").unwrap()).clone()
+    }
+}
+
+impl ::std::fmt::Display for CheckInitDataResponse {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+        ::protobuf::text_format::fmt(self, f)
+    }
+}
+
+impl ::protobuf::reflect::ProtobufValue for CheckInitDataResponse {
+    type RuntimeType = ::protobuf::reflect::rt::RuntimeTypeMessage<Self>;
+}
+
 static file_descriptor_proto_data: &'static [u8] = b"\
     \n\x17attestation-agent.proto\x12\x11attestation_agent\"6\n\x12GetEviden\
     ceRequest\x12\x20\n\x0bRuntimeData\x18\x01\x20\x01(\x0cR\x0bRuntimeData\
@@ -765,13 +1130,18 @@ static file_descriptor_proto_data: &'static [u8] = b"\
     \x20\x01(\x0cR\x05Token\"v\n\x1fExtendRuntimeMeasurementRequest\x12\x16\
     \n\x06Events\x18\x01\x20\x03(\x0cR\x06Events\x12)\n\rRegisterIndex\x18\
     \x02\x20\x01(\x04H\0R\rRegisterIndex\x88\x01\x01B\x10\n\x0e_RegisterInde\
-    x\"\"\n\x20ExtendRuntimeMeasurementResponse2\xd2\x02\n\x17AttestationAge\
-    ntService\x12\\\n\x0bGetEvidence\x12%.attestation_agent.GetEvidenceReque\
-    st\x1a&.attestation_agent.GetEvidenceResponse\x12S\n\x08GetToken\x12\".a\
-    ttestation_agent.GetTokenRequest\x1a#.attestation_agent.GetTokenResponse\
-    \x12\x83\x01\n\x18ExtendRuntimeMeasurement\x122.attestation_agent.Extend\
-    RuntimeMeasurementRequest\x1a3.attestation_agent.ExtendRuntimeMeasuremen\
-    tResponseb\x06proto3\
+    x\"\"\n\x20ExtendRuntimeMeasurementResponse\"K\n\x11InitDataPlaintext\
+    \x12\x18\n\x07Content\x18\x01\x20\x01(\x0cR\x07Content\x12\x1c\n\tAlgori\
+    thm\x18\x02\x20\x01(\tR\tAlgorithm\".\n\x14CheckInitDataRequest\x12\x16\
+    \n\x06Digest\x18\x01\x20\x01(\x0cR\x06Digest\"\x17\n\x15CheckInitDataRes\
+    ponse2\xb6\x03\n\x17AttestationAgentService\x12\\\n\x0bGetEvidence\x12%.\
+    attestation_agent.GetEvidenceRequest\x1a&.attestation_agent.GetEvidenceR\
+    esponse\x12S\n\x08GetToken\x12\".attestation_agent.GetTokenRequest\x1a#.\
+    attestation_agent.GetTokenResponse\x12\x83\x01\n\x18ExtendRuntimeMeasure\
+    ment\x122.attestation_agent.ExtendRuntimeMeasurementRequest\x1a3.attesta\
+    tion_agent.ExtendRuntimeMeasurementResponse\x12b\n\rCheckInitData\x12'.a\
+    ttestation_agent.CheckInitDataRequest\x1a(.attestation_agent.CheckInitDa\
+    taResponseb\x06proto3\
 ";
 
 /// `FileDescriptorProto` object which was a source for this generated file
@@ -789,13 +1159,16 @@ pub fn file_descriptor() -> &'static ::protobuf::reflect::FileDescriptor {
     file_descriptor.get(|| {
         let generated_file_descriptor = generated_file_descriptor_lazy.get(|| {
             let mut deps = ::std::vec::Vec::with_capacity(0);
-            let mut messages = ::std::vec::Vec::with_capacity(6);
+            let mut messages = ::std::vec::Vec::with_capacity(9);
             messages.push(GetEvidenceRequest::generated_message_descriptor_data());
             messages.push(GetEvidenceResponse::generated_message_descriptor_data());
             messages.push(GetTokenRequest::generated_message_descriptor_data());
             messages.push(GetTokenResponse::generated_message_descriptor_data());
             messages.push(ExtendRuntimeMeasurementRequest::generated_message_descriptor_data());
             messages.push(ExtendRuntimeMeasurementResponse::generated_message_descriptor_data());
+            messages.push(InitDataPlaintext::generated_message_descriptor_data());
+            messages.push(CheckInitDataRequest::generated_message_descriptor_data());
+            messages.push(CheckInitDataResponse::generated_message_descriptor_data());
             let mut enums = ::std::vec::Vec::with_capacity(0);
             ::protobuf::reflect::GeneratedFileDescriptor::new_generated(
                 file_descriptor_proto(),

--- a/attestation-agent/kbs_protocol/src/token_provider/aa/attestation_agent_ttrpc.rs
+++ b/attestation-agent/kbs_protocol/src/token_provider/aa/attestation_agent_ttrpc.rs
@@ -46,6 +46,11 @@ impl AttestationAgentServiceClient {
         let mut cres = super::attestation_agent::ExtendRuntimeMeasurementResponse::new();
         ::ttrpc::async_client_request!(self, ctx, req, "attestation_agent.AttestationAgentService", "ExtendRuntimeMeasurement", cres);
     }
+
+    pub async fn check_init_data(&self, ctx: ttrpc::context::Context, req: &super::attestation_agent::CheckInitDataRequest) -> ::ttrpc::Result<super::attestation_agent::CheckInitDataResponse> {
+        let mut cres = super::attestation_agent::CheckInitDataResponse::new();
+        ::ttrpc::async_client_request!(self, ctx, req, "attestation_agent.AttestationAgentService", "CheckInitData", cres);
+    }
 }
 
 struct GetEvidenceMethod {
@@ -81,6 +86,17 @@ impl ::ttrpc::r#async::MethodHandler for ExtendRuntimeMeasurementMethod {
     }
 }
 
+struct CheckInitDataMethod {
+    service: Arc<Box<dyn AttestationAgentService + Send + Sync>>,
+}
+
+#[async_trait]
+impl ::ttrpc::r#async::MethodHandler for CheckInitDataMethod {
+    async fn handler(&self, ctx: ::ttrpc::r#async::TtrpcContext, req: ::ttrpc::Request) -> ::ttrpc::Result<::ttrpc::Response> {
+        ::ttrpc::async_request_handler!(self, ctx, req, attestation_agent, CheckInitDataRequest, check_init_data);
+    }
+}
+
 #[async_trait]
 pub trait AttestationAgentService: Sync {
     async fn get_evidence(&self, _ctx: &::ttrpc::r#async::TtrpcContext, _: super::attestation_agent::GetEvidenceRequest) -> ::ttrpc::Result<super::attestation_agent::GetEvidenceResponse> {
@@ -91,6 +107,9 @@ pub trait AttestationAgentService: Sync {
     }
     async fn extend_runtime_measurement(&self, _ctx: &::ttrpc::r#async::TtrpcContext, _: super::attestation_agent::ExtendRuntimeMeasurementRequest) -> ::ttrpc::Result<super::attestation_agent::ExtendRuntimeMeasurementResponse> {
         Err(::ttrpc::Error::RpcStatus(::ttrpc::get_status(::ttrpc::Code::NOT_FOUND, "/attestation_agent.AttestationAgentService/ExtendRuntimeMeasurement is not supported".to_string())))
+    }
+    async fn check_init_data(&self, _ctx: &::ttrpc::r#async::TtrpcContext, _: super::attestation_agent::CheckInitDataRequest) -> ::ttrpc::Result<super::attestation_agent::CheckInitDataResponse> {
+        Err(::ttrpc::Error::RpcStatus(::ttrpc::get_status(::ttrpc::Code::NOT_FOUND, "/attestation_agent.AttestationAgentService/CheckInitData is not supported".to_string())))
     }
 }
 
@@ -107,6 +126,9 @@ pub fn create_attestation_agent_service(service: Arc<Box<dyn AttestationAgentSer
 
     methods.insert("ExtendRuntimeMeasurement".to_string(),
                     Box::new(ExtendRuntimeMeasurementMethod{service: service.clone()}) as Box<dyn ::ttrpc::r#async::MethodHandler + Send + Sync>);
+
+    methods.insert("CheckInitData".to_string(),
+                    Box::new(CheckInitDataMethod{service: service.clone()}) as Box<dyn ::ttrpc::r#async::MethodHandler + Send + Sync>);
 
     ret.insert("attestation_agent.AttestationAgentService".to_string(), ::ttrpc::r#async::Service{ methods, streams });
     ret

--- a/attestation-agent/lib/Cargo.toml
+++ b/attestation-agent/lib/Cargo.toml
@@ -17,6 +17,7 @@ resource_uri.workspace = true
 reqwest = { workspace = true, features = ["json"], optional = true }
 serde.workspace = true
 serde_json.workspace = true
+sha2.workspace = true
 strum.workspace = true
 thiserror.workspace = true
 tokio = { workspace = true, features = ["fs"] }

--- a/attestation-agent/protos/attestation-agent.proto
+++ b/attestation-agent/protos/attestation-agent.proto
@@ -25,8 +25,20 @@ message ExtendRuntimeMeasurementRequest {
 
 message ExtendRuntimeMeasurementResponse {}
 
+message InitDataPlaintext {
+    bytes Content = 1;
+    string Algorithm = 2; 
+}
+
+message CheckInitDataRequest {
+    bytes Digest = 1;
+}
+
+message CheckInitDataResponse {}
+
 service AttestationAgentService {
     rpc GetEvidence(GetEvidenceRequest) returns (GetEvidenceResponse) {};
     rpc GetToken(GetTokenRequest) returns (GetTokenResponse) {};
     rpc ExtendRuntimeMeasurement(ExtendRuntimeMeasurementRequest) returns (ExtendRuntimeMeasurementResponse) {};
+    rpc CheckInitData(CheckInitDataRequest) returns (CheckInitDataResponse) {};
 }


### PR DESCRIPTION
This new API is for kata-agent to check the data's integrity binding relationship with the hardware evidence.

Close #446 

The main work for TDX and SNP platform has been done by  @danmihai1 , this PR just refers most of the code.

cc @fitzthum