### PR TITLE
AA/attester: improve tdx runtime measurement

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -291,6 +291,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sev 1.2.1",
+ "sha2 0.10.8",
  "strum",
  "tdx-attest-rs",
  "thiserror",

--- a/attestation-agent/attester/Cargo.toml
+++ b/attestation-agent/attester/Cargo.toml
@@ -25,6 +25,7 @@ serde_json.workspace = true
 sev = { version = "1.2.0", default-features = false, features = [
     "snp",
 ], optional = true }
+sha2.workspace = true
 strum.workspace = true
 tdx-attest-rs = { git = "https://github.com/intel/SGXDataCenterAttestationPrimitives", tag = "DCAP_1.16", optional = true }
 thiserror.workspace = true

--- a/attestation-agent/attester/src/tdx/mod.rs
+++ b/attestation-agent/attester/src/tdx/mod.rs
@@ -11,6 +11,8 @@ use base64::Engine;
 use log::debug;
 use scroll::Pread;
 use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha384};
+use std::mem;
 use std::path::Path;
 use tdx_attest_rs::{self, tdx_report_t};
 
@@ -18,6 +20,7 @@ mod report;
 
 const TDX_REPORT_DATA_SIZE: usize = 64;
 const CCEL_PATH: &str = "/sys/firmware/acpi/tables/data/CCEL";
+const RUNTIME_MEASUREMENT_RTMR_INDEX: u64 = 2;
 
 pub fn detect_platform() -> bool {
     Path::new("/dev/tdx-attest").exists() || Path::new("/dev/tdx-guest").exists()
@@ -81,7 +84,17 @@ impl Attester for TdxAttester {
         _register_index: Option<u64>,
     ) -> Result<()> {
         for event in events {
-            match tdx_attest_rs::tdx_att_extend(&event) {
+            let mut event_buffer = [0u8; mem::size_of::<tdx_attest_rs::tdx_rtmr_event_t>()];
+            let mut hasher = Sha384::new();
+            hasher.update(&event);
+            let hash = hasher.finalize().to_vec();
+            let rtmr_event = unsafe {
+                &mut *(event_buffer.as_mut_ptr() as *mut tdx_attest_rs::tdx_rtmr_event_t)
+            };
+            rtmr_event.version = 1;
+            rtmr_event.rtmr_index = RUNTIME_MEASUREMENT_RTMR_INDEX;
+            rtmr_event.extend_data.copy_from_slice(&hash);
+            match tdx_attest_rs::tdx_att_extend(&event_buffer) {
                 tdx_attest_rs::tdx_attest_error_t::TDX_ATTEST_SUCCESS => {
                     log::debug!("TDX extend runtime measurement succeeded.")
                 }


### PR DESCRIPTION
improve implementation of tdx runtime measurement API, 'extend_runtime_measurement'.

tdx attester should call intel DCAP lib api with the specified parameter type to avoid the high level needing to know the details of the hardware platform when calling the runtime measurement interface.