### PR TITLE
CI: fix rust-nightly static checks

### DIFF
--- a/image-rs/src/pull.rs
+++ b/image-rs/src/pull.rs
@@ -470,7 +470,7 @@ mod tests {
 
         for image_url in nydus_images.iter() {
             let tempdir = tempfile::tempdir().unwrap();
-            let image = Reference::try_from((*image_url).clone()).expect("create reference failed");
+            let image = Reference::try_from(*image_url).expect("create reference failed");
             let mut client = PullClient::new(
                 image,
                 tempdir.path(),

--- a/image-rs/src/resource/mod.rs
+++ b/image-rs/src/resource/mod.rs
@@ -30,6 +30,7 @@ lazy_static::lazy_static! {
 /// - `SCHEME`: `file` string, to distinguish different uri scheme
 /// - `get_resource()`: get resource from the uri
 #[async_trait]
+#[allow(dead_code)]
 trait Protocol: Send + Sync {
     async fn get_resource(&mut self, uri: &str) -> Result<Vec<u8>>;
 }

--- a/image-rs/src/signature/image/digest.rs
+++ b/image-rs/src/signature/image/digest.rs
@@ -76,9 +76,9 @@ impl Digest {
     }
 }
 
-impl ToString for Digest {
-    fn to_string(&self) -> String {
-        format!("{}:{}", self.algorithm, self.value)
+impl fmt::Display for Digest {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}:{}", self.algorithm, self.value)
     }
 }
 


### PR DESCRIPTION
This PR attempts to fix these two rust nightly errors we started seeing:
```
    Checking image-rs v0.1.0 (/home/porter/wo/confidential-containers/guest-components/image-rs)
error: trait `Protocol` is never used
  --> image-rs/src/resource/mod.rs:33:7
   |
33 | trait Protocol: Send + Sync {
   |       ^^^^^^^^
   |
   = note: `-D dead-code` implied by `-D warnings`
   = help: to override `-D warnings` add `#[allow(dead_code)]`

error: direct implementation of `ToString`
  --> image-rs/src/signature/image/digest.rs:79:1
   |
79 | / impl ToString for Digest {
80 | |     fn to_string(&self) -> String {
81 | |         format!("{}:{}", self.algorithm, self.value)
82 | |     }
83 | | }
   | |_^
   |
   = help: prefer implementing `Display` instead
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#to_str
ing_trait_impl
   = note: `-D clippy::to-string-trait-impl` implied by `-D warnings`
   = help: to override `-D warnings` add `#[allow(clippy::to_string_trait_impl)]`
```