### PR TITLE
CI: Fix nightly lint error & fix rust nightly version

### DIFF
--- a/.github/workflows/aa_sample_keyprovider.yml
+++ b/.github/workflows/aa_sample_keyprovider.yml
@@ -22,7 +22,6 @@ jobs:
       matrix:
         rust:
           - stable
-          - nightly
 
     steps:
       - name: Code checkout

--- a/.github/workflows/image_rs_build.yml
+++ b/.github/workflows/image_rs_build.yml
@@ -30,7 +30,6 @@ jobs:
         rust:
           - 1.72.0
           - stable
-          - nightly
     steps:
       - name: Code checkout
         uses: actions/checkout@v4

--- a/.github/workflows/ocicrypt_rs_build.yml
+++ b/.github/workflows/ocicrypt_rs_build.yml
@@ -27,7 +27,6 @@ jobs:
         rust:
           - 1.72.0
           - stable
-          - nightly
 
     # Run all steps in the compilation testing containers
     container:

--- a/attestation-agent/app/src/rpc/keyprovider/message.rs
+++ b/attestation-agent/app/src/rpc/keyprovider/message.rs
@@ -7,9 +7,6 @@ use anyhow::{anyhow, Result};
 use base64::Engine;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
-use std::convert::TryFrom;
-use std::str;
-use std::vec::Vec;
 
 pub const ERR_INVALID_OP: &str = "invalid operator";
 pub const ERR_ANNOTATION_EMPTY: &str = "annotation cannot be empty";

--- a/attestation-agent/app/src/rpc/keyprovider/mod.rs
+++ b/attestation-agent/app/src/rpc/keyprovider/mod.rs
@@ -8,7 +8,6 @@ use attestation_agent::AttestationAPIs;
 use base64::Engine;
 use log::*;
 use serde::{Deserialize, Serialize};
-use std::convert::TryFrom;
 use std::str;
 use std::sync::Arc;
 
@@ -359,9 +358,6 @@ fn str_to_kbc_kbs(value: &str) -> Result<(String, String)> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::rpc::keyprovider::message::{
-        ERR_INVALID_OP, ERR_MISSING_OP, ERR_UNSUPPORTED_OP, ERR_UNWRAP_PARAMS_NO_DC,
-    };
 
     #[test]
     fn test_get_annotation() {

--- a/attestation-agent/attester/src/tdx/mod.rs
+++ b/attestation-agent/attester/src/tdx/mod.rs
@@ -12,7 +12,7 @@ use log::debug;
 use scroll::Pread;
 use serde::{Deserialize, Serialize};
 use std::path::Path;
-use tdx_attest_rs::{self, tdx_report_t};
+use tdx_attest_rs::tdx_report_t;
 
 mod report;
 

--- a/attestation-agent/coco_keyprovider/src/enc_mods/crypto.rs
+++ b/attestation-agent/coco_keyprovider/src/enc_mods/crypto.rs
@@ -3,6 +3,8 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+use std::fmt::Display;
+
 use aes_gcm::{aead::Aead, aes::Aes256, Aes256Gcm, Key, Nonce};
 use anyhow::*;
 use strum::EnumString;
@@ -20,11 +22,11 @@ pub enum Algorithm {
     A256CTR,
 }
 
-impl ToString for Algorithm {
-    fn to_string(&self) -> String {
+impl Display for Algorithm {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Algorithm::A256GCM => "A256GCM".into(),
-            Algorithm::A256CTR => "A256CTR".into(),
+            Algorithm::A256GCM => f.write_str("A256GCM"),
+            Algorithm::A256CTR => f.write_str("A256CTR"),
         }
     }
 }

--- a/attestation-agent/coco_keyprovider/src/grpc/protocol/keyprovider_structs.rs
+++ b/attestation-agent/coco_keyprovider/src/grpc/protocol/keyprovider_structs.rs
@@ -5,7 +5,6 @@
 
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
-use std::vec::Vec;
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct KeyProviderInput {

--- a/attestation-agent/lib/src/config/aa_kbc_params.rs
+++ b/attestation-agent/lib/src/config/aa_kbc_params.rs
@@ -1,6 +1,5 @@
 use log::debug;
 use serde::Deserialize;
-use std::convert::TryFrom;
 use std::env;
 use std::path::Path;
 use std::sync::OnceLock;

--- a/image-rs/src/auth/auth_config.rs
+++ b/image-rs/src/auth/auth_config.rs
@@ -118,7 +118,7 @@ fn auth_keys_for_key(key: &str) -> Vec<String> {
 
 #[cfg(test)]
 mod tests {
-    use std::{collections::HashMap, convert::TryFrom};
+    use std::collections::HashMap;
 
     use oci_distribution::{secrets::RegistryAuth, Reference};
     use rstest::rstest;

--- a/image-rs/src/bundle.rs
+++ b/image-rs/src/bundle.rs
@@ -218,7 +218,6 @@ pub fn create_runtime_config(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use tempfile;
 
     #[test]
     fn test_bundle_create_config() {

--- a/image-rs/src/config.rs
+++ b/image-rs/src/config.rs
@@ -4,7 +4,6 @@
 
 use anyhow::{anyhow, Result};
 use serde::{Deserialize, Deserializer};
-use std::convert::TryFrom;
 use std::fs::File;
 use std::path::{Path, PathBuf};
 
@@ -303,9 +302,7 @@ impl Default for FscacheConfig {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::fs::File;
     use std::io::prelude::*;
-    use tempfile;
 
     #[test]
     fn test_image_config() {

--- a/image-rs/src/decoder/mod.rs
+++ b/image-rs/src/decoder/mod.rs
@@ -2,7 +2,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-use std::convert::TryFrom;
 use std::fmt;
 use std::io;
 

--- a/image-rs/src/image.rs
+++ b/image-rs/src/image.rs
@@ -10,7 +10,6 @@ use oci_distribution::Reference;
 use oci_spec::image::{ImageConfiguration, Os};
 use serde::Deserialize;
 use std::collections::{BTreeSet, HashMap};
-use std::convert::TryFrom;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 

--- a/image-rs/src/meta_store.rs
+++ b/image-rs/src/meta_store.rs
@@ -1,7 +1,6 @@
 use anyhow::{anyhow, Result};
 use serde::Deserialize;
 use std::collections::HashMap;
-use std::convert::TryFrom;
 use std::fs::File;
 use std::path::Path;
 

--- a/image-rs/src/pull.rs
+++ b/image-rs/src/pull.rs
@@ -7,7 +7,6 @@ use futures_util::stream::{self, StreamExt, TryStreamExt};
 use oci_distribution::manifest::{OciDescriptor, OciImageManifest};
 use oci_distribution::{secrets::RegistryAuth, Client, Reference};
 use std::collections::BTreeMap;
-use std::convert::TryFrom;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use tokio::sync::Mutex;
@@ -211,7 +210,6 @@ mod tests {
     use oci_distribution::manifest::IMAGE_CONFIG_MEDIA_TYPE;
     use oci_spec::image::{ImageConfiguration, MediaType};
     use std::io::Write;
-    use tempfile;
 
     use test_utils::{assert_result, assert_retry};
 

--- a/image-rs/src/signature/image/digest.rs
+++ b/image-rs/src/signature/image/digest.rs
@@ -5,11 +5,9 @@
 
 use strum::{Display, EnumProperty, EnumString};
 
-use std::convert::TryFrom;
 use std::error::Error;
 use std::fmt;
 use std::str::FromStr;
-use std::string::ToString;
 
 // Supported digest algorithm types
 #[derive(EnumString, Display, Debug, PartialEq, Eq, EnumProperty)]

--- a/image-rs/src/signature/image/mod.rs
+++ b/image-rs/src/signature/image/mod.rs
@@ -3,8 +3,6 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-use std::convert::TryFrom;
-
 use anyhow::*;
 use oci_distribution::Reference;
 

--- a/image-rs/src/signature/mechanism/cosign/mod.rs
+++ b/image-rs/src/signature/mechanism/cosign/mod.rs
@@ -175,12 +175,9 @@ impl CosignParameters {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::signature::{
-        mechanism::SignScheme,
-        policy::{policy_requirement::PolicyReqType, ref_match::PolicyReqMatchType},
+    use crate::signature::policy::{
+        policy_requirement::PolicyReqType, ref_match::PolicyReqMatchType,
     };
-
-    use std::convert::TryFrom;
 
     use oci_distribution::Reference;
     use rstest::rstest;

--- a/image-rs/src/signature/mod.rs
+++ b/image-rs/src/signature/mod.rs
@@ -9,7 +9,6 @@ pub mod payload;
 pub mod policy;
 
 use crate::{config::Paths, signature::policy::Policy};
-use std::convert::TryFrom;
 
 use anyhow::Result;
 use oci_distribution::secrets::RegistryAuth;

--- a/image-rs/src/signature/policy/mod.rs
+++ b/image-rs/src/signature/policy/mod.rs
@@ -7,7 +7,6 @@ use anyhow::{bail, Result};
 use oci_distribution::secrets::RegistryAuth;
 use serde::Deserialize;
 use std::collections::HashMap;
-use std::vec::Vec;
 use strum_macros::{Display, EnumString};
 
 use self::policy_requirement::PolicyReqType;

--- a/image-rs/src/signature/policy/ref_match.rs
+++ b/image-rs/src/signature/policy/ref_match.rs
@@ -6,7 +6,6 @@
 use anyhow::{bail, Result};
 use oci_distribution::Reference;
 use serde::*;
-use std::convert::TryFrom;
 
 use crate::signature::{image, policy::ErrorInfo};
 
@@ -142,8 +141,6 @@ impl PolicyReqMatchType {
 
 #[cfg(test)]
 mod tests {
-    use std::convert::TryFrom;
-
     use crate::signature::policy::ref_match::PolicyReqMatchType;
 
     #[test]

--- a/image-rs/src/stream.rs
+++ b/image-rs/src/stream.rs
@@ -124,7 +124,6 @@ mod tests {
     use std::fs::File;
     use std::io::BufReader;
     use tar::{Builder, Header};
-    use tempfile;
 
     #[tokio::test]
     async fn test_channel_processing() {

--- a/image-rs/src/unpack.rs
+++ b/image-rs/src/unpack.rs
@@ -84,10 +84,8 @@ pub fn unpack<R: io::Read>(input: R, destination: &Path) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use filetime;
     use std::fs::File;
     use std::io::prelude::*;
-    use tempfile;
 
     #[test]
     fn test_unpack() {

--- a/ocicrypt-rs/src/keywrap/keyprovider/mod.rs
+++ b/ocicrypt-rs/src/keywrap/keyprovider/mod.rs
@@ -650,7 +650,6 @@ mod tests {
         };
         use std::net::SocketAddr;
         use tokio::sync::mpsc;
-        use tonic;
         use tonic::{transport::Server, Request};
 
         #[tonic::async_trait]
@@ -880,10 +879,6 @@ mod tests {
 
     #[cfg(feature = "keywrap-keyprovider-cmd")]
     mod cmd {
-        use super::super::{
-            KeyProviderKeyWrapProtocolInput, KeyProviderKeyWrapProtocolOutput, KeyUnwrapResults,
-            KeyWrapResults,
-        };
         use super::*;
 
         impl crate::utils::CommandExecuter for TestRunner {


### PR DESCRIPTION
1. Fixes nightly lint error
2. Follow [the discussion](https://github.com/confidential-containers/confidential-containers/issues/193) from @portersrc , I fix the version of rust nightly compiler in GHA to avoid unexpected CI errors everytime new rust nightly version is released.