### PR TITLE
image-rs: Add cargo build for multiarch

### DIFF
--- a/.github/workflows/image_rs_build.yml
+++ b/.github/workflows/image_rs_build.yml
@@ -63,6 +63,12 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y libdevmapper-dev
+
+      - name: Install cross-compliation support dependencies
+        run: |
+          sudo apt install -y gcc-s390x-linux-gnu gcc-powerpc64le-linux-gnu
+          rustup target add s390x-unknown-linux-gnu powerpc64le-unknown-linux-gnu
+
       - name: Run cargo fmt check
         uses: actions-rs/cargo@v1
         with:
@@ -83,6 +89,14 @@ jobs:
         with:
           command: build
           args: -p image-rs --features default
+
+      - name: Run cargo build, cross-compiling for s390x
+        run: |
+          sudo -E PATH=$PATH -s RUSTFLAGS=" -C linker=s390x-linux-gnu-gcc" cargo build --target s390x-unknown-linux-gnu -p image-rs --features default
+
+      - name: Run cargo build, cross-compiling for powerpc64le
+        run: |
+          sudo -E PATH=$PATH -s RUSTFLAGS=" -C linker=powerpc64le-linux-gnu-gcc" cargo build --target powerpc64le-unknown-linux-gnu -p image-rs --features default
 
       - name: Run cargo test - default
         run: |


### PR DESCRIPTION
- Add building image-rs on s390x and powerpc64le
Note: At the moment this will probably fail with:
```
error: failed to run custom build command for `ring v0.16.20`

Caused by:
  process didn't exit successfully: `/root/guest-components/target/debug/build/ring-f931d4c26d8deee2/build-script-build` (exit status: 101)
  --- stderr
  thread 'main' panicked at /root/.cargo/registry/src/index.crates.io-6f17d22bba15001f/ring-0.16.20/build.rs:358:10:
  called `Option::unwrap()` on a `None` value
  note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```
whilst we wait for #422 to get fixed, so we shouldn't merge it until after that is fixed