### PR TITLE
Fix makefile

### DIFF
--- a/.github/workflows/aa_basic.yml
+++ b/.github/workflows/aa_basic.yml
@@ -65,13 +65,13 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y libdevmapper-dev
 
-      - name: Build and install with default features
+      - name: Gnu build and install with ttrpc
         run: |
-          make && make install
+          make ttrpc=true && make install
 
-      - name: Musl build with none platform
+      - name: Musl build with all platform
         run: |
-          make LIBC=musl ATTESTER=none
+          make LIBC=musl ttrpc=true ATTESTER=none
 
       - name: Run cargo test
         uses: actions-rs/cargo@v1

--- a/.github/workflows/cdh_basic.yml
+++ b/.github/workflows/cdh_basic.yml
@@ -54,7 +54,7 @@ jobs:
 
       - name: Musl build
         run: |
-          make LIBC=musl RESOURCE_PROVIDER=kbs,sev
+          make LIBC=musl
 
       - name: s390x build
         run:

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,6 @@ ifeq ($(TEE_PLATFORM), none)
 else ifeq ($(TEE_PLATFORM), fs)
   ATTESTER = none
 else ifeq ($(TEE_PLATFORM), tdx)
-  LIBC = gnu
   ATTESTER = tdx-attester
 else ifeq ($(TEE_PLATFORM), az-tdx-vtpm)
   ATTESTER = az-tdx-vtpm-attester
@@ -36,7 +35,6 @@ else ifeq ($(TEE_PLATFORM), snp)
 else ifeq ($(TEE_PLATFORM), az-snp-vtpm)
   ATTESTER = az-snp-vtpm-attester
 else ifeq ($(TEE_PLATFORM), all)
-  LIBC = gnu
   ATTESTER = all-attesters
   ifeq ($(NO_RESOURCE_PROVIDER), true)
     RESOURCE_PROVIDER :=
@@ -44,7 +42,6 @@ else ifeq ($(TEE_PLATFORM), all)
     RESOURCE_PROVIDER = sev,kbs
   endif
 else ifeq ($(TEE_PLATFORM), amd)
-  LIBC = gnu
   ATTESTER = snp-attester
   ifeq ($(NO_RESOURCE_PROVIDER), true)
     RESOURCE_PROVIDER :=
@@ -55,6 +52,7 @@ endif
 # TODO: Add support for CCA and CSV
 
 ifeq ($(ARCH), $(filter $(ARCH), s390x powerpc64le))
+  echo "s390x/powerpc64le only supports gnu."
   LIBC = gnu
 endif
 


### PR DESCRIPTION
This makes the LIBC env could be overwritten for `all`, `tdx` and `amd` platforms.

Also update the ci workflow.

Related to https://github.com/kata-containers/kata-containers/pull/8870