### PR TITLE
Makefile: Fix error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ endif
 # TODO: Add support for CCA and CSV
 
 ifeq ($(ARCH), $(filter $(ARCH), s390x powerpc64le))
-  echo "s390x/powerpc64le only supports gnu."
+  $(info s390x/powerpc64le only supports gnu)
   LIBC = gnu
 endif
 


### PR DESCRIPTION
echo command outside of recipe not valid, and results in:
```
Makefile:55: *** missing separator.  Stop.
```
, so replace with $(info)