### PR TITLE
AA/Attester: fix TDX platform detection

### DIFF
--- a/attestation-agent/attester/src/tdx/mod.rs
+++ b/attestation-agent/attester/src/tdx/mod.rs
@@ -28,7 +28,9 @@ pub fn detect_platform() -> bool {
 }
 
 fn tdx_getquote_ioctl_is_available() -> bool {
-    Path::new("/dev/tdx-attest").exists() || Path::new("/dev/tdx-guest").exists()
+    Path::new("/dev/tdx-attest").exists()
+        || Path::new("/dev/tdx-guest").exists()
+        || Path::new("/dev/tdx_guest").exists()
 }
 
 fn get_quote_ioctl(report_data: &Vec<u8>) -> Result<Vec<u8>> {


### PR DESCRIPTION
On DCAP 1.20, TDX attester will get report via dev `/dev/tdx_guest`, this is defined in

https://github.com/intel/SGXDataCenterAttestationPrimitives/blob/DCAP_1.20/QuoteGeneration/quote_wrapper/tdx_attest/tdx_attest.c#L52

btw, is `/dev/tdx-guest` used or it is a wrong name? cc @jialez0 