### PR TITLE
CDH: fix config read

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -962,6 +962,7 @@ dependencies = [
  "serde_json",
  "sev 0.1.0",
  "storage",
+ "tempfile",
  "thiserror",
  "tokio",
  "ttrpc",

--- a/confidential-data-hub/hub/Cargo.toml
+++ b/confidential-data-hub/hub/Cargo.toml
@@ -37,6 +37,7 @@ ttrpc-codegen = { workspace = true, optional = true }
 
 [dev-dependencies]
 rstest.workspace = true
+tempfile.workspace = true
 
 [features]
 default = ["kbs", "bin"]

--- a/confidential-data-hub/hub/src/bin/confidential-data-hub/config.rs
+++ b/confidential-data-hub/hub/src/bin/confidential-data-hub/config.rs
@@ -42,6 +42,7 @@ pub struct Credential {
 pub struct CdhConfig {
     pub kbc: KbsConfig,
 
+    #[serde(default)]
     pub credentials: Vec<Credential>,
 
     pub socket: String,
@@ -76,7 +77,7 @@ impl CdhConfig {
             .add_source(File::with_name(config_path))
             .build()?;
 
-        let res = c.try_deserialize().context("invalid config").unwrap();
+        let res = c.try_deserialize().context("invalid config")?;
         Ok(res)
     }
 
@@ -132,5 +133,65 @@ impl CdhConfig {
         if let Some(kbs_cert) = &self.kbc.kbs_cert {
             env::set_var("KBS_CERT", kbs_cert);
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::Write;
+
+    use rstest::rstest;
+
+    use crate::CdhConfig;
+
+    #[rstest]
+    #[case(
+        r#"
+socket = "unix:///run/confidential-containers/cdh.sock"
+
+[kbc]
+name = "offline_fs_kbc"
+url = ""
+kbs_cert = ""
+    "#,
+        true
+    )]
+    #[case(
+        r#"
+socket = "unix:///run/confidential-containers/cdh.sock"
+
+[kbc]
+name = "offline_fs_kbc"
+url = ""
+kbs_cert = ""
+
+[[credentials]]
+    "#,
+        false
+    )]
+    #[case(
+        r#"
+socket = "unix:///run/confidential-containers/cdh.sock"
+
+[kbc]
+name = "offline_fs_kbc"
+url = ""
+kbs_cert = ""
+
+[[credentials]]
+resource_uri = "kbs:///default/1/1"
+path = "/run/confidential-containers/cdh/kms-credential/aliyun/config.toml"
+    "#,
+        true
+    )]
+    fn read_config(#[case] config: &str, #[case] successful: bool) {
+        let mut file = tempfile::Builder::new()
+            .append(true)
+            .suffix(".toml")
+            .tempfile()
+            .unwrap();
+        file.write_all(config.as_bytes()).unwrap();
+        let res = CdhConfig::from_file(file.path().to_str().unwrap());
+        assert_eq!(res.is_ok(), successful, "{res:?}");
     }
 }


### PR DESCRIPTION
This commit gets rid of unwrap() in parsing CDH's config and will result in an error. Also, this commit adds support for a configuration file without any [[credentials]] array member.

To ensure the config behavior is as expected, adds some unit tests.

Fixes #514

cc @wainersm 