### PR TITLE
AA: add envlogger to enable log

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -253,6 +253,7 @@ dependencies = [
  "base64 0.21.7",
  "clap 4.2.7",
  "const_format",
+ "env_logger 0.10.2",
  "kbs_protocol",
  "log",
  "prost 0.11.9",

--- a/attestation-agent/attestation-agent/Cargo.toml
+++ b/attestation-agent/attestation-agent/Cargo.toml
@@ -20,6 +20,7 @@ attester = { path = "../attester", default-features = false }
 base64.workspace = true
 clap = { workspace = true, features = ["derive"], optional = true }
 const_format = { workspace = true, optional = true }
+env_logger = { workspace = true, optional = true }
 kbs_protocol = { path = "../kbs_protocol", default-features = false, optional = true }
 log.workspace = true
 prost = { workspace = true, optional = true }
@@ -66,6 +67,6 @@ rust-crypto = ["kbs_protocol?/rust-crypto"]
 openssl = ["kbs_protocol?/openssl"]
 
 # Binary RPC type
-bin = ["clap", "tokio/rt-multi-thread"]
+bin = ["clap", "env_logger", "tokio/rt-multi-thread"]
 grpc = ["prost", "tonic", "tonic-build", "tokio/signal"]
 ttrpc = ["const_format", "dep:ttrpc", "ttrpc-codegen", "protobuf", "tokio/signal"]

--- a/attestation-agent/attestation-agent/src/bin/grpc-aa/main.rs
+++ b/attestation-agent/attestation-agent/src/bin/grpc-aa/main.rs
@@ -29,6 +29,7 @@ struct Cli {
 
 #[tokio::main]
 pub async fn main() -> Result<()> {
+    env_logger::init_from_env(env_logger::Env::new().default_filter_or("info"));
     let cli = Cli::parse();
 
     let attestation_socket = cli.attestation_sock.parse::<SocketAddr>()?;

--- a/attestation-agent/attestation-agent/src/bin/ttrpc-aa/main.rs
+++ b/attestation-agent/attestation-agent/src/bin/ttrpc-aa/main.rs
@@ -37,6 +37,7 @@ struct Cli {
 
 #[tokio::main]
 pub async fn main() -> Result<()> {
+    env_logger::init_from_env(env_logger::Env::new().default_filter_or("info"));
     let cli = Cli::parse();
 
     if !Path::new(DEFAULT_UNIX_SOCKET_DIR).exists() {


### PR DESCRIPTION
Before this commit, AA will not enable log by default, so that the process will not print any output even if `RUST_LOG` env is set.