### PR TITLE
image-rs: get rid of checking `decrypt_config` parameter

### DIFF
--- a/image-rs/src/decrypt.rs
+++ b/image-rs/src/decrypt.rs
@@ -93,16 +93,18 @@ mod encryption {
         pub fn get_decrypt_key(
             &self,
             descriptor: &OciDescriptor,
-            decrypt_config: &str,
+            decrypt_config: &Option<&str>,
         ) -> Result<Vec<u8>> {
             if !self.is_encrypted() {
                 bail!("unencrypted media type: {}", self.media_type);
             }
-            if decrypt_config.is_empty() {
-                bail!("decrypt_config is empty");
-            }
 
-            let cc = create_decrypt_config(vec![decrypt_config.to_string()], vec![])?;
+            let keys = match decrypt_config {
+                Some(decrypt_config) => vec![decrypt_config.to_string()],
+                None => Vec::new(),
+            };
+
+            let cc = create_decrypt_config(keys, vec![])?;
             if let Some(decrypt_config) = cc.decrypt_config {
                 decrypt_layer_key_opts_data(&decrypt_config, descriptor.annotations.as_ref())
             } else {
@@ -359,7 +361,7 @@ impl Decryptor {
     pub fn get_decrypt_key(
         &self,
         _descriptor: &OciDescriptor,
-        _decrypt_config: &str,
+        _decrypt_config: &Option<&str>,
     ) -> Result<Vec<u8>> {
         bail!(
             "no support of encryption, can't handle '{}'",

--- a/image-rs/tests/common/mod.rs
+++ b/image-rs/tests/common/mod.rs
@@ -16,7 +16,7 @@ const SIGNATURE_SCRIPT: &str = "scripts/install_test_signatures.sh";
 const OFFLINE_FS_KBC_RESOURCE_SCRIPT: &str = "scripts/install_offline_fs_kbc_files.sh";
 
 /// Attestation Agent Key Provider Parameter
-pub const AA_PARAMETER: &str = "provider:attestation-agent:offline_fs_kbc::null";
+pub const AA_PARAMETER: &str = "offline_fs_kbc::null";
 
 /// Attestation Agent Offline Filesystem KBC resources file for general tests that use images stored in the quay.io registry
 pub const OFFLINE_FS_KBC_RESOURCES_FILE: &str = "aa-offline_fs_kbc-resources.json";
@@ -97,6 +97,7 @@ pub async fn start_confidential_data_hub() -> Result<Child> {
     cfg_if::cfg_if! {
         if #[cfg(feature = "keywrap-ttrpc")] {
             let mut cdh = Command::new(cdh_path)
+            .env("AA_KBC_PARAM", AA_PARAMETER)
             .kill_on_drop(true)
             .spawn()
             .expect("Failed to start confidential-data-hub");

--- a/image-rs/tests/image_decryption.rs
+++ b/image-rs/tests/image_decryption.rs
@@ -71,13 +71,13 @@ async fn test_decrypt_layers(#[case] image: &str) {
     let mut image_client = ImageClient::new(work_dir.path().to_path_buf());
     if cfg!(feature = "snapshot-overlayfs") {
         image_client
-            .pull_image(image, bundle_dir.path(), &None, &Some(common::AA_PARAMETER))
+            .pull_image(image, bundle_dir.path(), &None, &None)
             .await
             .expect("failed to download image");
         common::umount_bundle(&bundle_dir);
     } else {
         image_client
-            .pull_image(image, bundle_dir.path(), &None, &Some(common::AA_PARAMETER))
+            .pull_image(image, bundle_dir.path(), &None, &None)
             .await
             .unwrap_err();
     }


### PR DESCRIPTION
The high level API of image-rs is `pull_image()`. There is one parameter named `decrypt_config` passed to the api, and the parameter is to specify the orignal kbc parameter, e.g.

provider:attestation-agent:offline_fs_kbc:null

However, different parts of the parameter is now specified
- `attestation-agent`: the key to look up keyprovider is embedded inside the encrypted image layer annotation.
- `offline_fs_kbc:null`: so-called AA_KBC_PARAMS, is defined in CDH if Kata-CC is used, so in this case, we do not to ensure the parameter is given as it will not be used. This is why we get rid of this parameter checking in this commit.

In enclave-cc scenarios, the `decrypt_config` is still used, and we will check the parameter in concrete `ocicrypt-rs`'s  `native` key provider plugin.