### PR TITLE
image-rs: refactor secure channel initialization logic

### DIFF
--- a/image-rs/src/image.rs
+++ b/image-rs/src/image.rs
@@ -199,7 +199,7 @@ impl ImageClient {
         };
 
         // If one of self.config.auth and self.config.security_validate is enabled,
-        // there will establish a secure channel between image-rs and Attestation-Agent
+        // there will establish a secure channel
         #[cfg(feature = "getresource")]
         if self.config.auth || self.config.security_validate {
             // Both we need a [`IMAGE_SECURITY_CONFIG_DIR`] dir
@@ -211,18 +211,8 @@ impl ImageClient {
                     })?;
             }
 
-            if let Some(wrapped_aa_kbc_params) = decrypt_config {
-                let wrapped_aa_kbc_params = wrapped_aa_kbc_params.to_string();
-                let aa_kbc_params =
-                    wrapped_aa_kbc_params.trim_start_matches("provider:attestation-agent:");
-
-                // The secure channel to communicate with KBS.
-                // This step will initialize the secure channel
-                let mut channel = crate::resource::SECURE_CHANNEL.lock().await;
-                *channel = Some(crate::resource::kbs::SecureChannel::new(aa_kbc_params).await?);
-            } else {
-                bail!("Secure channel creation needs aa_kbc_params.");
-            }
+            let mut channel = crate::resource::SECURE_CHANNEL.lock().await;
+            *channel = Some(crate::resource::kbs::SecureChannel::new(decrypt_config).await?);
         };
 
         // If no valid auth is given and config.auth is enabled, try to load

--- a/image-rs/src/resource/kbs/mod.rs
+++ b/image-rs/src/resource/kbs/mod.rs
@@ -59,8 +59,9 @@ trait Client: Send + Sync {
 
 impl SecureChannel {
     /// Create a new [`SecureChannel`], the input parameter:
-    /// * `aa_kbc_params`: s string with format `<kbc_name>::<kbs_uri>`.
-    pub async fn new(_aa_kbc_params: &str) -> Result<Self> {
+    /// * `decrypt_config`: s string with format `provider:attestation-agent:<kbc_name>::<kbs_uri>`.
+    /// This parameter is only used when in native secure channel (for enclave-cc)
+    pub async fn new(_decrypt_config: &Option<&str>) -> Result<Self> {
         let client: Box<dyn Client> = {
             cfg_if::cfg_if! {
                 if #[cfg(feature = "keywrap-ttrpc")] {
@@ -68,7 +69,7 @@ impl SecureChannel {
                     Box::new(ttrpc::Ttrpc::new().context("ttrpc client init failed")?)
                 } else if #[cfg(feature = "keywrap-native")] {
                     info!("secure channel uses native-aa");
-                    Box::new(native::Native::new(_aa_kbc_params)?)
+                    Box::new(native::Native::new(_decrypt_config)?)
                 } else if #[cfg(feature = "keywrap-grpc")] {
                     info!("secure channel uses gRPC");
                     Box::new(grpc::Grpc::new().await.context("grpc client init failed")?)

--- a/image-rs/src/resource/kbs/native.rs
+++ b/image-rs/src/resource/kbs/native.rs
@@ -22,7 +22,13 @@ pub struct Native {
 }
 
 impl Native {
-    pub fn new(aa_kbc_params: &str) -> Result<Self> {
+    pub fn new(decrypt_config: &Option<&str>) -> Result<Self> {
+        let Some(wrapped_aa_kbc_params) = decrypt_config else {
+            bail!("Secure channel creation needs aa_kbc_params.");
+        };
+
+        let aa_kbc_params = wrapped_aa_kbc_params.trim_start_matches("provider:attestation-agent:");
+
         let Some((kbc_name, kbs_uri)) = aa_kbc_params.split_once("::") else {
             bail!("illegal aa_kbc_params : {aa_kbc_params}");
         };


### PR DESCRIPTION
Currently image signature verification keys, auth files are got from confidential datahub who has a fixed ttrpc socket. So we do not require image-rs to have to configure the aa_kbc_params.

In Kata-CC this is important because in this way we can avoid parsing kernel cmdline in kata-agent.

Only when in enclave-cc, aa_kbc_params is still used by image-rs.