### PR TITLE
AA & CDH | Add feature information and git sha via `-V`

### DIFF
--- a/attestation-agent/attestation-agent/Cargo.toml
+++ b/attestation-agent/attestation-agent/Cargo.toml
@@ -55,12 +55,12 @@ kbs = ["kbs_protocol/background_check", "token"]
 # CoCoAS Attestation Token
 coco_as = ["reqwest", "token"]
 
-all-attesters = ["kbs_protocol?/all-attesters", "attester/all-attesters"]
-tdx-attester = ["kbs_protocol/tdx-attester", "attester/tdx-attester"]
-sgx-attester = ["kbs_protocol/sgx-attester", "attester/sgx-attester"]
-az-snp-vtpm-attester = ["kbs_protocol/az-snp-vtpm-attester", "attester/az-snp-vtpm-attester"]
-az-tdx-vtpm-attester = ["kbs_protocol/az-tdx-vtpm-attester", "attester/az-tdx-vtpm-attester"]
-snp-attester = ["kbs_protocol/snp-attester", "attester/snp-attester"]
+all-attesters = ["tdx-attester", "sgx-attester", "az-snp-vtpm-attester", "az-tdx-vtpm-attester", "snp-attester"]
+tdx-attester = ["kbs_protocol?/tdx-attester", "attester/tdx-attester"]
+sgx-attester = ["kbs_protocol?/sgx-attester", "attester/sgx-attester"]
+az-snp-vtpm-attester = ["kbs_protocol?/az-snp-vtpm-attester", "attester/az-snp-vtpm-attester"]
+az-tdx-vtpm-attester = ["kbs_protocol?/az-tdx-vtpm-attester", "attester/az-tdx-vtpm-attester"]
+snp-attester = ["kbs_protocol?/snp-attester", "attester/snp-attester"]
 
 # Either `rust-crypto` or `openssl` should be enabled to work as underlying crypto module
 rust-crypto = ["kbs_protocol?/rust-crypto"]

--- a/attestation-agent/attestation-agent/build.rs
+++ b/attestation-agent/attestation-agent/build.rs
@@ -34,5 +34,62 @@ fn main() -> std::io::Result<()> {
             .expect("Generate ttrpc protocol code failed.");
     }
 
+    #[cfg(feature = "bin")]
+    {
+        use std::env;
+        use std::fs::File;
+        use std::io::Write;
+        use std::path::Path;
+        use std::process::Command;
+
+        // generate an `intro` file that includes the feature information of the build
+        fn feature_list(features: Vec<&str>) -> String {
+            let enabled_features: Vec<&str> = features
+                .into_iter()
+                .filter(|&feature| env::var(format!("CARGO_FEATURE_{}", feature)).is_ok())
+                .collect();
+
+            enabled_features.join(", ")
+        }
+
+        let token_plugins = feature_list(vec!["KBS", "COCO_AS"]);
+        let attester = feature_list(vec![
+            "TDX_ATTESTER",
+            "SGX_ATTESTER",
+            "AZ_SNP_VTPM_ATTESTER",
+            "AZ_TDX_VTPM_ATTESTER",
+            "SNP_ATTESTER",
+        ]);
+
+        let out_dir = env::var("OUT_DIR").unwrap();
+        let dest_path = Path::new(&out_dir).join("version");
+        let mut f = File::create(dest_path).unwrap();
+        let git_commit_hash = Command::new("git")
+            .args(["rev-parse", "HEAD"])
+            .output()
+            .unwrap()
+            .stdout;
+
+        let git_commit_hash = String::from_utf8(git_commit_hash).unwrap();
+        let git_commit_hash = git_commit_hash.trim_end();
+
+        let git_status_output = match Command::new("git")
+            .args(["diff", "HEAD"])
+            .output()
+            .unwrap()
+            .stdout
+            .is_empty()
+        {
+            true => "",
+            false => "(dirty)",
+        };
+
+        writeln!(f, "\n\nCommit Hash: {git_commit_hash} {git_status_output}",).unwrap();
+
+        writeln!(f, "Supported Attesters: {}", attester).unwrap();
+
+        writeln!(f, "Token plugins: {}", token_plugins).unwrap();
+    }
+
     Ok(())
 }

--- a/attestation-agent/attestation-agent/src/bin/grpc-aa/main.rs
+++ b/attestation-agent/attestation-agent/src/bin/grpc-aa/main.rs
@@ -14,8 +14,10 @@ use std::net::SocketAddr;
 
 const DEFAULT_ATTESTATION_AGENT_ADDR: &str = "127.0.0.1:50002";
 
+const VERSION: &str = include_str!(concat!(env!("OUT_DIR"), "/version"));
+
 #[derive(Debug, Parser)]
-#[command(author, version, about, long_about = None)]
+#[command(author, version = Some(VERSION))]
 struct Cli {
     /// Attestation gRPC Unix socket addr.
     ///

--- a/attestation-agent/attestation-agent/src/bin/ttrpc-aa/main.rs
+++ b/attestation-agent/attestation-agent/src/bin/ttrpc-aa/main.rs
@@ -22,8 +22,10 @@ const DEFAULT_ATTESTATION_SOCKET_ADDR: &str = concatcp!(
     "attestation-agent.sock"
 );
 
+const VERSION: &str = include_str!(concat!(env!("OUT_DIR"), "/version"));
+
 #[derive(Debug, Parser)]
-#[command(author, version, about, long_about = None)]
+#[command(author, version = Some(VERSION))]
 struct Cli {
     /// Attestation ttRPC Unix socket addr.
     ///

--- a/confidential-data-hub/hub/build.rs
+++ b/confidential-data-hub/hub/build.rs
@@ -6,8 +6,11 @@
 fn main() {
     #[cfg(feature = "bin")]
     {
+        use std::env;
         use std::fs::File;
         use std::io::{Read, Write};
+        use std::path::Path;
+        use std::process::Command;
         use ttrpc_codegen::{Codegen, Customize, ProtobufCustomize};
 
         fn replace_text_in_file(file_name: &str, from: &str, to: &str) {
@@ -39,5 +42,46 @@ fn main() {
 
         // Fix clippy warnings of code generated from ttrpc_codegen
         replace_text_in_file("src/bin/protos/api_ttrpc.rs", "client: client", "client");
+
+        // generate an `intro` file that includes the feature information of the build
+        fn feature_list(features: Vec<&str>) -> String {
+            let enabled_features: Vec<&str> = features
+                .into_iter()
+                .filter(|&feature| env::var(format!("CARGO_FEATURE_{}", feature)).is_ok())
+                .collect();
+
+            enabled_features.join(", ")
+        }
+
+        let resource_providers = feature_list(vec!["KBS", "SEV"]);
+        let kms = feature_list(vec!["ALIYUN", "EHSM"]);
+
+        let out_dir = env::var("OUT_DIR").unwrap();
+        let dest_path = Path::new(&out_dir).join("version");
+        let mut f = File::create(dest_path).unwrap();
+
+        let git_commit_hash = Command::new("git")
+            .args(["rev-parse", "HEAD"])
+            .output()
+            .unwrap()
+            .stdout;
+
+        let git_commit_hash = String::from_utf8(git_commit_hash).unwrap();
+        let git_commit_hash = git_commit_hash.trim_end();
+
+        let git_status_output = match Command::new("git")
+            .args(["diff", "HEAD"])
+            .output()
+            .unwrap()
+            .stdout
+            .is_empty()
+        {
+            true => "",
+            false => "(dirty)",
+        };
+        writeln!(f, "\n\nCommit Hash: {git_commit_hash} {git_status_output}",).unwrap();
+        writeln!(f, "Resource Providers: {}", resource_providers).unwrap();
+
+        writeln!(f, "KMS plugins: {}", kms).unwrap();
     }
 }

--- a/confidential-data-hub/hub/src/bin/confidential-data-hub.rs
+++ b/confidential-data-hub/hub/src/bin/confidential-data-hub.rs
@@ -31,8 +31,10 @@ const DEFAULT_CONFIG_PATH: &str = "/etc/confidential-data-hub.toml";
 
 const UNIX_SOCKET_PREFIX: &str = "unix://";
 
+const VERSION: &str = include_str!(concat!(env!("OUT_DIR"), "/version"));
+
 #[derive(Debug, Parser)]
-#[command(author, version, about, long_about = None)]
+#[command(author, version = Some(VERSION))]
 struct Cli {
     /// Path to the config  file
     ///


### PR DESCRIPTION
Fixes #530 

After this PR, the AA would show its built-in plugins by `-V` like the following
```
$ ./attestation-agent -V

attestation-agent 

Commit Hash: 083cb8750c325c7d90147f3bce1f498664e376fb (dirty)
Supported Attesters: TDX_ATTESTER, SGX_ATTESTER, AZ_SNP_VTPM_ATTESTER, AZ_TDX_VTPM_ATTESTER, SNP_ATTESTER
Token plugins: KBS, COCO_AS
```

and CDH
```
$ ./confidential-data-hub -V

confidential-data-hub 

Commit Hash: 083cb8750c325c7d90147f3bce1f498664e376fb (dirty)
Resource Providers: KBS, SEV
KMS plugins: ALIYUN, EHSM
```

Related to also #487 

cc @fitzthum @surajssd @mkulke 