### PR TITLE
Optimize error for guest-components

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2586,6 +2586,7 @@ dependencies = [
 name = "image"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "assert-json-diff",
  "base64 0.21.7",
  "crypto",
@@ -5178,6 +5179,7 @@ dependencies = [
 name = "secret"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "assert-json-diff",
  "assert_cmd",
  "async-trait",

--- a/api-server-rest/src/cdh.rs
+++ b/api-server-rest/src/cdh.rs
@@ -47,13 +47,10 @@ impl ApiHandler for CDHClient {
 
         if let Some((api, resource_path)) = split_nth_slash(url_path, 2) {
             match api {
-                CDH_RESOURCE_URL => {
-                    let results = self
-                        .get_resource(resource_path)
-                        .await
-                        .unwrap_or_else(|e| e.to_string().into());
-                    return self.octet_stream_response(results);
-                }
+                CDH_RESOURCE_URL => match self.get_resource(resource_path).await {
+                    std::result::Result::Ok(results) => return self.octet_stream_response(results),
+                    Err(e) => return self.internal_error(e.to_string()),
+                },
                 _ => {
                     return self.not_found();
                 }

--- a/api-server-rest/src/router.rs
+++ b/api-server-rest/src/router.rs
@@ -65,6 +65,13 @@ pub trait ApiHandler: Send {
             .status(StatusCode::METHOD_NOT_ALLOWED)
             .body(Body::from("Method Not Allowed"))?)
     }
+
+    // Build 500 Internal Server Error response.
+    fn internal_error(&self, body: String) -> Result<Response<Body>> {
+        Ok(Response::builder()
+            .status(StatusCode::INTERNAL_SERVER_ERROR)
+            .body(Body::from(body))?)
+    }
 }
 
 pub struct Router {

--- a/attestation-agent/attestation-agent/src/bin/grpc-aa/server.rs
+++ b/attestation-agent/attestation-agent/src/bin/grpc-aa/server.rs
@@ -39,17 +39,17 @@ impl AttestationAgentService for AA {
 
         let mut attestation_agent = self.inner.lock().await;
 
-        debug!("Call AA to get token ...");
+        debug!("AA (grpc): get token ...");
 
         let token = attestation_agent
             .get_token(&request.token_type)
             .await
             .map_err(|e| {
-                error!("Call AA to get token failed: {}", e);
-                Status::internal(format!("[ERROR:{}] AA get token failed: {}", AGENT_NAME, e))
+                error!("AA (grpc): get token failed:\n{e:?}");
+                Status::internal(format!("[ERROR:{AGENT_NAME}] AA get token failed"))
             })?;
 
-        debug!("Get token successfully!");
+        debug!("AA (grpc): Get token successfully!");
 
         let reply = GetTokenResponse { token };
 
@@ -64,20 +64,17 @@ impl AttestationAgentService for AA {
 
         let mut attestation_agent = self.inner.lock().await;
 
-        debug!("Call AA to get evidence ...");
+        debug!("AA (grpc): get evidence ...");
 
         let evidence = attestation_agent
             .get_evidence(&request.runtime_data)
             .await
             .map_err(|e| {
-                error!("Call AA to get evidence failed: {}", e);
-                Status::internal(format!(
-                    "[ERROR:{}] AA get evidence failed: {}",
-                    AGENT_NAME, e
-                ))
+                error!("AA (grpc): get evidence failed:\n{e:?}");
+                Status::internal(format!("[ERROR:{AGENT_NAME}] AA get evidence failed"))
             })?;
 
-        debug!("Get evidence successfully!");
+        debug!("AA (grpc): Get evidence successfully!");
 
         let reply = GetEvidenceResponse { evidence };
 
@@ -92,20 +89,19 @@ impl AttestationAgentService for AA {
 
         let mut attestation_agent = self.inner.lock().await;
 
-        debug!("Call AA to extend runtime measurement ...");
+        debug!("AA (grpc): extend runtime measurement ...");
 
         attestation_agent
             .extend_runtime_measurement(request.events, request.register_index)
             .await
             .map_err(|e| {
-                error!("Call AA to extend runtime measurement failed: {}", e);
+                error!("AA (grpc): extend runtime measurement failed:\n{e:?}");
                 Status::internal(format!(
-                    "[ERROR:{}] AA extend runtime measurement failed: {}",
-                    AGENT_NAME, e
+                    "[ERROR:{AGENT_NAME}] AA extend runtime measurement failed"
                 ))
             })?;
 
-        debug!("Extend runtime measurement successfully!");
+        debug!("AA (grpc): extend runtime measurement succeeded.");
 
         let reply = ExtendRuntimeMeasurementResponse {};
 
@@ -120,20 +116,17 @@ impl AttestationAgentService for AA {
 
         let mut attestation_agent = self.inner.lock().await;
 
-        debug!("Call AA to check init data ...");
+        debug!("AA (grpc): check init data ...");
 
         attestation_agent
             .check_init_data(&request.digest)
             .await
             .map_err(|e| {
-                error!("Call AA to check init data failed: {}", e);
-                Status::internal(format!(
-                    "[ERROR:{}] AA check init data failed: {}",
-                    AGENT_NAME, e
-                ))
+                error!("AA (grpc): check init data failed:\n{e:?}");
+                Status::internal(format!("[ERROR:{AGENT_NAME}] AA check init data failed"))
             })?;
 
-        debug!("Check init data successfully!");
+        debug!("AA (grpc): Check init data successfully!");
 
         let reply = CheckInitDataResponse {};
 

--- a/attestation-agent/attestation-agent/src/bin/ttrpc-aa/server.rs
+++ b/attestation-agent/attestation-agent/src/bin/ttrpc-aa/server.rs
@@ -35,7 +35,7 @@ impl AttestationAgentService for AA {
         _ctx: &::ttrpc::r#async::TtrpcContext,
         req: GetTokenRequest,
     ) -> ::ttrpc::Result<GetTokenResponse> {
-        debug!("Call AA to get token ...");
+        debug!("AA (ttrpc): get token ...");
 
         let mut attestation_agent = self.inner.lock().await;
 
@@ -43,17 +43,14 @@ impl AttestationAgentService for AA {
             .get_token(&req.TokenType)
             .await
             .map_err(|e| {
-                error!("Call AA-KBC to get token failed: {}", e);
+                error!("AA (ttrpc): get token failed\n {e:?}");
                 let mut error_status = ::ttrpc::proto::Status::new();
                 error_status.set_code(Code::INTERNAL);
-                error_status.set_message(format!(
-                    "[ERROR:{}] AA-KBC get token failed: {}",
-                    AGENT_NAME, e
-                ));
+                error_status.set_message(format!("[ERROR:{AGENT_NAME}] AA-KBC get token failed"));
                 ::ttrpc::Error::RpcStatus(error_status)
             })?;
 
-        debug!("Get token successfully!");
+        debug!("AA (ttrpc): Get token successfully!");
 
         let mut reply = GetTokenResponse::new();
         reply.Token = token;
@@ -66,7 +63,7 @@ impl AttestationAgentService for AA {
         _ctx: &::ttrpc::r#async::TtrpcContext,
         req: GetEvidenceRequest,
     ) -> ::ttrpc::Result<GetEvidenceResponse> {
-        debug!("Call AA to get evidence ...");
+        debug!("AA (ttrpc): get evidence ...");
 
         let mut attestation_agent = self.inner.lock().await;
 
@@ -74,17 +71,15 @@ impl AttestationAgentService for AA {
             .get_evidence(&req.RuntimeData)
             .await
             .map_err(|e| {
-                error!("Call AA-KBC to get evidence failed: {}", e);
+                error!("AA (ttrpc): get evidence failed:\n {e:?}");
                 let mut error_status = ::ttrpc::proto::Status::new();
                 error_status.set_code(Code::INTERNAL);
-                error_status.set_message(format!(
-                    "[ERROR:{}] AA-KBC get evidence failed: {}",
-                    AGENT_NAME, e
-                ));
+                error_status
+                    .set_message(format!("[ERROR:{AGENT_NAME}] AA-KBC get evidence failed"));
                 ::ttrpc::Error::RpcStatus(error_status)
             })?;
 
-        debug!("Get evidence successfully!");
+        debug!("AA (ttrpc): Get evidence successfully!");
 
         let mut reply = GetEvidenceResponse::new();
         reply.Evidence = evidence;
@@ -97,7 +92,7 @@ impl AttestationAgentService for AA {
         _ctx: &::ttrpc::r#async::TtrpcContext,
         req: ExtendRuntimeMeasurementRequest,
     ) -> ::ttrpc::Result<ExtendRuntimeMeasurementResponse> {
-        debug!("Call AA to extend runtime measurement ...");
+        debug!("AA (ttrpc): extend runtime measurement ...");
 
         let mut attestation_agent = self.inner.lock().await;
 
@@ -105,16 +100,16 @@ impl AttestationAgentService for AA {
             .extend_runtime_measurement(req.Events, req.RegisterIndex)
             .await
             .map_err(|e| {
-                error!("Call AA to extend runtime measurement failed: {}", e);
+                error!("AA (ttrpc): extend runtime measurement failed:\n {e:?}");
                 let mut error_status = ::ttrpc::proto::Status::new();
                 error_status.set_code(Code::INTERNAL);
                 error_status.set_message(format!(
-                    "[ERROR:{}] AA extend runtime measurement failed: {}",
-                    AGENT_NAME, e
+                    "[ERROR:{AGENT_NAME}] AA extend runtime measurement failed"
                 ));
                 ::ttrpc::Error::RpcStatus(error_status)
             })?;
 
+        debug!("AA (ttrpc): extend runtime measurement succeeded.");
         let reply = ExtendRuntimeMeasurementResponse::new();
         ::ttrpc::Result::Ok(reply)
     }

--- a/confidential-data-hub/hub/protos/api.proto
+++ b/confidential-data-hub/hub/protos/api.proto
@@ -3,6 +3,8 @@ syntax = "proto3";
 package api;
 
 message UnsealSecretInput {
+    // The input `secret`` is in the following format
+    // `sealed`.`JWS header`.`JWS body (secret content)`.`signature`
     bytes secret = 1;
 }
 

--- a/confidential-data-hub/hub/src/error.rs
+++ b/confidential-data-hub/hub/src/error.rs
@@ -9,18 +9,27 @@ pub type Result<T> = std::result::Result<T, Error>;
 
 #[derive(Error, Debug)]
 pub enum Error {
-    #[error("get resource failed: {0}")]
-    GetResource(String),
+    #[error("kbs client initialization failed")]
+    KbsClient {
+        #[source]
+        source: kms::Error,
+    },
 
-    #[error("decrypt image (unwrap key) failed: {0}")]
-    ImageDecryption(String),
+    #[error("get resource failed")]
+    GetResource {
+        #[source]
+        source: kms::Error,
+    },
+
+    #[error("decrypt image (unwrap key) failed")]
+    ImageDecryption(#[from] image::Error),
 
     #[error("init Hub failed: {0}")]
     InitializationFailed(String),
 
-    #[error("unseal secret failed: {0}")]
-    UnsealSecret(String),
+    #[error("unseal secret failed")]
+    UnsealSecret(#[from] secret::SecretError),
 
-    #[error("secure mount failed: {0}")]
-    SecureMount(String),
+    #[error("secure mount failed")]
+    SecureMount(#[from] storage::Error),
 }

--- a/confidential-data-hub/hub/src/hub.rs
+++ b/confidential-data-hub/hub/src/hub.rs
@@ -6,11 +6,8 @@
 use std::collections::HashMap;
 
 use async_trait::async_trait;
-use base64::{engine::general_purpose::STANDARD, Engine};
-use image::AnnotationPacket;
 use kms::{Annotations, ProviderSettings};
 use log::info;
-use secret::secret::Secret;
 use storage::volume_type::Storage;
 
 use crate::{DataHub, Error, Result};
@@ -32,39 +29,16 @@ impl Hub {
 impl DataHub for Hub {
     async fn unseal_secret(&self, secret: Vec<u8>) -> Result<Vec<u8>> {
         info!("unseal secret called");
-        // TODO: verify the jws signature using the key specified by `kid`
-        // in header. Here we directly get the JWS payload
-        let payload = secret
-            .split(|c| *c == b'.')
-            .nth(1)
-            .ok_or_else(|| Error::UnsealSecret("illegal input sealed secret (not a JWS)".into()))?;
 
-        let secret_json = STANDARD.decode(payload).map_err(|e| {
-            Error::UnsealSecret(format!(
-                "illegal input sealed secret (JWS body is not standard base64 encoded): {e}"
-            ))
-        })?;
-        let secret: Secret = serde_json::from_slice(&secret_json).map_err(|e| {
-            Error::UnsealSecret(format!(
-                "illegal input sealed secret format (json deseralization failed): {e}"
-            ))
-        })?;
+        let res = secret::unseal_secret(&secret).await?;
 
-        let res = secret
-            .unseal()
-            .await
-            .map_err(|e| Error::UnsealSecret(format!("unseal failed: {e}")))?;
         Ok(res)
     }
 
     async fn unwrap_key(&self, annotation_packet: &[u8]) -> Result<Vec<u8>> {
         info!("unwrap key called");
-        let annotation_packet: AnnotationPacket = serde_json::from_slice(annotation_packet)
-            .map_err(|e| Error::ImageDecryption(format!("illegal AnnotationPacket format: {e}")))?;
-        let lek = annotation_packet
-            .unwrap_key()
-            .await
-            .map_err(|e| Error::ImageDecryption(format!("unwrap key failed: {e}")))?;
+
+        let lek = image::unwrap_key(annotation_packet).await?;
         Ok(lek)
     }
 
@@ -73,22 +47,19 @@ impl DataHub for Hub {
         // to initialize a get_resource_provider client we do not need the ProviderSettings.
         let mut client = kms::new_getter("kbs", ProviderSettings::default())
             .await
-            .map_err(|e| Error::GetResource(format!("create kbs client failed: {e}")))?;
+            .map_err(|e| Error::KbsClient { source: e })?;
 
         // to get resource using a get_resource_provider client we do not need the Annotations.
         let res = client
             .get_secret(&uri, &Annotations::default())
             .await
-            .map_err(|e| Error::GetResource(format!("get rersource failed: {e}")))?;
+            .map_err(|e| Error::GetResource { source: e })?;
         Ok(res)
     }
 
     async fn secure_mount(&self, storage: Storage) -> Result<String> {
         info!("secure mount called");
-        let res = storage
-            .mount()
-            .await
-            .map_err(|e| Error::SecureMount(e.to_string()))?;
+        let res = storage.mount().await?;
         Ok(res)
     }
 }

--- a/confidential-data-hub/image/Cargo.toml
+++ b/confidential-data-hub/image/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+anyhow.workspace = true
 base64.workspace = true
 crypto.path = "../../attestation-agent/deps/crypto"
 kms = { path = "../kms", default-features = false }

--- a/confidential-data-hub/image/src/error.rs
+++ b/confidential-data-hub/image/src/error.rs
@@ -9,12 +9,32 @@ pub type Result<T> = std::result::Result<T, Error>;
 
 #[derive(Error, Debug)]
 pub enum Error {
-    #[error("Convert AnnotationPacket failed: {0}")]
-    ConvertAnnotationPacketFailed(String),
+    #[error("Unknown WrapType: {0}")]
+    UnknownWrapType(String),
 
-    #[error("unwrap key failed (Annotation V1): {0}")]
-    UnwrapAnnotationV1Failed(String),
+    #[error("kms interface when {context}")]
+    KmsError {
+        #[source]
+        source: kms::Error,
+        context: &'static str,
+    },
 
-    #[error("unwrap key failed (Annotation V2): {0}")]
-    UnwrapAnnotationV2Failed(String),
+    #[error("base64 decoding failed when {context}")]
+    Base64DecodeFailed {
+        #[source]
+        source: base64::DecodeError,
+        context: &'static str,
+    },
+
+    #[error("decrypt LEK using KEK failed")]
+    DecryptFailed {
+        #[source]
+        source: anyhow::Error,
+    },
+
+    #[error("malwared AnnotationPacket format")]
+    ParseAnnotationPacket {
+        #[source]
+        source: anyhow::Error,
+    },
 }

--- a/confidential-data-hub/image/src/lib.rs
+++ b/confidential-data-hub/image/src/lib.rs
@@ -7,4 +7,15 @@ pub mod annotation_packet;
 pub mod error;
 
 pub use annotation_packet::AnnotationPacket;
+use anyhow::anyhow;
 pub use error::*;
+
+pub async fn unwrap_key(annotation_packet: &[u8]) -> Result<Vec<u8>> {
+    let annotation_packet: AnnotationPacket =
+        serde_json::from_slice(annotation_packet).map_err(|e| Error::ParseAnnotationPacket {
+            source: anyhow!("deserialize failed, {e}"),
+        })?;
+    let lek = annotation_packet.unwrap_key().await?;
+
+    Ok(lek)
+}

--- a/confidential-data-hub/secret/Cargo.toml
+++ b/confidential-data-hub/secret/Cargo.toml
@@ -11,6 +11,7 @@ name = "secret_cli"
 required-features = [ "cli" ]
 
 [dependencies]
+anyhow.workspace = true
 async-trait.workspace = true
 base64.workspace = true
 clap = { workspace = true, optional = true }

--- a/confidential-data-hub/secret/src/bin/secret_cli.rs
+++ b/confidential-data-hub/secret/src/bin/secret_cli.rs
@@ -127,7 +127,7 @@ async fn main() {
                 .await
                 .expect("failed to read sealed secret");
             let secret: Secret = serde_json::from_slice(&secret_json)
-                .expect("illegal input sealed secret format (json deseralization failed)");
+                .expect("illegal input sealed secret format (json deserialization failed)");
 
             match secret.r#type {
                 SecretContent::Envelope(ref envelope) => match envelope.provider.as_str() {

--- a/confidential-data-hub/secret/src/error.rs
+++ b/confidential-data-hub/secret/src/error.rs
@@ -5,13 +5,24 @@
 
 use thiserror::Error;
 
-pub type Result<T> = std::result::Result<T, Error>;
+use crate::secret::{
+    layout::{envelope::EnvelopeError, vault::VaultError},
+    VERSION,
+};
+
+pub type Result<T> = std::result::Result<T, SecretError>;
 
 #[derive(Error, Debug)]
-pub enum Error {
-    #[error("unseal envelope secret failed: {0}")]
-    UnsealEnvelopeFailed(String),
+pub enum SecretError {
+    #[error("version not supported, only {} supported", VERSION)]
+    VersionError,
 
-    #[error("unseal vault secret failed: {0}")]
-    UnsealVaultFailed(String),
+    #[error("unseal envelope secret failed")]
+    UnsealEnvelopeFailed(#[from] EnvelopeError),
+
+    #[error("unseal vault secret failed")]
+    UnsealVaultFailed(#[from] VaultError),
+
+    #[error("parse SealedSecret failed: {0}")]
+    ParseFailed(&'static str),
 }

--- a/confidential-data-hub/secret/src/lib.rs
+++ b/confidential-data-hub/secret/src/lib.rs
@@ -6,6 +6,35 @@
 pub mod error;
 pub mod secret;
 
-pub use error::*;
+use base64::{engine::general_purpose::STANDARD, Engine};
 
+use crate::secret::Secret;
+
+pub use error::*;
 pub use kms::{Annotations, ProviderSettings};
+
+pub async fn unseal_secret(secret: &[u8]) -> Result<Vec<u8>> {
+    let sections: Vec<_> = secret.split(|c| *c == b'.').collect();
+
+    if sections.len() != 4 {
+        return Err(SecretError::ParseFailed("malformed input sealed secret"));
+    }
+
+    if sections[0] != b"sealed" {
+        return Err(SecretError::ParseFailed(
+            "malformed input sealed secret. Without `sealed.` prefix",
+        ));
+    }
+
+    let secret_json = STANDARD
+        .decode(sections[2])
+        .map_err(|_| SecretError::ParseFailed("base64 decode Secret body"))?;
+
+    let secret: Secret = serde_json::from_slice(&secret_json).map_err(|_| {
+        SecretError::ParseFailed(
+            "malformed input sealed secret format (json deserialization failed)",
+        )
+    })?;
+
+    secret.unseal().await
+}

--- a/confidential-data-hub/secret/src/lib.rs
+++ b/confidential-data-hub/secret/src/lib.rs
@@ -13,6 +13,8 @@ use crate::secret::Secret;
 pub use error::*;
 pub use kms::{Annotations, ProviderSettings};
 
+/// The input sealed secret is in the following format
+/// `sealed`.`JWS header`.`JWS body (secret content)`.`signature`
 pub async fn unseal_secret(secret: &[u8]) -> Result<Vec<u8>> {
     let sections: Vec<_> = secret.split(|c| *c == b'.').collect();
 

--- a/confidential-data-hub/secret/src/secret/layout/envelope.rs
+++ b/confidential-data-hub/secret/src/secret/layout/envelope.rs
@@ -9,9 +9,30 @@ use base64::{engine::general_purpose::STANDARD, Engine};
 use crypto::WrapType;
 use kms::ProviderSettings;
 use serde::{Deserialize, Serialize};
+use thiserror::Error;
 use zeroize::Zeroizing;
 
-use crate::{Error, Result};
+pub type Result<T> = std::result::Result<T, EnvelopeError>;
+
+#[derive(Error, Debug)]
+pub enum EnvelopeError {
+    #[error("base64 decoding failed when {context}")]
+    Base64DecodeFailed {
+        #[source]
+        source: base64::DecodeError,
+        context: &'static str,
+    },
+
+    #[error("kms interface when {context}")]
+    KmsError {
+        #[source]
+        source: kms::Error,
+        context: &'static str,
+    },
+
+    #[error("decrypt envelope")]
+    Decrypt(#[from] anyhow::Error),
+}
 
 /// An Envelope is a secret encrypted by digital envelope mechanism.
 /// It can be described as
@@ -52,29 +73,41 @@ impl Envelope {
     pub(crate) async fn unseal(&self) -> Result<Vec<u8>> {
         // get encryption key
         let enc_dek = STANDARD.decode(&self.encrypted_key).map_err(|e| {
-            Error::UnsealEnvelopeFailed(format!("base64 decode encrypted_key failed: {e}"))
+            EnvelopeError::Base64DecodeFailed {
+                context: "decode `encrypted_key`",
+                source: e,
+            }
         })?;
         let mut provider = kms::new_decryptor(&self.provider, self.provider_settings.clone())
             .await
-            .map_err(|e| Error::UnsealEnvelopeFailed(format!("create provider failed: {e}")))?;
+            .map_err(|e| EnvelopeError::KmsError {
+                context: "create KMS provider",
+                source: e,
+            })?;
         let dek = Zeroizing::new(
             provider
                 .decrypt(&enc_dek, &self.key_id, &self.annotations)
                 .await
-                .map_err(|e| {
-                    Error::UnsealEnvelopeFailed(format!("decrypt encryption key failed: {e}"))
+                .map_err(|e| EnvelopeError::KmsError {
+                    context: "decrypt encryption key",
+                    source: e,
                 })?,
         );
 
         // get plaintext of secret
         let iv = STANDARD
             .decode(&self.iv)
-            .map_err(|e| Error::UnsealEnvelopeFailed(format!("base64 decode iv failed: {e}")))?;
+            .map_err(|e| EnvelopeError::Base64DecodeFailed {
+                context: "decode iv",
+                source: e,
+            })?;
         let encrypted_data = STANDARD.decode(&self.encrypted_data).map_err(|e| {
-            Error::UnsealEnvelopeFailed(format!("base64 decode encrypted_data failed: {e}"))
+            EnvelopeError::Base64DecodeFailed {
+                context: "decode encrypted_data",
+                source: e,
+            }
         })?;
-        let plaintext = crypto::decrypt(dek, encrypted_data, iv, self.wrap_type.clone())
-            .map_err(|e| Error::UnsealEnvelopeFailed(format!("decrypt envelope failed: {e}")))?;
+        let plaintext = crypto::decrypt(dek, encrypted_data, iv, self.wrap_type.clone())?;
         Ok(plaintext)
     }
 }

--- a/confidential-data-hub/secret/src/secret/layout/vault.rs
+++ b/confidential-data-hub/secret/src/secret/layout/vault.rs
@@ -5,10 +5,21 @@
 
 use kms::ProviderSettings;
 use serde::{Deserialize, Serialize};
-
-use crate::{Error, Result};
+use thiserror::Error;
 
 pub use kms::Annotations;
+
+pub type Result<T> = std::result::Result<T, VaultError>;
+
+#[derive(Error, Debug)]
+pub enum VaultError {
+    #[error("kms interface when {context}")]
+    KmsError {
+        #[source]
+        source: kms::Error,
+        context: &'static str,
+    },
+}
 
 #[derive(Serialize, Deserialize, PartialEq, Debug)]
 pub struct VaultSecret {
@@ -29,14 +40,19 @@ impl VaultSecret {
     pub(crate) async fn unseal(&self) -> Result<Vec<u8>> {
         let mut provider = kms::new_getter(&self.provider, self.provider_settings.clone())
             .await
-            .map_err(|e| Error::UnsealVaultFailed(format!("create provider failed: {e}")))?;
+            .map_err(|e| VaultError::KmsError {
+                context: "create kms provider",
+                source: e,
+            })?;
 
         let secret = provider
             .get_secret(&self.name, &self.annotations)
             .await
-            .map_err(|e| {
-                Error::UnsealVaultFailed(format!("get secret from provider failed: {e}"))
+            .map_err(|e| VaultError::KmsError {
+                context: "get secret from provider",
+                source: e,
             })?;
+
         Ok(secret)
     }
 }


### PR DESCRIPTION
This PR does the following
1. Reorganize error handling and information in logs in CDH/AA. Only a brief error information will be responsed to caller, and detailed information will be printed in the log of CDH/AA. Close #541
2. ASR now will response an internal error (HTTP 500) when failed to execute API call. Close #529
3. Based on the code change, we bring out the duplicated code for `unseal_secret` in storage plugin