### PR TITLE
AA: add UpdateConfiguration API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -303,6 +303,7 @@ dependencies = [
  "serde_json",
  "sha2 0.10.8",
  "strum",
+ "tempfile",
  "thiserror",
  "tokio",
  "toml 0.8.10",

--- a/attestation-agent/attestation-agent/Cargo.toml
+++ b/attestation-agent/attestation-agent/Cargo.toml
@@ -31,6 +31,7 @@ serde.workspace = true
 serde_json.workspace = true
 sha2.workspace = true
 strum.workspace = true
+tempfile.workspace = true
 thiserror.workspace = true
 tokio = { workspace = true, features = ["fs"] }
 toml.workspace = true

--- a/attestation-agent/attestation-agent/src/bin/ttrpc-aa/server.rs
+++ b/attestation-agent/attestation-agent/src/bin/ttrpc-aa/server.rs
@@ -16,7 +16,8 @@ use std::sync::Arc;
 
 use crate::ttrpc_protocol::attestation_agent::{
     ExtendRuntimeMeasurementRequest, ExtendRuntimeMeasurementResponse, GetEvidenceRequest,
-    GetEvidenceResponse, GetTokenRequest, GetTokenResponse,
+    GetEvidenceResponse, GetTokenRequest, GetTokenResponse, UpdateConfigurationRequest,
+    UpdateConfigurationResponse,
 };
 use crate::ttrpc_protocol::attestation_agent_ttrpc::{
     create_attestation_agent_service, AttestationAgentService,
@@ -111,6 +112,32 @@ impl AttestationAgentService for AA {
 
         debug!("AA (ttrpc): extend runtime measurement succeeded.");
         let reply = ExtendRuntimeMeasurementResponse::new();
+        ::ttrpc::Result::Ok(reply)
+    }
+
+    async fn update_configuration(
+        &self,
+        _ctx: &::ttrpc::r#async::TtrpcContext,
+        req: UpdateConfigurationRequest,
+    ) -> ::ttrpc::Result<UpdateConfigurationResponse> {
+        debug!("AA (ttrpc): update configuration ...");
+
+        let mut attestation_agent = self.inner.lock().await;
+
+        attestation_agent
+            .update_configuration(&req.config)
+            .map_err(|e| {
+                error!("AA (ttrpc): update configuration failed:\n {e:?}");
+                let mut error_status = ::ttrpc::proto::Status::new();
+                error_status.set_code(Code::INTERNAL);
+                error_status.set_message(format!(
+                    "[ERROR:{AGENT_NAME}] AA update configuration failed"
+                ));
+                ::ttrpc::Error::RpcStatus(error_status)
+            })?;
+
+        debug!("AA (ttrpc): update configuration succeeded.");
+        let reply = UpdateConfigurationResponse::new();
         ::ttrpc::Result::Ok(reply)
     }
 }

--- a/attestation-agent/attestation-agent/src/bin/ttrpc-aa/ttrpc_protocol/attestation_agent.rs
+++ b/attestation-agent/attestation-agent/src/bin/ttrpc-aa/ttrpc_protocol/attestation_agent.rs
@@ -1121,6 +1121,231 @@ impl ::protobuf::reflect::ProtobufValue for CheckInitDataResponse {
     type RuntimeType = ::protobuf::reflect::rt::RuntimeTypeMessage<Self>;
 }
 
+// @@protoc_insertion_point(message:attestation_agent.UpdateConfigurationRequest)
+#[derive(PartialEq,Clone,Default,Debug)]
+pub struct UpdateConfigurationRequest {
+    // message fields
+    // @@protoc_insertion_point(field:attestation_agent.UpdateConfigurationRequest.config)
+    pub config: ::std::string::String,
+    // special fields
+    // @@protoc_insertion_point(special_field:attestation_agent.UpdateConfigurationRequest.special_fields)
+    pub special_fields: ::protobuf::SpecialFields,
+}
+
+impl<'a> ::std::default::Default for &'a UpdateConfigurationRequest {
+    fn default() -> &'a UpdateConfigurationRequest {
+        <UpdateConfigurationRequest as ::protobuf::Message>::default_instance()
+    }
+}
+
+impl UpdateConfigurationRequest {
+    pub fn new() -> UpdateConfigurationRequest {
+        ::std::default::Default::default()
+    }
+
+    fn generated_message_descriptor_data() -> ::protobuf::reflect::GeneratedMessageDescriptorData {
+        let mut fields = ::std::vec::Vec::with_capacity(1);
+        let mut oneofs = ::std::vec::Vec::with_capacity(0);
+        fields.push(::protobuf::reflect::rt::v2::make_simpler_field_accessor::<_, _>(
+            "config",
+            |m: &UpdateConfigurationRequest| { &m.config },
+            |m: &mut UpdateConfigurationRequest| { &mut m.config },
+        ));
+        ::protobuf::reflect::GeneratedMessageDescriptorData::new_2::<UpdateConfigurationRequest>(
+            "UpdateConfigurationRequest",
+            fields,
+            oneofs,
+        )
+    }
+}
+
+impl ::protobuf::Message for UpdateConfigurationRequest {
+    const NAME: &'static str = "UpdateConfigurationRequest";
+
+    fn is_initialized(&self) -> bool {
+        true
+    }
+
+    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream<'_>) -> ::protobuf::Result<()> {
+        while let Some(tag) = is.read_raw_tag_or_eof()? {
+            match tag {
+                10 => {
+                    self.config = is.read_string()?;
+                },
+                tag => {
+                    ::protobuf::rt::read_unknown_or_skip_group(tag, is, self.special_fields.mut_unknown_fields())?;
+                },
+            };
+        }
+        ::std::result::Result::Ok(())
+    }
+
+    // Compute sizes of nested messages
+    #[allow(unused_variables)]
+    fn compute_size(&self) -> u64 {
+        let mut my_size = 0;
+        if !self.config.is_empty() {
+            my_size += ::protobuf::rt::string_size(1, &self.config);
+        }
+        my_size += ::protobuf::rt::unknown_fields_size(self.special_fields.unknown_fields());
+        self.special_fields.cached_size().set(my_size as u32);
+        my_size
+    }
+
+    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream<'_>) -> ::protobuf::Result<()> {
+        if !self.config.is_empty() {
+            os.write_string(1, &self.config)?;
+        }
+        os.write_unknown_fields(self.special_fields.unknown_fields())?;
+        ::std::result::Result::Ok(())
+    }
+
+    fn special_fields(&self) -> &::protobuf::SpecialFields {
+        &self.special_fields
+    }
+
+    fn mut_special_fields(&mut self) -> &mut ::protobuf::SpecialFields {
+        &mut self.special_fields
+    }
+
+    fn new() -> UpdateConfigurationRequest {
+        UpdateConfigurationRequest::new()
+    }
+
+    fn clear(&mut self) {
+        self.config.clear();
+        self.special_fields.clear();
+    }
+
+    fn default_instance() -> &'static UpdateConfigurationRequest {
+        static instance: UpdateConfigurationRequest = UpdateConfigurationRequest {
+            config: ::std::string::String::new(),
+            special_fields: ::protobuf::SpecialFields::new(),
+        };
+        &instance
+    }
+}
+
+impl ::protobuf::MessageFull for UpdateConfigurationRequest {
+    fn descriptor() -> ::protobuf::reflect::MessageDescriptor {
+        static descriptor: ::protobuf::rt::Lazy<::protobuf::reflect::MessageDescriptor> = ::protobuf::rt::Lazy::new();
+        descriptor.get(|| file_descriptor().message_by_package_relative_name("UpdateConfigurationRequest").unwrap()).clone()
+    }
+}
+
+impl ::std::fmt::Display for UpdateConfigurationRequest {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+        ::protobuf::text_format::fmt(self, f)
+    }
+}
+
+impl ::protobuf::reflect::ProtobufValue for UpdateConfigurationRequest {
+    type RuntimeType = ::protobuf::reflect::rt::RuntimeTypeMessage<Self>;
+}
+
+// @@protoc_insertion_point(message:attestation_agent.UpdateConfigurationResponse)
+#[derive(PartialEq,Clone,Default,Debug)]
+pub struct UpdateConfigurationResponse {
+    // special fields
+    // @@protoc_insertion_point(special_field:attestation_agent.UpdateConfigurationResponse.special_fields)
+    pub special_fields: ::protobuf::SpecialFields,
+}
+
+impl<'a> ::std::default::Default for &'a UpdateConfigurationResponse {
+    fn default() -> &'a UpdateConfigurationResponse {
+        <UpdateConfigurationResponse as ::protobuf::Message>::default_instance()
+    }
+}
+
+impl UpdateConfigurationResponse {
+    pub fn new() -> UpdateConfigurationResponse {
+        ::std::default::Default::default()
+    }
+
+    fn generated_message_descriptor_data() -> ::protobuf::reflect::GeneratedMessageDescriptorData {
+        let mut fields = ::std::vec::Vec::with_capacity(0);
+        let mut oneofs = ::std::vec::Vec::with_capacity(0);
+        ::protobuf::reflect::GeneratedMessageDescriptorData::new_2::<UpdateConfigurationResponse>(
+            "UpdateConfigurationResponse",
+            fields,
+            oneofs,
+        )
+    }
+}
+
+impl ::protobuf::Message for UpdateConfigurationResponse {
+    const NAME: &'static str = "UpdateConfigurationResponse";
+
+    fn is_initialized(&self) -> bool {
+        true
+    }
+
+    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream<'_>) -> ::protobuf::Result<()> {
+        while let Some(tag) = is.read_raw_tag_or_eof()? {
+            match tag {
+                tag => {
+                    ::protobuf::rt::read_unknown_or_skip_group(tag, is, self.special_fields.mut_unknown_fields())?;
+                },
+            };
+        }
+        ::std::result::Result::Ok(())
+    }
+
+    // Compute sizes of nested messages
+    #[allow(unused_variables)]
+    fn compute_size(&self) -> u64 {
+        let mut my_size = 0;
+        my_size += ::protobuf::rt::unknown_fields_size(self.special_fields.unknown_fields());
+        self.special_fields.cached_size().set(my_size as u32);
+        my_size
+    }
+
+    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream<'_>) -> ::protobuf::Result<()> {
+        os.write_unknown_fields(self.special_fields.unknown_fields())?;
+        ::std::result::Result::Ok(())
+    }
+
+    fn special_fields(&self) -> &::protobuf::SpecialFields {
+        &self.special_fields
+    }
+
+    fn mut_special_fields(&mut self) -> &mut ::protobuf::SpecialFields {
+        &mut self.special_fields
+    }
+
+    fn new() -> UpdateConfigurationResponse {
+        UpdateConfigurationResponse::new()
+    }
+
+    fn clear(&mut self) {
+        self.special_fields.clear();
+    }
+
+    fn default_instance() -> &'static UpdateConfigurationResponse {
+        static instance: UpdateConfigurationResponse = UpdateConfigurationResponse {
+            special_fields: ::protobuf::SpecialFields::new(),
+        };
+        &instance
+    }
+}
+
+impl ::protobuf::MessageFull for UpdateConfigurationResponse {
+    fn descriptor() -> ::protobuf::reflect::MessageDescriptor {
+        static descriptor: ::protobuf::rt::Lazy<::protobuf::reflect::MessageDescriptor> = ::protobuf::rt::Lazy::new();
+        descriptor.get(|| file_descriptor().message_by_package_relative_name("UpdateConfigurationResponse").unwrap()).clone()
+    }
+}
+
+impl ::std::fmt::Display for UpdateConfigurationResponse {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+        ::protobuf::text_format::fmt(self, f)
+    }
+}
+
+impl ::protobuf::reflect::ProtobufValue for UpdateConfigurationResponse {
+    type RuntimeType = ::protobuf::reflect::rt::RuntimeTypeMessage<Self>;
+}
+
 static file_descriptor_proto_data: &'static [u8] = b"\
     \n\x17attestation-agent.proto\x12\x11attestation_agent\"6\n\x12GetEviden\
     ceRequest\x12\x20\n\x0bRuntimeData\x18\x01\x20\x01(\x0cR\x0bRuntimeData\
@@ -1134,14 +1359,17 @@ static file_descriptor_proto_data: &'static [u8] = b"\
     \x12\x18\n\x07Content\x18\x01\x20\x01(\x0cR\x07Content\x12\x1c\n\tAlgori\
     thm\x18\x02\x20\x01(\tR\tAlgorithm\".\n\x14CheckInitDataRequest\x12\x16\
     \n\x06Digest\x18\x01\x20\x01(\x0cR\x06Digest\"\x17\n\x15CheckInitDataRes\
-    ponse2\xb6\x03\n\x17AttestationAgentService\x12\\\n\x0bGetEvidence\x12%.\
-    attestation_agent.GetEvidenceRequest\x1a&.attestation_agent.GetEvidenceR\
-    esponse\x12S\n\x08GetToken\x12\".attestation_agent.GetTokenRequest\x1a#.\
-    attestation_agent.GetTokenResponse\x12\x83\x01\n\x18ExtendRuntimeMeasure\
-    ment\x122.attestation_agent.ExtendRuntimeMeasurementRequest\x1a3.attesta\
-    tion_agent.ExtendRuntimeMeasurementResponse\x12b\n\rCheckInitData\x12'.a\
-    ttestation_agent.CheckInitDataRequest\x1a(.attestation_agent.CheckInitDa\
-    taResponseb\x06proto3\
+    ponse\"4\n\x1aUpdateConfigurationRequest\x12\x16\n\x06config\x18\x01\x20\
+    \x01(\tR\x06config\"\x1d\n\x1bUpdateConfigurationResponse2\xac\x04\n\x17\
+    AttestationAgentService\x12\\\n\x0bGetEvidence\x12%.attestation_agent.Ge\
+    tEvidenceRequest\x1a&.attestation_agent.GetEvidenceResponse\x12S\n\x08Ge\
+    tToken\x12\".attestation_agent.GetTokenRequest\x1a#.attestation_agent.Ge\
+    tTokenResponse\x12\x83\x01\n\x18ExtendRuntimeMeasurement\x122.attestatio\
+    n_agent.ExtendRuntimeMeasurementRequest\x1a3.attestation_agent.ExtendRun\
+    timeMeasurementResponse\x12b\n\rCheckInitData\x12'.attestation_agent.Che\
+    ckInitDataRequest\x1a(.attestation_agent.CheckInitDataResponse\x12t\n\
+    \x13UpdateConfiguration\x12-.attestation_agent.UpdateConfigurationReques\
+    t\x1a..attestation_agent.UpdateConfigurationResponseb\x06proto3\
 ";
 
 /// `FileDescriptorProto` object which was a source for this generated file
@@ -1159,7 +1387,7 @@ pub fn file_descriptor() -> &'static ::protobuf::reflect::FileDescriptor {
     file_descriptor.get(|| {
         let generated_file_descriptor = generated_file_descriptor_lazy.get(|| {
             let mut deps = ::std::vec::Vec::with_capacity(0);
-            let mut messages = ::std::vec::Vec::with_capacity(9);
+            let mut messages = ::std::vec::Vec::with_capacity(11);
             messages.push(GetEvidenceRequest::generated_message_descriptor_data());
             messages.push(GetEvidenceResponse::generated_message_descriptor_data());
             messages.push(GetTokenRequest::generated_message_descriptor_data());
@@ -1169,6 +1397,8 @@ pub fn file_descriptor() -> &'static ::protobuf::reflect::FileDescriptor {
             messages.push(InitDataPlaintext::generated_message_descriptor_data());
             messages.push(CheckInitDataRequest::generated_message_descriptor_data());
             messages.push(CheckInitDataResponse::generated_message_descriptor_data());
+            messages.push(UpdateConfigurationRequest::generated_message_descriptor_data());
+            messages.push(UpdateConfigurationResponse::generated_message_descriptor_data());
             let mut enums = ::std::vec::Vec::with_capacity(0);
             ::protobuf::reflect::GeneratedFileDescriptor::new_generated(
                 file_descriptor_proto(),

--- a/attestation-agent/attestation-agent/src/bin/ttrpc-aa/ttrpc_protocol/attestation_agent_ttrpc.rs
+++ b/attestation-agent/attestation-agent/src/bin/ttrpc-aa/ttrpc_protocol/attestation_agent_ttrpc.rs
@@ -51,6 +51,11 @@ impl AttestationAgentServiceClient {
         let mut cres = super::attestation_agent::CheckInitDataResponse::new();
         ::ttrpc::async_client_request!(self, ctx, req, "attestation_agent.AttestationAgentService", "CheckInitData", cres);
     }
+
+    pub async fn update_configuration(&self, ctx: ttrpc::context::Context, req: &super::attestation_agent::UpdateConfigurationRequest) -> ::ttrpc::Result<super::attestation_agent::UpdateConfigurationResponse> {
+        let mut cres = super::attestation_agent::UpdateConfigurationResponse::new();
+        ::ttrpc::async_client_request!(self, ctx, req, "attestation_agent.AttestationAgentService", "UpdateConfiguration", cres);
+    }
 }
 
 struct GetEvidenceMethod {
@@ -97,6 +102,17 @@ impl ::ttrpc::r#async::MethodHandler for CheckInitDataMethod {
     }
 }
 
+struct UpdateConfigurationMethod {
+    service: Arc<Box<dyn AttestationAgentService + Send + Sync>>,
+}
+
+#[async_trait]
+impl ::ttrpc::r#async::MethodHandler for UpdateConfigurationMethod {
+    async fn handler(&self, ctx: ::ttrpc::r#async::TtrpcContext, req: ::ttrpc::Request) -> ::ttrpc::Result<::ttrpc::Response> {
+        ::ttrpc::async_request_handler!(self, ctx, req, attestation_agent, UpdateConfigurationRequest, update_configuration);
+    }
+}
+
 #[async_trait]
 pub trait AttestationAgentService: Sync {
     async fn get_evidence(&self, _ctx: &::ttrpc::r#async::TtrpcContext, _: super::attestation_agent::GetEvidenceRequest) -> ::ttrpc::Result<super::attestation_agent::GetEvidenceResponse> {
@@ -110,6 +126,9 @@ pub trait AttestationAgentService: Sync {
     }
     async fn check_init_data(&self, _ctx: &::ttrpc::r#async::TtrpcContext, _: super::attestation_agent::CheckInitDataRequest) -> ::ttrpc::Result<super::attestation_agent::CheckInitDataResponse> {
         Err(::ttrpc::Error::RpcStatus(::ttrpc::get_status(::ttrpc::Code::NOT_FOUND, "/attestation_agent.AttestationAgentService/CheckInitData is not supported".to_string())))
+    }
+    async fn update_configuration(&self, _ctx: &::ttrpc::r#async::TtrpcContext, _: super::attestation_agent::UpdateConfigurationRequest) -> ::ttrpc::Result<super::attestation_agent::UpdateConfigurationResponse> {
+        Err(::ttrpc::Error::RpcStatus(::ttrpc::get_status(::ttrpc::Code::NOT_FOUND, "/attestation_agent.AttestationAgentService/UpdateConfiguration is not supported".to_string())))
     }
 }
 
@@ -129,6 +148,9 @@ pub fn create_attestation_agent_service(service: Arc<Box<dyn AttestationAgentSer
 
     methods.insert("CheckInitData".to_string(),
                     Box::new(CheckInitDataMethod{service: service.clone()}) as Box<dyn ::ttrpc::r#async::MethodHandler + Send + Sync>);
+
+    methods.insert("UpdateConfiguration".to_string(),
+                    Box::new(UpdateConfigurationMethod{service: service.clone()}) as Box<dyn ::ttrpc::r#async::MethodHandler + Send + Sync>);
 
     ret.insert("attestation_agent.AttestationAgentService".to_string(), ::ttrpc::r#async::Service{ methods, streams });
     ret

--- a/attestation-agent/kbs_protocol/src/token_provider/aa/attestation_agent.rs
+++ b/attestation-agent/kbs_protocol/src/token_provider/aa/attestation_agent.rs
@@ -1121,6 +1121,231 @@ impl ::protobuf::reflect::ProtobufValue for CheckInitDataResponse {
     type RuntimeType = ::protobuf::reflect::rt::RuntimeTypeMessage<Self>;
 }
 
+// @@protoc_insertion_point(message:attestation_agent.UpdateConfigurationRequest)
+#[derive(PartialEq,Clone,Default,Debug)]
+pub struct UpdateConfigurationRequest {
+    // message fields
+    // @@protoc_insertion_point(field:attestation_agent.UpdateConfigurationRequest.config)
+    pub config: ::std::string::String,
+    // special fields
+    // @@protoc_insertion_point(special_field:attestation_agent.UpdateConfigurationRequest.special_fields)
+    pub special_fields: ::protobuf::SpecialFields,
+}
+
+impl<'a> ::std::default::Default for &'a UpdateConfigurationRequest {
+    fn default() -> &'a UpdateConfigurationRequest {
+        <UpdateConfigurationRequest as ::protobuf::Message>::default_instance()
+    }
+}
+
+impl UpdateConfigurationRequest {
+    pub fn new() -> UpdateConfigurationRequest {
+        ::std::default::Default::default()
+    }
+
+    fn generated_message_descriptor_data() -> ::protobuf::reflect::GeneratedMessageDescriptorData {
+        let mut fields = ::std::vec::Vec::with_capacity(1);
+        let mut oneofs = ::std::vec::Vec::with_capacity(0);
+        fields.push(::protobuf::reflect::rt::v2::make_simpler_field_accessor::<_, _>(
+            "config",
+            |m: &UpdateConfigurationRequest| { &m.config },
+            |m: &mut UpdateConfigurationRequest| { &mut m.config },
+        ));
+        ::protobuf::reflect::GeneratedMessageDescriptorData::new_2::<UpdateConfigurationRequest>(
+            "UpdateConfigurationRequest",
+            fields,
+            oneofs,
+        )
+    }
+}
+
+impl ::protobuf::Message for UpdateConfigurationRequest {
+    const NAME: &'static str = "UpdateConfigurationRequest";
+
+    fn is_initialized(&self) -> bool {
+        true
+    }
+
+    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream<'_>) -> ::protobuf::Result<()> {
+        while let Some(tag) = is.read_raw_tag_or_eof()? {
+            match tag {
+                10 => {
+                    self.config = is.read_string()?;
+                },
+                tag => {
+                    ::protobuf::rt::read_unknown_or_skip_group(tag, is, self.special_fields.mut_unknown_fields())?;
+                },
+            };
+        }
+        ::std::result::Result::Ok(())
+    }
+
+    // Compute sizes of nested messages
+    #[allow(unused_variables)]
+    fn compute_size(&self) -> u64 {
+        let mut my_size = 0;
+        if !self.config.is_empty() {
+            my_size += ::protobuf::rt::string_size(1, &self.config);
+        }
+        my_size += ::protobuf::rt::unknown_fields_size(self.special_fields.unknown_fields());
+        self.special_fields.cached_size().set(my_size as u32);
+        my_size
+    }
+
+    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream<'_>) -> ::protobuf::Result<()> {
+        if !self.config.is_empty() {
+            os.write_string(1, &self.config)?;
+        }
+        os.write_unknown_fields(self.special_fields.unknown_fields())?;
+        ::std::result::Result::Ok(())
+    }
+
+    fn special_fields(&self) -> &::protobuf::SpecialFields {
+        &self.special_fields
+    }
+
+    fn mut_special_fields(&mut self) -> &mut ::protobuf::SpecialFields {
+        &mut self.special_fields
+    }
+
+    fn new() -> UpdateConfigurationRequest {
+        UpdateConfigurationRequest::new()
+    }
+
+    fn clear(&mut self) {
+        self.config.clear();
+        self.special_fields.clear();
+    }
+
+    fn default_instance() -> &'static UpdateConfigurationRequest {
+        static instance: UpdateConfigurationRequest = UpdateConfigurationRequest {
+            config: ::std::string::String::new(),
+            special_fields: ::protobuf::SpecialFields::new(),
+        };
+        &instance
+    }
+}
+
+impl ::protobuf::MessageFull for UpdateConfigurationRequest {
+    fn descriptor() -> ::protobuf::reflect::MessageDescriptor {
+        static descriptor: ::protobuf::rt::Lazy<::protobuf::reflect::MessageDescriptor> = ::protobuf::rt::Lazy::new();
+        descriptor.get(|| file_descriptor().message_by_package_relative_name("UpdateConfigurationRequest").unwrap()).clone()
+    }
+}
+
+impl ::std::fmt::Display for UpdateConfigurationRequest {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+        ::protobuf::text_format::fmt(self, f)
+    }
+}
+
+impl ::protobuf::reflect::ProtobufValue for UpdateConfigurationRequest {
+    type RuntimeType = ::protobuf::reflect::rt::RuntimeTypeMessage<Self>;
+}
+
+// @@protoc_insertion_point(message:attestation_agent.UpdateConfigurationResponse)
+#[derive(PartialEq,Clone,Default,Debug)]
+pub struct UpdateConfigurationResponse {
+    // special fields
+    // @@protoc_insertion_point(special_field:attestation_agent.UpdateConfigurationResponse.special_fields)
+    pub special_fields: ::protobuf::SpecialFields,
+}
+
+impl<'a> ::std::default::Default for &'a UpdateConfigurationResponse {
+    fn default() -> &'a UpdateConfigurationResponse {
+        <UpdateConfigurationResponse as ::protobuf::Message>::default_instance()
+    }
+}
+
+impl UpdateConfigurationResponse {
+    pub fn new() -> UpdateConfigurationResponse {
+        ::std::default::Default::default()
+    }
+
+    fn generated_message_descriptor_data() -> ::protobuf::reflect::GeneratedMessageDescriptorData {
+        let mut fields = ::std::vec::Vec::with_capacity(0);
+        let mut oneofs = ::std::vec::Vec::with_capacity(0);
+        ::protobuf::reflect::GeneratedMessageDescriptorData::new_2::<UpdateConfigurationResponse>(
+            "UpdateConfigurationResponse",
+            fields,
+            oneofs,
+        )
+    }
+}
+
+impl ::protobuf::Message for UpdateConfigurationResponse {
+    const NAME: &'static str = "UpdateConfigurationResponse";
+
+    fn is_initialized(&self) -> bool {
+        true
+    }
+
+    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream<'_>) -> ::protobuf::Result<()> {
+        while let Some(tag) = is.read_raw_tag_or_eof()? {
+            match tag {
+                tag => {
+                    ::protobuf::rt::read_unknown_or_skip_group(tag, is, self.special_fields.mut_unknown_fields())?;
+                },
+            };
+        }
+        ::std::result::Result::Ok(())
+    }
+
+    // Compute sizes of nested messages
+    #[allow(unused_variables)]
+    fn compute_size(&self) -> u64 {
+        let mut my_size = 0;
+        my_size += ::protobuf::rt::unknown_fields_size(self.special_fields.unknown_fields());
+        self.special_fields.cached_size().set(my_size as u32);
+        my_size
+    }
+
+    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream<'_>) -> ::protobuf::Result<()> {
+        os.write_unknown_fields(self.special_fields.unknown_fields())?;
+        ::std::result::Result::Ok(())
+    }
+
+    fn special_fields(&self) -> &::protobuf::SpecialFields {
+        &self.special_fields
+    }
+
+    fn mut_special_fields(&mut self) -> &mut ::protobuf::SpecialFields {
+        &mut self.special_fields
+    }
+
+    fn new() -> UpdateConfigurationResponse {
+        UpdateConfigurationResponse::new()
+    }
+
+    fn clear(&mut self) {
+        self.special_fields.clear();
+    }
+
+    fn default_instance() -> &'static UpdateConfigurationResponse {
+        static instance: UpdateConfigurationResponse = UpdateConfigurationResponse {
+            special_fields: ::protobuf::SpecialFields::new(),
+        };
+        &instance
+    }
+}
+
+impl ::protobuf::MessageFull for UpdateConfigurationResponse {
+    fn descriptor() -> ::protobuf::reflect::MessageDescriptor {
+        static descriptor: ::protobuf::rt::Lazy<::protobuf::reflect::MessageDescriptor> = ::protobuf::rt::Lazy::new();
+        descriptor.get(|| file_descriptor().message_by_package_relative_name("UpdateConfigurationResponse").unwrap()).clone()
+    }
+}
+
+impl ::std::fmt::Display for UpdateConfigurationResponse {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+        ::protobuf::text_format::fmt(self, f)
+    }
+}
+
+impl ::protobuf::reflect::ProtobufValue for UpdateConfigurationResponse {
+    type RuntimeType = ::protobuf::reflect::rt::RuntimeTypeMessage<Self>;
+}
+
 static file_descriptor_proto_data: &'static [u8] = b"\
     \n\x17attestation-agent.proto\x12\x11attestation_agent\"6\n\x12GetEviden\
     ceRequest\x12\x20\n\x0bRuntimeData\x18\x01\x20\x01(\x0cR\x0bRuntimeData\
@@ -1134,14 +1359,17 @@ static file_descriptor_proto_data: &'static [u8] = b"\
     \x12\x18\n\x07Content\x18\x01\x20\x01(\x0cR\x07Content\x12\x1c\n\tAlgori\
     thm\x18\x02\x20\x01(\tR\tAlgorithm\".\n\x14CheckInitDataRequest\x12\x16\
     \n\x06Digest\x18\x01\x20\x01(\x0cR\x06Digest\"\x17\n\x15CheckInitDataRes\
-    ponse2\xb6\x03\n\x17AttestationAgentService\x12\\\n\x0bGetEvidence\x12%.\
-    attestation_agent.GetEvidenceRequest\x1a&.attestation_agent.GetEvidenceR\
-    esponse\x12S\n\x08GetToken\x12\".attestation_agent.GetTokenRequest\x1a#.\
-    attestation_agent.GetTokenResponse\x12\x83\x01\n\x18ExtendRuntimeMeasure\
-    ment\x122.attestation_agent.ExtendRuntimeMeasurementRequest\x1a3.attesta\
-    tion_agent.ExtendRuntimeMeasurementResponse\x12b\n\rCheckInitData\x12'.a\
-    ttestation_agent.CheckInitDataRequest\x1a(.attestation_agent.CheckInitDa\
-    taResponseb\x06proto3\
+    ponse\"4\n\x1aUpdateConfigurationRequest\x12\x16\n\x06config\x18\x01\x20\
+    \x01(\tR\x06config\"\x1d\n\x1bUpdateConfigurationResponse2\xac\x04\n\x17\
+    AttestationAgentService\x12\\\n\x0bGetEvidence\x12%.attestation_agent.Ge\
+    tEvidenceRequest\x1a&.attestation_agent.GetEvidenceResponse\x12S\n\x08Ge\
+    tToken\x12\".attestation_agent.GetTokenRequest\x1a#.attestation_agent.Ge\
+    tTokenResponse\x12\x83\x01\n\x18ExtendRuntimeMeasurement\x122.attestatio\
+    n_agent.ExtendRuntimeMeasurementRequest\x1a3.attestation_agent.ExtendRun\
+    timeMeasurementResponse\x12b\n\rCheckInitData\x12'.attestation_agent.Che\
+    ckInitDataRequest\x1a(.attestation_agent.CheckInitDataResponse\x12t\n\
+    \x13UpdateConfiguration\x12-.attestation_agent.UpdateConfigurationReques\
+    t\x1a..attestation_agent.UpdateConfigurationResponseb\x06proto3\
 ";
 
 /// `FileDescriptorProto` object which was a source for this generated file
@@ -1159,7 +1387,7 @@ pub fn file_descriptor() -> &'static ::protobuf::reflect::FileDescriptor {
     file_descriptor.get(|| {
         let generated_file_descriptor = generated_file_descriptor_lazy.get(|| {
             let mut deps = ::std::vec::Vec::with_capacity(0);
-            let mut messages = ::std::vec::Vec::with_capacity(9);
+            let mut messages = ::std::vec::Vec::with_capacity(11);
             messages.push(GetEvidenceRequest::generated_message_descriptor_data());
             messages.push(GetEvidenceResponse::generated_message_descriptor_data());
             messages.push(GetTokenRequest::generated_message_descriptor_data());
@@ -1169,6 +1397,8 @@ pub fn file_descriptor() -> &'static ::protobuf::reflect::FileDescriptor {
             messages.push(InitDataPlaintext::generated_message_descriptor_data());
             messages.push(CheckInitDataRequest::generated_message_descriptor_data());
             messages.push(CheckInitDataResponse::generated_message_descriptor_data());
+            messages.push(UpdateConfigurationRequest::generated_message_descriptor_data());
+            messages.push(UpdateConfigurationResponse::generated_message_descriptor_data());
             let mut enums = ::std::vec::Vec::with_capacity(0);
             ::protobuf::reflect::GeneratedFileDescriptor::new_generated(
                 file_descriptor_proto(),

--- a/attestation-agent/kbs_protocol/src/token_provider/aa/attestation_agent_ttrpc.rs
+++ b/attestation-agent/kbs_protocol/src/token_provider/aa/attestation_agent_ttrpc.rs
@@ -51,6 +51,11 @@ impl AttestationAgentServiceClient {
         let mut cres = super::attestation_agent::CheckInitDataResponse::new();
         ::ttrpc::async_client_request!(self, ctx, req, "attestation_agent.AttestationAgentService", "CheckInitData", cres);
     }
+
+    pub async fn update_configuration(&self, ctx: ttrpc::context::Context, req: &super::attestation_agent::UpdateConfigurationRequest) -> ::ttrpc::Result<super::attestation_agent::UpdateConfigurationResponse> {
+        let mut cres = super::attestation_agent::UpdateConfigurationResponse::new();
+        ::ttrpc::async_client_request!(self, ctx, req, "attestation_agent.AttestationAgentService", "UpdateConfiguration", cres);
+    }
 }
 
 struct GetEvidenceMethod {
@@ -97,6 +102,17 @@ impl ::ttrpc::r#async::MethodHandler for CheckInitDataMethod {
     }
 }
 
+struct UpdateConfigurationMethod {
+    service: Arc<Box<dyn AttestationAgentService + Send + Sync>>,
+}
+
+#[async_trait]
+impl ::ttrpc::r#async::MethodHandler for UpdateConfigurationMethod {
+    async fn handler(&self, ctx: ::ttrpc::r#async::TtrpcContext, req: ::ttrpc::Request) -> ::ttrpc::Result<::ttrpc::Response> {
+        ::ttrpc::async_request_handler!(self, ctx, req, attestation_agent, UpdateConfigurationRequest, update_configuration);
+    }
+}
+
 #[async_trait]
 pub trait AttestationAgentService: Sync {
     async fn get_evidence(&self, _ctx: &::ttrpc::r#async::TtrpcContext, _: super::attestation_agent::GetEvidenceRequest) -> ::ttrpc::Result<super::attestation_agent::GetEvidenceResponse> {
@@ -110,6 +126,9 @@ pub trait AttestationAgentService: Sync {
     }
     async fn check_init_data(&self, _ctx: &::ttrpc::r#async::TtrpcContext, _: super::attestation_agent::CheckInitDataRequest) -> ::ttrpc::Result<super::attestation_agent::CheckInitDataResponse> {
         Err(::ttrpc::Error::RpcStatus(::ttrpc::get_status(::ttrpc::Code::NOT_FOUND, "/attestation_agent.AttestationAgentService/CheckInitData is not supported".to_string())))
+    }
+    async fn update_configuration(&self, _ctx: &::ttrpc::r#async::TtrpcContext, _: super::attestation_agent::UpdateConfigurationRequest) -> ::ttrpc::Result<super::attestation_agent::UpdateConfigurationResponse> {
+        Err(::ttrpc::Error::RpcStatus(::ttrpc::get_status(::ttrpc::Code::NOT_FOUND, "/attestation_agent.AttestationAgentService/UpdateConfiguration is not supported".to_string())))
     }
 }
 
@@ -129,6 +148,9 @@ pub fn create_attestation_agent_service(service: Arc<Box<dyn AttestationAgentSer
 
     methods.insert("CheckInitData".to_string(),
                     Box::new(CheckInitDataMethod{service: service.clone()}) as Box<dyn ::ttrpc::r#async::MethodHandler + Send + Sync>);
+
+    methods.insert("UpdateConfiguration".to_string(),
+                    Box::new(UpdateConfigurationMethod{service: service.clone()}) as Box<dyn ::ttrpc::r#async::MethodHandler + Send + Sync>);
 
     ret.insert("attestation_agent.AttestationAgentService".to_string(), ::ttrpc::r#async::Service{ methods, streams });
     ret

--- a/attestation-agent/protos/attestation-agent.proto
+++ b/attestation-agent/protos/attestation-agent.proto
@@ -36,9 +36,20 @@ message CheckInitDataRequest {
 
 message CheckInitDataResponse {}
 
+message UpdateConfigurationRequest {
+    string config = 1;
+}
+
+message UpdateConfigurationResponse {}
+
 service AttestationAgentService {
     rpc GetEvidence(GetEvidenceRequest) returns (GetEvidenceResponse) {};
     rpc GetToken(GetTokenRequest) returns (GetTokenResponse) {};
     rpc ExtendRuntimeMeasurement(ExtendRuntimeMeasurementRequest) returns (ExtendRuntimeMeasurementResponse) {};
     rpc CheckInitData(CheckInitDataRequest) returns (CheckInitDataResponse) {};
+
+    // This is a workaround API for initdata in CoCo. Once
+    // a better design is implemented we can deprecate the API.
+    // See https://github.com/kata-containers/kata-containers/issues/9468
+    rpc UpdateConfiguration(UpdateConfigurationRequest) returns (UpdateConfigurationResponse) {};
 }


### PR DESCRIPTION
As discussed, this API is a workaround API for CoCo to apply initdata proposal. Once we agree on a better way (like systemd scheme), we can deprecate the API.

See https://github.com/kata-containers/kata-containers/issues/9468

cc @fitzthum 