### PR TITLE
Support gzip.multiple_members

### DIFF
--- a/image-rs/src/decoder/mod.rs
+++ b/image-rs/src/decoder/mod.rs
@@ -60,9 +60,12 @@ impl Compression {
         input: (impl AsyncRead + Unpin + 'a + Send),
     ) -> Box<dyn AsyncRead + Unpin + 'a + Send> {
         match self {
-            Self::Gzip => Box::new(async_compression::tokio::bufread::GzipDecoder::new(
-                BufReader::new(input),
-            )),
+            Self::Gzip => {
+                let mut gzip =
+                    async_compression::tokio::bufread::GzipDecoder::new(BufReader::new(input));
+                gzip.multiple_members(true);
+                Box::new(gzip)
+            }
             Self::Zstd => Box::new(async_compression::tokio::bufread::ZstdDecoder::new(
                 BufReader::new(input),
             )),


### PR DESCRIPTION
Images like `cgr.dev/chainguard/busybox` built using gzip directly might legitimately be using gzip multiple members. This really has to be supported to have broad compatibility with docker images as this style is prevalent in the distroless community.