### PR TITLE
Gzip should preserve ownership/permissions

### DIFF
--- a/image-rs/src/stream.rs
+++ b/image-rs/src/stream.rs
@@ -135,6 +135,8 @@ mod tests {
         let mut header = Header::new_gnu();
         header.set_size(100000);
         header.set_cksum();
+        header.set_uid(0);
+        header.set_gid(0);
         ar.append_data(&mut header, "file.txt", data.as_slice())
             .unwrap();
 
@@ -175,6 +177,8 @@ mod tests {
         let mut header = Header::new_gnu();
         header.set_size(100000);
         header.set_cksum();
+        header.set_uid(0);
+        header.set_gid(0);
         ar.append_data(&mut header, "file.txt", data.as_slice())
             .unwrap();
 

--- a/image-rs/src/unpack.rs
+++ b/image-rs/src/unpack.rs
@@ -16,6 +16,8 @@ use tar::Archive;
 /// Unpack the contents of tarball to the destination path
 pub fn unpack<R: io::Read>(input: R, destination: &Path) -> Result<()> {
     let mut archive = Archive::new(input);
+    archive.set_preserve_ownerships(true);
+    archive.set_preserve_permissions(true);
 
     if destination.exists() {
         warn!(


### PR DESCRIPTION
This is necessary to support images using non-root users and a mixture of runtime users.