### PR TITLE
tdx-attester: make DCAP libs optional

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -322,6 +322,7 @@ dependencies = [
  "az-snp-vtpm",
  "az-tdx-vtpm",
  "base64 0.21.7",
+ "cfg-if",
  "codicon",
  "csv-rs",
  "hyper",

--- a/attestation-agent/attester/Cargo.toml
+++ b/attestation-agent/attester/Cargo.toml
@@ -10,6 +10,7 @@ anyhow.workspace = true
 async-trait.workspace = true
 az-snp-vtpm = { version = "0.5.3", default-features = false, features = ["attester"], optional = true }
 az-tdx-vtpm = { version = "0.5.3", default-features = false, features = ["attester"], optional = true }
+cfg-if.workspace = true
 base64.workspace = true
 kbs-types.workspace = true
 log.workspace = true
@@ -54,10 +55,11 @@ all-attesters = [
 ]
 
 # tsm-report enables a module that helps attesters to use Linux TSM_REPORTS for generating
-# quotes. It's an unconditional dependency for tdx-attester since that is the only way to
+# quotes. It's an unconditional dependency for tdx-attester since that is the preferred way to
 # generate TDX quotes with upstream kernels.
 tsm-report = ["tempfile"]
-tdx-attester = ["scroll", "tsm-report", "tdx-attest-rs"]
+tdx-attester = ["tsm-report", "tdx-dcap-extras"]
+tdx-dcap-extras = ["scroll", "tdx-attest-rs"]
 sgx-attester = ["occlum_dcap"]
 az-snp-vtpm-attester = ["az-snp-vtpm"]
 az-tdx-vtpm-attester = ["az-tdx-vtpm"]

--- a/attestation-agent/attester/Cargo.toml
+++ b/attestation-agent/attester/Cargo.toml
@@ -65,4 +65,4 @@ snp-attester = ["sev"]
 csv-attester = ["csv-rs", "codicon", "hyper", "hyper-tls", "tokio"]
 cca-attester = ["nix"]
 
-bin = ["tokio/rt", "tokio/macros", "all-attesters"]
+bin = ["tokio/rt", "tokio/macros", "codicon"]

--- a/attestation-agent/attester/src/tdx/mod.rs
+++ b/attestation-agent/attester/src/tdx/mod.rs
@@ -24,13 +24,7 @@ const CCEL_PATH: &str = "/sys/firmware/acpi/tables/data/CCEL";
 const RUNTIME_MEASUREMENT_RTMR_INDEX: u64 = 2;
 
 pub fn detect_platform() -> bool {
-    TsmReportPath::new(TsmReportProvider::Tdx).is_ok() || tdx_getquote_ioctl_is_available()
-}
-
-fn tdx_getquote_ioctl_is_available() -> bool {
-    Path::new("/dev/tdx-attest").exists()
-        || Path::new("/dev/tdx-guest").exists()
-        || Path::new("/dev/tdx_guest").exists()
+    TsmReportPath::new(TsmReportProvider::Tdx).is_ok() || Path::new("/dev/tdx_guest").exists()
 }
 
 fn get_quote_ioctl(report_data: &Vec<u8>) -> Result<Vec<u8>> {
@@ -47,16 +41,6 @@ fn get_quote_ioctl(report_data: &Vec<u8>) -> Result<Vec<u8>> {
             error_code
         )),
     }
-}
-
-// Return true if the TD environment can extend runtime measurement,
-// else false.
-fn runtime_measurement_extend_available() -> bool {
-    if Path::new("/dev/tdx_guest").exists() || Path::new("/sys/kernel/config/tsm/report").exists() {
-        return false;
-    }
-
-    true
 }
 
 #[derive(Serialize, Deserialize)]
@@ -112,7 +96,9 @@ impl Attester for TdxAttester {
         events: Vec<Vec<u8>>,
         _register_index: Option<u64>,
     ) -> Result<()> {
-        if !runtime_measurement_extend_available() {
+        // Test if the TD can extend RTRMs. The best guess at the moment is that if "TSM reports"
+        // is available, the TD runs Linux upstream kernel and is _currently_ not able to do it.
+        if Path::new("/sys/kernel/config/tsm/report").exists() {
             bail!("TDX Attester: Cannot extend runtime measurement on this system");
         }
 

--- a/attestation-agent/attester/src/tdx/mod.rs
+++ b/attestation-agent/attester/src/tdx/mod.rs
@@ -9,7 +9,7 @@ use crate::utils::pad;
 use crate::InitdataResult;
 use anyhow::*;
 use base64::Engine;
-use log::debug;
+use log::{debug, warn};
 use scroll::Pread;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha384};
@@ -81,7 +81,7 @@ impl Attester for TdxAttester {
         let cc_eventlog = match std::fs::read(CCEL_PATH) {
             Result::Ok(el) => Some(engine.encode(el)),
             Result::Err(e) => {
-                log::warn!("Read CC Eventlog failed: {:?}", e);
+                warn!("Read CC Eventlog failed: {:?}", e);
                 None
             }
         };
@@ -115,7 +115,7 @@ impl Attester for TdxAttester {
             rtmr_event.extend_data.copy_from_slice(&hash);
             match tdx_attest_rs::tdx_att_extend(&event_buffer) {
                 tdx_attest_rs::tdx_attest_error_t::TDX_ATTEST_SUCCESS => {
-                    log::debug!("TDX extend runtime measurement succeeded.")
+                    debug!("TDX extend runtime measurement succeeded.")
                 }
                 error_code => {
                     bail!(


### PR DESCRIPTION
Still WIP/RFC.

In #434 I had proposed to make use of `tdx-attest-rs` behind a new feature but dropped the idea since the initdata work moved to use it too and that is a valid case event with upstream kernels.

However, @fidencio mentioned a use case that building `kbs-client` without having to install `libtdx-attest*` (because of added complexity and the fact that the libs are not yet avail on all OS'es, e.g, 24.04) but still get the basic `get_evidence()` working can be useful. So I restored my original code and added here for feedback on how it's best handled.