### PR TITLE
Enable basic CI for s390x

### DIFF
--- a/.github/workflows/aa_basic.yml
+++ b/.github/workflows/aa_basic.yml
@@ -24,12 +24,24 @@ jobs:
     defaults:
       run:
         working-directory: ./attestation-agent
-    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:
         rust:
           - stable
+        instance:
+          - ubuntu-22.04
+          - s390x
+        include:
+          - instance: ubuntu-22.04
+            make_args: ""
+            cargo_test_opts: "--features openssl,rust-crypto,all-attesters,kbs,coco_as"
+            cargo_lint_opts: "--workspace"
+          - instance: s390x
+            make_args: "ATTESTER=se-attester TEE_PLATFORM=se"
+            cargo_test_opts: "--no-default-features --features openssl,passport,se-attester,kbs,coco_as"
+            cargo_lint_opts: "--no-default-features --features openssl,se-attester,kbs,coco_as -p attestation-agent -p attester -p coco_keyprovider -p kbc -p kbs_protocol -p crypto -p resource_uri"
+    runs-on: ${{ matrix.instance }}
     steps:
       - name: Code checkout
         uses: actions/checkout@v4
@@ -54,11 +66,13 @@ jobs:
           sudo echo 'deb [arch=amd64 signed-by=/usr/share/keyrings/intel-sgx.gpg] https://download.01.org/intel-sgx/sgx_repo/ubuntu jammy main' | sudo tee /etc/apt/sources.list.d/intel-sgx.list
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends libtdx-attest-dev
+        if: matrix.instance == 'ubuntu-22.04'
 
       - name: Install TPM dependencies
         run: |
           sudo apt-get update
           sudo apt-get install -y libtss2-dev
+        if: matrix.instance == 'ubuntu-22.04'
 
       - name: Install dm-verity dependencies
         run: |
@@ -67,17 +81,21 @@ jobs:
 
       - name: Gnu build and install with ttrpc
         run: |
-          make ttrpc=true && make install
+          mkdir -p ${HOME}/.local/bin
+          eval make ttrpc=true ${MAKE_ARGS} && make install PREFIX=${HOME}/.local
+        env:
+          MAKE_ARGS: ${{ matrix.make_args }}
 
       - name: Musl build with all platform
         run: |
           make LIBC=musl ttrpc=true ATTESTER=none
+        if: matrix.instance == 'ubuntu-22.04'
 
       - name: Run cargo test
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --features openssl,rust-crypto,all-attesters,kbs,coco_as -p attestation-agent -p attester -p coco_keyprovider -p kbc -p kbs_protocol -p crypto -p resource_uri
+          args: ${{ matrix.cargo_test_opts }} -p attestation-agent -p attester -p coco_keyprovider -p kbc -p kbs_protocol -p crypto -p resource_uri
 
       - name: Run cargo fmt check
         uses: actions-rs/cargo@v1
@@ -90,4 +108,11 @@ jobs:
         with:
           command: clippy
           # We are getting error in generated code due to derive_partial_eq_without_eq check, so ignore it for now
-          args: --workspace -- -D warnings -A clippy::derive-partial-eq-without-eq
+          args: ${{ matrix.cargo_lint_opts }} -- -D warnings -A clippy::derive-partial-eq-without-eq
+
+      - name: Take a post-action for self-hosted runner
+        if: always()
+        run: |
+          if [ -f ${HOME}/script/post_action.sh ]; then
+            ${HOME}/script/post_action.sh cc-guest-components
+          fi

--- a/.github/workflows/aa_basic.yml
+++ b/.github/workflows/aa_basic.yml
@@ -18,6 +18,10 @@ on:
   create:
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   basic_ci:
     name: Check

--- a/.github/workflows/api-server-rest-basic.yml
+++ b/.github/workflows/api-server-rest-basic.yml
@@ -24,12 +24,15 @@ jobs:
     defaults:
       run:
         working-directory: ./api-server-rest
-    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
+        instance:
+          - ubuntu-latest
+          - s390x
         rust:
           - stable
+    runs-on: ${{ matrix.instance }}
     steps:
       - name: Code checkout
         uses: actions/checkout@v4
@@ -50,18 +53,23 @@ jobs:
 
       - name: Build and install with default features
         run: |
-          make && make install
+          mkdir -p ${HOME}/.local/bin
+          make && make install PREFIX=${HOME}/.local
 
       - name: Musl build with default features
         run: |
           make LIBC=musl
-
-      - name: s390x build
-        run:
-          make ARCH=s390x
+        if: matrix.instance == 'ubuntu-latest'
 
       - name: Run cargo test
         uses: actions-rs/cargo@v1
         with:
           command: test
           args: -p api-server-rest
+
+      - name: Take a post-action for self-hosted runner
+        if: always()
+        run: |
+          if [ -f ${HOME}/script/post_action.sh ]; then
+            ${HOME}/script/post_action.sh cc-guest-components
+          fi

--- a/.github/workflows/api-server-rest-basic.yml
+++ b/.github/workflows/api-server-rest-basic.yml
@@ -18,6 +18,10 @@ on:
   create:
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   basic_ci:
     name: Check

--- a/.github/workflows/cdh_basic.yml
+++ b/.github/workflows/cdh_basic.yml
@@ -18,6 +18,10 @@ on:
   create:
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   basic_ci:
     name: Check

--- a/.github/workflows/cdh_basic.yml
+++ b/.github/workflows/cdh_basic.yml
@@ -24,12 +24,15 @@ jobs:
     defaults:
       run:
         working-directory: ./confidential-data-hub
-    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
+        instance:
+          - ubuntu-latest
+          - s390x
         rust:
           - stable
+    runs-on: ${{ matrix.instance }}
     steps:
       - name: Code checkout
         uses: actions/checkout@v4
@@ -50,15 +53,13 @@ jobs:
 
       - name: Build and install
         run: |
-          make RESOURCE_PROVIDER=kbs,sev && make install
+          mkdir -p ${HOME}/.local/bin
+          make RESOURCE_PROVIDER=kbs,sev && make install PREFIX=${HOME}/.local
 
       - name: Musl build
         run: |
           make LIBC=musl
-
-      - name: s390x build
-        run:
-          make ARCH=s390x
+        if: matrix.instance == 'ubuntu-latest'
 
       - name: Run cargo test
         uses: actions-rs/cargo@v1
@@ -78,3 +79,10 @@ jobs:
           command: clippy
           # We are getting error in generated code due to derive_partial_eq_without_eq check, so ignore it for now
           args: -p kms -p confidential-data-hub -p secret -p image -- -D warnings -A clippy::derive-partial-eq-without-eq 
+
+      - name: Take a post-action for self-hosted runner
+        if: always()
+        run: |
+          if [ -f ${HOME}/script/post_action.sh ]; then
+            ${HOME}/script/post_action.sh cc-guest-components
+          fi

--- a/.github/workflows/image_rs_build.yml
+++ b/.github/workflows/image_rs_build.yml
@@ -23,13 +23,16 @@ jobs:
     defaults:
       run:
         working-directory: ./image-rs
-    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:
         rust:
           - 1.76.0
           - stable
+        instance:
+          - ubuntu-latest
+          - s390x
+    runs-on: ${{ matrix.instance }}
     steps:
       - name: Code checkout
         uses: actions/checkout@v4
@@ -46,7 +49,7 @@ jobs:
 
       - name: Install nettle-sys building dependence
         run: |
-          sudo apt install clang llvm pkg-config nettle-dev protobuf-compiler libprotobuf-dev
+          sudo apt install -y clang llvm pkg-config nettle-dev protobuf-compiler libprotobuf-dev
 
       - name: Install TDX dependencies
         run: |
@@ -54,20 +57,25 @@ jobs:
           sudo echo 'deb [arch=amd64 signed-by=/usr/share/keyrings/intel-sgx.gpg] https://download.01.org/intel-sgx/sgx_repo/ubuntu jammy main' | sudo tee /etc/apt/sources.list.d/intel-sgx.list
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends libtdx-attest-dev
+        if: matrix.instance == 'ubuntu-latest'
 
       - name: Install TPM dependencies
         run: |
           sudo apt-get update
           sudo apt-get install -y libtss2-dev
+        if: matrix.instance == 'ubuntu-latest'
+
       - name: Install dm-verity dependencies
         run: |
           sudo apt-get update
           sudo apt-get install -y libdevmapper-dev
+        if: matrix.instance == 'ubuntu-latest'
 
       - name: Install cross-compliation support dependencies
         run: |
-          sudo apt install -y gcc-s390x-linux-gnu gcc-powerpc64le-linux-gnu
-          rustup target add s390x-unknown-linux-gnu powerpc64le-unknown-linux-gnu
+          sudo apt install -y gcc-powerpc64le-linux-gnu
+          rustup target add powerpc64le-unknown-linux-gnu
+        if: matrix.instance == 'ubuntu-latest'
 
       - name: Run cargo fmt check
         uses: actions-rs/cargo@v1
@@ -75,14 +83,18 @@ jobs:
           command: fmt
           args: -p image-rs -- --check
 
-      - name: Run rust lint check
+      - name: Run rust lint check (all platforms)
         run: |
           cargo clippy -p image-rs --all-targets --features=default -- -D warnings
           cargo clippy -p image-rs --all-targets --features=kata-cc-rustls-tls --no-default-features -- -D warnings
           cargo clippy -p image-rs --all-targets --features=kata-cc-native-tls --no-default-features -- -D warnings
-          cargo clippy -p image-rs --all-targets --features=enclave-cc-cckbc-native-tls --no-default-features -- -D warnings
           cargo clippy -p image-rs --all-targets --features=kata-cc-native-tls,signature-simple-xrss --no-default-features -- -D warnings
-          cargo clippy -p image-rs --all-targets --features=kata-cc-native-tls,nydus --no-default-features -- -D warnings
+
+      - name: Run rust lint check (x86_64 only)
+        run: |
+            cargo clippy -p image-rs --all-targets --features=enclave-cc-cckbc-native-tls --no-default-features -- -D warnings
+            cargo clippy -p image-rs --all-targets --features=kata-cc-native-tls,nydus --no-default-features -- -D warnings
+        if: matrix.instance == 'ubuntu-latest'
 
       - name: Run cargo build
         uses: actions-rs/cargo@v1
@@ -90,13 +102,10 @@ jobs:
           command: build
           args: -p image-rs --features default
 
-      - name: Run cargo build, cross-compiling for s390x
-        run: |
-          sudo -E PATH=$PATH -s RUSTFLAGS=" -C linker=s390x-linux-gnu-gcc" cargo build --target s390x-unknown-linux-gnu -p image-rs --features default
-
       - name: Run cargo build, cross-compiling for powerpc64le
         run: |
           sudo -E PATH=$PATH -s RUSTFLAGS=" -C linker=powerpc64le-linux-gnu-gcc" cargo build --target powerpc64le-unknown-linux-gnu -p image-rs --features default
+        if: matrix.instance == 'ubuntu-latest'
 
       - name: Run cargo test - default
         run: |
@@ -131,3 +140,11 @@ jobs:
       - name: Run cargo test - kata-cc (native-tls version) with keywrap-ttrpc (default) + keywrap-jwe + nydus
         run: |
           sudo -E PATH=$PATH -s cargo test -p image-rs --no-default-features --features=kata-cc-native-tls,keywrap-jwe,nydus
+        if: matrix.instance == 'ubuntu-latest'
+
+      - name: Take a post-action for self-hosted runner
+        if: always()
+        run: |
+          if [ -f ${HOME}/script/post_action.sh ]; then
+            ${HOME}/script/post_action.sh cc-guest-components
+          fi

--- a/.github/workflows/image_rs_build.yml
+++ b/.github/workflows/image_rs_build.yml
@@ -17,6 +17,10 @@ on:
   create:
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   ci:
     name: Check

--- a/.github/workflows/ocicrypt_rs_build.yml
+++ b/.github/workflows/ocicrypt_rs_build.yml
@@ -17,6 +17,10 @@ on:
   create:
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   ci:
     name: Check

--- a/confidential-data-hub/secret/src/bin/secret_cli.rs
+++ b/confidential-data-hub/secret/src/bin/secret_cli.rs
@@ -84,6 +84,9 @@ enum EnvelopeArgs {
     /// Intel eHSM driver to seal the envelope
     #[cfg(feature = "ehsm")]
     Ehsm(EhsmProviderArgs),
+
+    /// Dummy driver to prevent the unreachable pattern for neither aliyun nor ehsm
+    Dummy,
 }
 
 #[cfg(feature = "aliyun")]


### PR DESCRIPTION
The following workflows are enabled by a self-hosted runner named `s390x-runner-01` registered to the `coco` org:

- attestation agent
- confidential data hub
- API server rest
- image-rs

`ocicrypt-rs` is not included for the enablement this time because a base build image `runetest/compilation-testing` does not support s390x.

The changes are verified via a private runner:

- AA: https://github.com/BbolroC/cc-guest-components/actions/runs/9451193780
- CDH: https://github.com/BbolroC/cc-guest-components/actions/runs/9450832623
- API server rest: https://github.com/BbolroC/cc-guest-components/actions/runs/9450572957
- image-rs: https://github.com/BbolroC/cc-guest-components/actions/runs/9453177410

This PR will enable the community to run tests natively for each component.

The rationale for a post-action script at the end of each workflow

1. A self-hosted runner for s390x cannot be instantiated and used instantly on request, rather should be ready/running 24/7. It is inevitable to institute a hook for the management over test runs.
2. The management script could be committed to the repo, but it wouldn't be flexible enough to deal with an environmental issue on the runner.

The script is managed internally, but all commands in the script will be transparently tracked by `set -x`.

Signed-off-by: Hyounggyu Choi <Hyounggyu.Choi@ibm.com>