### PR TITLE
GHA: Place pre-action for s390x self-hosted runner

### DIFF
--- a/.github/workflows/aa_basic.yml
+++ b/.github/workflows/aa_basic.yml
@@ -47,6 +47,12 @@ jobs:
             cargo_lint_opts: "--no-default-features --features openssl,se-attester,kbs,coco_as -p attestation-agent -p attester -p coco_keyprovider -p kbc -p kbs_protocol -p crypto -p resource_uri"
     runs-on: ${{ matrix.instance }}
     steps:
+    - name: Take a pre-action for self-hosted runner
+      run: |
+        if [ -f "${HOME}/script/pre_action.sh" ]; then
+          "${HOME}/script/pre_action.sh" cc-guest-components
+        fi
+
       - name: Code checkout
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/api-server-rest-basic.yml
+++ b/.github/workflows/api-server-rest-basic.yml
@@ -38,6 +38,12 @@ jobs:
           - stable
     runs-on: ${{ matrix.instance }}
     steps:
+    - name: Take a pre-action for self-hosted runner
+      run: |
+        if [ -f "${HOME}/script/pre_action.sh" ]; then
+          "${HOME}/script/pre_action.sh" cc-guest-components
+        fi
+
       - name: Code checkout
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/cdh_basic.yml
+++ b/.github/workflows/cdh_basic.yml
@@ -38,6 +38,12 @@ jobs:
           - stable
     runs-on: ${{ matrix.instance }}
     steps:
+    - name: Take a pre-action for self-hosted runner
+      run: |
+        if [ -f "${HOME}/script/pre_action.sh" ]; then
+          "${HOME}/script/pre_action.sh" cc-guest-components
+        fi
+
       - name: Code checkout
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/image_rs_build.yml
+++ b/.github/workflows/image_rs_build.yml
@@ -38,6 +38,12 @@ jobs:
           - s390x
     runs-on: ${{ matrix.instance }}
     steps:
+    - name: Take a pre-action for self-hosted runner
+      run: |
+        if [ -f "${HOME}/script/pre_action.sh" ]; then
+          "${HOME}/script/pre_action.sh" cc-guest-components
+        fi
+
       - name: Code checkout
         uses: actions/checkout@v4
         with:


### PR DESCRIPTION
It is observed that some packages (e.g. docker) are required to run workflows for s390x. Like the post-action, we need to place pre-action for the platform.

Signed-off-by: Hyounggyu Choi <Hyounggyu.Choi@ibm.com>