### PR TITLE
GHA: Fix indentation error and skip image.rs tests for s390x

### DIFF
--- a/.github/workflows/aa_basic.yml
+++ b/.github/workflows/aa_basic.yml
@@ -47,16 +47,16 @@ jobs:
             cargo_lint_opts: "--no-default-features --features openssl,se-attester,kbs,coco_as -p attestation-agent -p attester -p coco_keyprovider -p kbc -p kbs_protocol -p crypto -p resource_uri"
     runs-on: ${{ matrix.instance }}
     steps:
-    - name: Take a pre-action for self-hosted runner
-      run: |
-        if [ -f "${HOME}/script/pre_action.sh" ]; then
-          "${HOME}/script/pre_action.sh" cc-guest-components
-        fi
-
       - name: Code checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 1
+
+      - name: Take a pre-action for self-hosted runner
+        run: |
+          if [ -f "${HOME}/script/pre_action.sh" ]; then
+            "${HOME}/script/pre_action.sh" cc-guest-components
+          fi
 
       - name: Install Rust toolchain (${{ matrix.rust }})
         uses: actions-rs/toolchain@v1

--- a/.github/workflows/api-server-rest-basic.yml
+++ b/.github/workflows/api-server-rest-basic.yml
@@ -38,16 +38,16 @@ jobs:
           - stable
     runs-on: ${{ matrix.instance }}
     steps:
-    - name: Take a pre-action for self-hosted runner
-      run: |
-        if [ -f "${HOME}/script/pre_action.sh" ]; then
-          "${HOME}/script/pre_action.sh" cc-guest-components
-        fi
-
       - name: Code checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 1
+
+      - name: Take a pre-action for self-hosted runner
+        run: |
+          if [ -f "${HOME}/script/pre_action.sh" ]; then
+            "${HOME}/script/pre_action.sh" cc-guest-components
+          fi
 
       - name: Install Rust toolchain (${{ matrix.rust }})
         uses: actions-rs/toolchain@v1

--- a/.github/workflows/cdh_basic.yml
+++ b/.github/workflows/cdh_basic.yml
@@ -38,16 +38,16 @@ jobs:
           - stable
     runs-on: ${{ matrix.instance }}
     steps:
-    - name: Take a pre-action for self-hosted runner
-      run: |
-        if [ -f "${HOME}/script/pre_action.sh" ]; then
-          "${HOME}/script/pre_action.sh" cc-guest-components
-        fi
-
       - name: Code checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 1
+
+      - name: Take a pre-action for self-hosted runner
+        run: |
+          if [ -f "${HOME}/script/pre_action.sh" ]; then
+            "${HOME}/script/pre_action.sh" cc-guest-components
+          fi
 
       - name: Install Rust toolchain (${{ matrix.rust }})
         uses: actions-rs/toolchain@v1

--- a/.github/workflows/image_rs_build.yml
+++ b/.github/workflows/image_rs_build.yml
@@ -38,16 +38,16 @@ jobs:
           - s390x
     runs-on: ${{ matrix.instance }}
     steps:
-    - name: Take a pre-action for self-hosted runner
-      run: |
-        if [ -f "${HOME}/script/pre_action.sh" ]; then
-          "${HOME}/script/pre_action.sh" cc-guest-components
-        fi
-
       - name: Code checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 1
+
+      - name: Take a pre-action for self-hosted runner
+        run: |
+          if [ -f "${HOME}/script/pre_action.sh" ]; then
+            "${HOME}/script/pre_action.sh" cc-guest-components
+          fi
 
       - name: Install Rust toolchain (${{ matrix.rust }})
         uses: actions-rs/toolchain@v1

--- a/image-rs/src/image.rs
+++ b/image-rs/src/image.rs
@@ -510,6 +510,7 @@ fn create_bundle(
     Ok(image_id)
 }
 
+#[cfg(not(target_arch = "s390x"))]
 #[cfg(feature = "snapshot-overlayfs")]
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
This commit fixes the wrongly indented configuration in #585 and place the pre action step after the code check-out.

There is an issue on pulling an image `mcr.microsoft.com/hello-world` on s390x.
It looks a load balancer for the microsoft registry is unstable so that the runner was able to pull the image with 10& success ratio (see https://github.com/microsoft/containerregistry/issues/144)
It is not reasonable to let the test run under the unstable environment.

This commit skips the tests at image.rs for the platform.

Signed-off-by: Hyounggyu Choi <Hyounggyu.Choi@ibm.com>