### PR TITLE
ci: update occlum ci

### DIFF
--- a/.github/workflows/aa_occlum_sgx.yml
+++ b/.github/workflows/aa_occlum_sgx.yml
@@ -34,10 +34,3 @@ jobs:
       - name: Run Occlum instance
         run: |
           docker run --rm -i --device /dev/sgx_enclave --device /dev/sgx_provision -v /etc/sgx_default_qcnl.conf:/etc/sgx_default_qcnl.conf -v $(pwd):/home occlum/occlum:latest-ubuntu20.04 bash -c "cd /home/attestation-agent/ci && ./occlum.sh"
-
-      - name: Take a post-action for self-hosted runner
-        if: always()
-        run: |
-          if [ -f ${HOME}/script/post_action.sh ]; then
-            ${HOME}/script/post_action.sh guest-components
-          fi


### PR DESCRIPTION
Now we are using a ACTIONS_RUNNER_HOOK_JOB_COMPLETED ability provided by github action. This allows us not to explicitly define a post-run script in yaml. The post actions are defined onside the runner itself.

See documents: https://docs.github.com/en/actions/hosting-your-own-runners/managing-self-hosted-runners/running-scripts-before-or-after-a-job#triggering-the-scripts

cc @mythi 