### PR TITLE
CDH: fix aa_kbc_params and config reading

### DIFF
--- a/attestation-agent/attestation-agent/src/config/coco_as.rs
+++ b/attestation-agent/attestation-agent/src/config/coco_as.rs
@@ -17,7 +17,7 @@ impl Default for CoCoASConfig {
     fn default() -> Self {
         let aa_kbc_params = aa_kbc_params::get_params().expect("failed to get aa_kbc_params");
         Self {
-            url: aa_kbc_params.uri().into(),
+            url: aa_kbc_params.uri.clone(),
         }
     }
 }

--- a/attestation-agent/attestation-agent/src/config/kbs.rs
+++ b/attestation-agent/attestation-agent/src/config/kbs.rs
@@ -20,7 +20,7 @@ impl Default for KbsConfig {
     fn default() -> Self {
         let aa_kbc_params = aa_kbc_params::get_params().expect("failed to get aa_kbc_params");
         Self {
-            url: aa_kbc_params.uri().into(),
+            url: aa_kbc_params.uri.clone(),
             cert: None,
         }
     }

--- a/confidential-data-hub/hub/src/bin/grpc-cdh.rs
+++ b/confidential-data-hub/hub/src/bin/grpc-cdh.rs
@@ -17,8 +17,6 @@ mod message;
 
 use config::*;
 
-const DEFAULT_CONFIG_PATH: &str = "/etc/confidential-data-hub.conf";
-
 const VERSION: &str = include_str!(concat!(env!("OUT_DIR"), "/version"));
 
 #[derive(Debug, Parser)]
@@ -31,23 +29,12 @@ struct Cli {
     config: Option<String>,
 }
 
-fn get_config_path(cli: Cli) -> String {
-    cli.config.unwrap_or_else(|| {
-        if let Ok(env_path) = env::var("CDH_CONFIG_PATH") {
-            return env_path;
-        }
-        DEFAULT_CONFIG_PATH.into()
-    })
-}
-
 #[tokio::main]
 async fn main() -> Result<()> {
     env_logger::init_from_env(env_logger::Env::new().default_filter_or("info"));
     let cli = Cli::parse();
-    let config_path = get_config_path(cli);
-    info!("Use configuration file {}", config_path);
 
-    let config = CdhConfig::init(&config_path).await?;
+    let config = CdhConfig::new(cli.config)?;
     config.set_configuration_envs();
 
     let cdh_socket = config.socket.parse::<SocketAddr>()?;

--- a/confidential-data-hub/hub/src/bin/ttrpc-cdh.rs
+++ b/confidential-data-hub/hub/src/bin/ttrpc-cdh.rs
@@ -28,8 +28,6 @@ mod ttrpc_server;
 
 use config::*;
 
-const DEFAULT_CONFIG_PATH: &str = "/etc/confidential-data-hub.conf";
-
 const UNIX_SOCKET_PREFIX: &str = "unix://";
 
 const VERSION: &str = include_str!(concat!(env!("OUT_DIR"), "/version"));
@@ -52,23 +50,12 @@ macro_rules! ttrpc_service {
     }};
 }
 
-fn get_config_path(cli: Cli) -> String {
-    cli.config.unwrap_or_else(|| {
-        if let Ok(env_path) = env::var("CDH_CONFIG_PATH") {
-            return env_path;
-        }
-        DEFAULT_CONFIG_PATH.into()
-    })
-}
-
 #[tokio::main]
 async fn main() -> Result<()> {
     env_logger::init_from_env(env_logger::Env::new().default_filter_or("info"));
     let cli = Cli::parse();
-    let config_path = get_config_path(cli);
-    info!("Use configuration file {}", config_path);
 
-    let config = CdhConfig::init(&config_path).await?;
+    let config = CdhConfig::new(cli.config)?;
     config.set_configuration_envs();
 
     let unix_socket_path = config
@@ -135,33 +122,4 @@ async fn create_socket_parent_directory(unix_socket_file: &str) -> Result<()> {
         .ok_or(anyhow!("The file path does not have a parent directory."))?;
     fs::create_dir_all(parent_directory).await?;
     Ok(())
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_get_config_path() {
-        // --config takes precedence,
-        // then env.CDH_CONFIG_PATH,
-        // then DEFAULT_CONFIG_PATH.
-
-        let cli = Cli { config: None };
-        assert_eq!(get_config_path(cli), DEFAULT_CONFIG_PATH);
-
-        let cli = Cli {
-            config: Some("/thing".into()),
-        };
-        assert_eq!(get_config_path(cli), "/thing");
-
-        env::set_var("CDH_CONFIG_PATH", "/byenv");
-        let cli = Cli { config: None };
-        assert_eq!(get_config_path(cli), "/byenv");
-
-        let cli = Cli {
-            config: Some("/thing".into()),
-        };
-        assert_eq!(get_config_path(cli), "/thing");
-    }
 }


### PR DESCRIPTION
CDH should firstly read config specified with commandline, and then env.

aa_kbc_param should be firstly read directly from CDH's config file. If there is no config file, try to read from env and then kernel cmdline. If still no values found, use a default one with offline_fs_kbc.

Close #593

cc @huoqifeng @mkulke 