### PR TITLE
AA: fix launch configuration

### DIFF
--- a/attestation-agent/attestation-agent/src/config/coco_as.rs
+++ b/attestation-agent/attestation-agent/src/config/coco_as.rs
@@ -3,9 +3,10 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+use anyhow::Result;
 use serde::Deserialize;
 
-use super::aa_kbc_params;
+use super::aa_kbc_params::AaKbcParams;
 
 #[derive(Clone, Debug, Deserialize)]
 pub struct CoCoASConfig {
@@ -13,11 +14,11 @@ pub struct CoCoASConfig {
     pub url: String,
 }
 
-impl Default for CoCoASConfig {
-    fn default() -> Self {
-        let aa_kbc_params = aa_kbc_params::get_params().expect("failed to get aa_kbc_params");
-        Self {
-            url: aa_kbc_params.uri.clone(),
-        }
+impl CoCoASConfig {
+    pub fn new() -> Result<Self> {
+        let aa_kbc_params = AaKbcParams::new()?;
+        Ok(Self {
+            url: aa_kbc_params.uri,
+        })
     }
 }

--- a/attestation-agent/attestation-agent/src/config/kbs.rs
+++ b/attestation-agent/attestation-agent/src/config/kbs.rs
@@ -3,9 +3,10 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+use anyhow::Result;
 use serde::Deserialize;
 
-use super::aa_kbc_params;
+use super::aa_kbc_params::AaKbcParams;
 
 #[derive(Clone, Debug, Deserialize)]
 pub struct KbsConfig {
@@ -16,12 +17,12 @@ pub struct KbsConfig {
     pub cert: Option<String>,
 }
 
-impl Default for KbsConfig {
-    fn default() -> Self {
-        let aa_kbc_params = aa_kbc_params::get_params().expect("failed to get aa_kbc_params");
-        Self {
-            url: aa_kbc_params.uri.clone(),
+impl KbsConfig {
+    pub fn new() -> Result<Self> {
+        let aa_kbc_params = AaKbcParams::new()?;
+        Ok(Self {
+            url: aa_kbc_params.uri,
             cert: None,
-        }
+        })
     }
 }

--- a/attestation-agent/attestation-agent/src/config/mod.rs
+++ b/attestation-agent/attestation-agent/src/config/mod.rs
@@ -16,14 +16,22 @@ pub mod kbs;
 
 pub const DEFAULT_AA_CONFIG_PATH: &str = "/etc/attestation-agent.conf";
 
-#[derive(Clone, Debug, Deserialize, Default)]
+#[derive(Clone, Debug, Deserialize)]
 pub struct Config {
     /// configs about token
     pub token_configs: TokenConfigs,
     // TODO: Add more fields that accessing AS needs.
 }
 
-#[derive(Clone, Debug, Deserialize, Default)]
+impl Config {
+    pub fn new() -> Result<Self> {
+        Ok(Self {
+            token_configs: TokenConfigs::new()?,
+        })
+    }
+}
+
+#[derive(Clone, Debug, Deserialize)]
 pub struct TokenConfigs {
     /// This config item is used when `coco_as` feature is enabled.
     #[cfg(feature = "coco_as")]
@@ -32,6 +40,18 @@ pub struct TokenConfigs {
     /// This config item is used when `kbs` feature is enabled.
     #[cfg(feature = "kbs")]
     pub kbs: kbs::KbsConfig,
+}
+
+impl TokenConfigs {
+    pub fn new() -> Result<Self> {
+        Ok(Self {
+            #[cfg(feature = "coco_as")]
+            coco_as: coco_as::CoCoASConfig::new()?,
+
+            #[cfg(feature = "kbs")]
+            kbs: kbs::KbsConfig::new()?,
+        })
+    }
 }
 
 impl TryFrom<&str> for Config {

--- a/attestation-agent/attestation-agent/src/lib.rs
+++ b/attestation-agent/attestation-agent/src/lib.rs
@@ -73,13 +73,15 @@ pub struct AttestationAgent {
 }
 
 impl Default for AttestationAgent {
+    /// This function would panic if a malformed `aa_kbc_param` is given
+    /// either env or kernel cmdline
     fn default() -> Self {
         if let Ok(_config) = Config::try_from(config::DEFAULT_AA_CONFIG_PATH) {
             return AttestationAgent { _config };
         }
 
         AttestationAgent {
-            _config: Config::default(),
+            _config: Config::new().expect("AA initialize"),
         }
     }
 }
@@ -94,7 +96,7 @@ impl AttestationAgent {
             }
             None => {
                 warn!("No AA config file specified. Using a default configuration.");
-                Config::default()
+                Config::new()?
             }
         };
 


### PR DESCRIPTION
Before this commit, if no configuration and proper aa_kbc_param given to AA, the launch of AA will panic.

This commit will use a default value for aa_kbc_param for AA/CDH. If no env or kernel cmdline, default value offline_fs_kbc and null will be used. If a aa_kbc_param is specified, it will be parsed as kbc:url. If the aa_kbc_param is malwared, the launch process will still fail.

cc @mkulke 