### PR TITLE
CDH/AA: make offline_fs_kbc::null default in get_params()

### DIFF
--- a/attestation-agent/attestation-agent/src/config/aa_kbc_params.rs
+++ b/attestation-agent/attestation-agent/src/config/aa_kbc_params.rs
@@ -17,6 +17,15 @@ pub struct AaKbcParams {
     pub uri: String,
 }
 
+impl Default for AaKbcParams {
+    fn default() -> Self {
+        AaKbcParams {
+            kbc: "offline_fs_kbc".into(),
+            uri: "null".into(),
+        }
+    }
+}
+
 impl TryFrom<String> for AaKbcParams {
     type Error = ParamError;
 
@@ -48,8 +57,12 @@ pub fn get_value() -> Result<String, ParamError> {
 }
 
 pub fn get_params() -> Result<AaKbcParams, ParamError> {
-    let value = get_value()?;
-    value.try_into()
+    let Ok(value) = get_value() else {
+        debug!("Failed to get aa_kbc_params from env or kernel cmdline. Use offline_fs_kbc by default.");
+        return Ok(AaKbcParams::default());
+    };
+    let aa_kbc_params = value.try_into()?;
+    Ok(aa_kbc_params)
 }
 
 fn from_cmdline() -> Result<String, ParamError> {


### PR DESCRIPTION
At the moment we don't support a case in which attestation-agent can start without either an AA config provided or aa_kbc_params specified. In CDH we default to `aa_kbc_params=offline_fs_kbc::null` for those cases. This change will make it the default for both AA and CDH.