### PR TITLE
image-rs: make tar reader async

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1097,9 +1097,9 @@ checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
 name = "const_fn"
-version = "0.4.9"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbdcdcb6d86f71c5e97409ad45898af11cbc995b4ee8112d59095a28d376c935"
+checksum = "373e9fafaa20882876db20562275ff58d50e0caa2590077fe7ce7bef90211d0d"
 
 [[package]]
 name = "const_format"
@@ -2013,7 +2013,7 @@ checksum = "1ee447700ac8aa0b2f2bd7bc4462ad686ba06baa6727ac149a2d6277f0d240fd"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.4.1",
  "windows-sys 0.52.0",
 ]
 
@@ -2767,6 +2767,7 @@ dependencies = [
  "futures-util",
  "hex",
  "kbc",
+ "krata-tokio-tar",
  "lazy_static",
  "libc",
  "log",
@@ -2792,7 +2793,6 @@ dependencies = [
  "sigstore",
  "strum",
  "strum_macros 0.26.2",
- "tar",
  "tempfile",
  "test-utils",
  "tokio",
@@ -3172,6 +3172,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "krata-tokio-tar"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba844968838c1c5892da2116e5f744bceab2b43af34539abdd6cd3975eaca973"
+dependencies = [
+ "filetime",
+ "futures-core",
+ "libc",
+ "redox_syscall 0.3.5",
+ "tokio",
+ "tokio-stream",
+ "xattr",
+]
+
+[[package]]
 name = "lalrpop"
 version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3329,7 +3344,7 @@ checksum = "85c833ca1e66078851dba29046874e38f08b2c883700aa29a03ddd3b23814ee8"
 dependencies = [
  "bitflags 2.4.2",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.4.1",
 ]
 
 [[package]]
@@ -4091,7 +4106,7 @@ checksum = "4c42a9226546d68acdd9c0a280d17ce19bfe27a46bf68784e4066115788d008e"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.4.1",
  "smallvec",
  "windows-targets 0.48.5",
 ]
@@ -4156,9 +4171,9 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "pest"
-version = "2.7.7"
+version = "2.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "219c0dcc30b6a27553f9cc242972b67f75b60eb0db71f0b5462f38b058c41546"
+checksum = "560131c633294438da9f7c4b08189194b20946c8274c6b9e38881a7874dc8ee8"
 dependencies = [
  "memchr",
  "thiserror",
@@ -4167,9 +4182,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.7.6"
+version = "2.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcd6ab1236bbdb3a49027e920e693192ebfe8913f6d60e294de57463a493cfde"
+checksum = "26293c9193fbca7b1a3bf9b79dc1e388e927e6cacaa78b4a3ab705a1d3d41459"
 dependencies = [
  "pest",
  "pest_generator",
@@ -4177,9 +4192,9 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.7.6"
+version = "2.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a31940305ffc96863a735bef7c7994a00b325a7138fdbc5bda0f1a0476d3275"
+checksum = "3ec22af7d3fb470a85dd2ca96b7c577a1eb4ef6f1683a9fe9a8c16e136c04687"
 dependencies = [
  "pest",
  "pest_meta",
@@ -4190,9 +4205,9 @@ dependencies = [
 
 [[package]]
 name = "pest_meta"
-version = "2.7.6"
+version = "2.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7ff62f5259e53b78d1af898941cdcdccfae7385cf7d793a6e55de5d05bb4b7d"
+checksum = "d7a240022f37c361ec1878d646fc5b7d7c4d28d5946e1a80ad5a7a4f4ca0bdcd"
 dependencies = [
  "once_cell",
  "pest",
@@ -4265,18 +4280,18 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.1.4"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0302c4a0442c456bd56f841aee5c3bfd17967563f6fadc9ceb9f9c23cf3807e0"
+checksum = "b6bf43b791c5b9e34c3d182969b4abb522f9343702850a2e57f460d00d09b4b3"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.4"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "266c042b60c9c76b8d53061e52b2e0d1116abc57cefc8c5cd671619a56ac3690"
+checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4718,6 +4733,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62c64daa8e9438b84aaae55010a93f396f8e60e3911590fcba770d04643fc1dd"
 dependencies = [
  "cipher",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
+dependencies = [
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -7125,9 +7149,9 @@ checksum = "32b752e52a2da0ddfbdbcc6fceadfeede4c939ed16d13e648833a61dfb611ed8"
 
 [[package]]
 name = "winnow"
-version = "0.6.5"
+version = "0.6.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dffa400e67ed5a4dd237983829e66475f0a4a26938c4b04c21baede6262215b8"
+checksum = "59b5e5f6c299a3c7890b876a2a587f3115162487e704907d9b6cd29473052ba1"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2769,7 +2769,6 @@ dependencies = [
  "kbc",
  "krata-tokio-tar",
  "lazy_static",
- "libc",
  "log",
  "loopdev",
  "nix 0.28.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ jwt-simple = { version = "0.12", default-features = false, features = ["pure-rus
 kbs-types = "0.6.0"
 lazy_static = "1.4.0"
 log = "0.4.14"
+nix = "0.28"
 openssl = "0.10"
 prost = "0.11"
 protobuf = "3.4.0"

--- a/attestation-agent/attester/Cargo.toml
+++ b/attestation-agent/attester/Cargo.toml
@@ -14,7 +14,7 @@ base64.workspace = true
 clap = { workspace = true, features = ["derive"], optional = true }
 kbs-types.workspace = true
 log.workspace = true
-nix = { version = "0.28", optional = true, features = ["ioctl", "fs"] }
+nix = { workspace = true, optional = true, features = ["ioctl", "fs"] }
 occlum_dcap = { git = "https://github.com/occlum/occlum", tag = "v0.29.7", optional = true }
 pv = { version = "0.10.0", package = "s390_pv", optional = true }
 scroll = { version = "0.12.0", default-features = false, features = ["derive", "std"], optional = true }

--- a/image-rs/Cargo.toml
+++ b/image-rs/Cargo.toml
@@ -29,10 +29,9 @@ futures-util = "0.3"
 hex = { workspace = true, optional = true }
 kbc = { path = "../attestation-agent/kbc", default-features = false, optional = true }
 lazy_static = { workspace = true, optional = true }
-libc = "0.2.155"
 log = "0.4.14"
 loopdev = { git = "https://github.com/mdaffin/loopdev", rev = "c9f91e8f0326ce8a3364ac911e81eb32328a5f27" }
-nix = { version = "0.28", optional = true, features = ["mount"] }
+nix = { workspace = true, optional = true, features = ["mount"] }
 oci-distribution = { version = "0.11", default-features = false, optional = true }
 oci-spec = "0.6.2"
 ocicrypt-rs = { path = "../ocicrypt-rs", default-features = false, features = [
@@ -74,7 +73,7 @@ ttrpc-codegen = { workspace = true, optional = true }
 
 [dev-dependencies]
 cfg-if.workspace = true
-nix = { version = "0.28", features = ["user"] }
+nix = { workspace = true, features = ["user"] }
 ring.workspace = true
 rstest.workspace = true
 serial_test = "2.0.0"

--- a/image-rs/Cargo.toml
+++ b/image-rs/Cargo.toml
@@ -21,6 +21,7 @@ base64.workspace = true
 cfg-if = { workspace = true, optional = true }
 devicemapper = { version = "0.34.2", optional = true }
 dircpy = { version = "0.3.12", optional = true }
+filetime = "0.2"
 flate2 = "1.0"
 fs_extra = { version = "1.2.0", optional = true }
 futures = { version = "0.3.28", optional = true }
@@ -54,7 +55,7 @@ sha2.workspace = true
 sigstore = { git = "https://github.com/sigstore/sigstore-rs.git", rev = "1b6ccf0f64d173350ec5515bd69ab48a26a9c0a3", default-features = false, optional = true }
 strum.workspace = true
 strum_macros = "0.26"
-tar = "0.4.37"
+krata-tokio-tar = "0.4.0"
 tokio.workspace = true
 tokio-util = "0.7.10"
 tonic = { workspace = true, optional = true }
@@ -73,7 +74,6 @@ ttrpc-codegen = { workspace = true, optional = true }
 
 [dev-dependencies]
 cfg-if.workspace = true
-filetime = "0.2"
 nix = { version = "0.28", features = ["user"] }
 ring.workspace = true
 rstest.workspace = true

--- a/image-rs/src/unpack.rs
+++ b/image-rs/src/unpack.rs
@@ -2,22 +2,36 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-use anyhow::Context;
-use anyhow::{bail, Result};
+use anyhow::{bail, Context, Result};
+use filetime::FileTime;
+use futures::StreamExt;
 use libc::timeval;
 use log::warn;
-use std::collections::HashMap;
-use std::ffi::CString;
-use std::fs;
-use std::io;
-use std::path::Path;
-use tar::Archive;
+use std::{
+    collections::HashMap,
+    convert::TryInto,
+    ffi::CString,
+    fs::Permissions,
+    io,
+    os::{
+        fd::{AsFd, AsRawFd},
+        unix::fs::PermissionsExt,
+    },
+    path::Path,
+};
+use tokio::{fs, io::AsyncRead};
+use tokio_tar::ArchiveBuilder;
 
 /// Unpack the contents of tarball to the destination path
-pub fn unpack<R: io::Read>(input: R, destination: &Path) -> Result<()> {
-    let mut archive = Archive::new(input);
-    archive.set_preserve_ownerships(true);
-    archive.set_preserve_permissions(true);
+pub async fn unpack<R: AsyncRead + Unpin>(input: R, destination: &Path) -> Result<()> {
+    let mut archive = ArchiveBuilder::new(input)
+        .set_ignore_zeros(true)
+        .set_unpack_xattrs(true)
+        .set_preserve_permissions(true)
+        .build();
+    let mut entries = archive
+        .entries()
+        .context("failed to read entries from the tar")?;
 
     if destination.exists() {
         warn!(
@@ -25,46 +39,77 @@ pub fn unpack<R: io::Read>(input: R, destination: &Path) -> Result<()> {
             destination
         );
         fs::remove_dir_all(destination)
+            .await
             .context("Failed to delete existed broken layer when unpacking")?;
     }
 
-    fs::create_dir_all(destination)?;
+    fs::create_dir_all(destination).await?;
 
     let mut dirs: HashMap<CString, [timeval; 2]> = HashMap::default();
-    for file in archive.entries()? {
+    while let Some(file) = entries.next().await {
         let mut file = file?;
-        file.unpack_in(destination)?;
 
-        // tar-rs crate only preserve timestamps of files,
-        // symlink file and directory are not covered.
-        // upstream fix PR: https://github.com/alexcrichton/tar-rs/pull/217
-        if file.header().entry_type().is_symlink() || file.header().entry_type().is_dir() {
-            let mtime = file.header().mtime()? as i64;
+        let uid = file
+            .header()
+            .uid()?
+            .try_into()
+            .context("UID is too large!")?;
+        let gid = file
+            .header()
+            .gid()?
+            .try_into()
+            .context("GID is too large!")?;
 
+        file.unpack_in(destination).await?;
+
+        let path = CString::new(format!(
+            "{}/{}",
+            destination.display(),
+            file.path()?.display()
+        ))?;
+
+        let file_path = path.to_str().expect("must be utf8");
+
+        let kind = file.header().entry_type();
+        let mode = file.header().mode().ok();
+        let mtime = file.header().mtime()? as i64;
+
+        // krata-tokio-tar crate does not provide a way to preserve permissions
+        // for all kinds of files.
+        //
+        // this crate also does not cover symlink files/dir mtime.
+        //
+        // because we changed the files ownership manually, thus we need to reset
+        // the mtime again.
+        if kind.is_dir() || file.header().as_ustar().is_none() && file.path_bytes().ends_with(b"/")
+        {
+            set_perms_ownerships(&path, ChownType::LChown, uid, gid, mode).await?;
             let atime = timeval {
                 tv_sec: mtime,
                 tv_usec: 0,
             };
-            let path = CString::new(format!(
-                "{}/{}",
-                destination.display(),
-                file.path()?.display()
-            ))?;
 
             let times = [atime, atime];
 
-            if file.header().entry_type().is_dir() {
-                dirs.insert(path, times);
-            } else {
-                let ret = unsafe { libc::lutimes(path.as_ptr(), times.as_ptr()) };
-                if ret != 0 {
-                    bail!(
-                        "change symlink file: {:?} utime error: {:?}",
-                        path,
-                        io::Error::last_os_error()
-                    );
-                }
-            }
+            dirs.insert(path.clone(), times);
+        } else if kind.is_symlink() {
+            let mtime = FileTime::from_unix_time(mtime, 0);
+            filetime::set_symlink_file_times(file_path, mtime, mtime)
+                .context(format!("failed to set mtime for sym link `{file_path}`"))?;
+        } else if !kind.is_hard_link() {
+            // for other files except link we use fchown
+            let f = fs::OpenOptions::new()
+                .write(true)
+                .open(file_path)
+                .await
+                .context("open file failed")?;
+
+            set_perms_ownerships(&path, ChownType::FChown(f), uid, gid, mode).await?;
+
+            // set mtime
+            let mtime = FileTime::from_unix_time(mtime, 0);
+            filetime::set_file_times(file_path, mtime, mtime)
+                .context(format!("failed to set mtime for `{file_path}`"))?;
         }
     }
 
@@ -83,57 +128,129 @@ pub fn unpack<R: io::Read>(input: R, destination: &Path) -> Result<()> {
     Ok(())
 }
 
+enum ChownType {
+    LChown,
+    FChown(fs::File),
+}
+
+async fn set_perms_ownerships(
+    dst: &CString,
+    chown: ChownType,
+    uid: u32,
+    gid: u32,
+    mode: Option<u32>,
+) -> Result<()> {
+    match chown {
+        ChownType::FChown(f) => {
+            let ret = unsafe { libc::fchown(f.as_fd().as_raw_fd(), uid, gid) };
+            if ret != 0 {
+                bail!(
+                    "failed to set ownerships of file: {:?} chown error: {:?}",
+                    dst,
+                    io::Error::last_os_error()
+                );
+            }
+        }
+        ChownType::LChown => {
+            let ret = unsafe { libc::lchown(dst.as_ptr(), uid, gid) };
+            if ret != 0 {
+                bail!(
+                    "failed to set ownerships of file: {:?} lchown error: {:?}",
+                    dst,
+                    io::Error::last_os_error()
+                );
+            }
+        }
+    }
+    // ... then set permissions, SUID bits set here is kept
+    if let Some(mode) = mode {
+        let perm = Permissions::from_mode(mode as _);
+        fs::set_permissions(Path::new(dst.to_str().expect("must be utf8")), perm)
+            .await
+            .context("failed to set permissions")?;
+    }
+
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use std::fs::File;
-    use std::io::prelude::*;
+    use std::os::unix::fs::{chown, lchown, MetadataExt};
 
-    #[test]
-    fn test_unpack() {
-        let mut ar = tar::Builder::new(Vec::new());
+    use tokio::{
+        fs::{self, File},
+        io::AsyncWriteExt,
+    };
+    use tokio_tar::Builder;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn test_unpack() {
+        let mut ar = Builder::new(Vec::new());
         let tempdir = tempfile::tempdir().unwrap();
 
         let path = tempdir.path().join("file.txt");
-        File::create(&path)
-            .unwrap()
-            .write_all(b"file data")
-            .unwrap();
+        let mut f = File::create(&path).await.unwrap();
+        f.write_all(b"file data").await.unwrap();
+        f.flush().await.unwrap();
+
+        chown(path.clone(), Some(10), Some(10)).unwrap();
 
         let mtime = filetime::FileTime::from_unix_time(20_000, 0);
         filetime::set_file_mtime(&path, mtime).unwrap();
-        ar.append_file("file.txt", &mut File::open(&path).unwrap())
+
+        ar.append_file("file.txt", &mut File::open(&path).await.unwrap())
+            .await
+            .unwrap();
+
+        let path = tempdir.path().join("link");
+        tokio::fs::symlink("file.txt", &path).await.unwrap();
+        let mtime = filetime::FileTime::from_unix_time(20_000, 0);
+        filetime::set_file_mtime(&path, mtime).unwrap();
+        lchown(path.clone(), Some(10), Some(10)).unwrap();
+        ar.append_file("link", &mut File::open(&path).await.unwrap())
+            .await
             .unwrap();
 
         let path = tempdir.path().join("dir");
-        fs::create_dir(&path).unwrap();
+        fs::create_dir(&path).await.unwrap();
 
         filetime::set_file_mtime(&path, mtime).unwrap();
-        ar.append_path_with_name(&path, "dir").unwrap();
+        ar.append_path_with_name(&path, "dir").await.unwrap();
 
         // TODO: Add more file types like symlink, char, block devices.
-        let data = ar.into_inner().unwrap();
+        let data = ar.into_inner().await.unwrap();
         tempdir.close().unwrap();
 
         let destination = Path::new("/tmp/image_test_dir");
         if destination.exists() {
-            fs::remove_dir_all(destination).unwrap();
+            fs::remove_dir_all(destination).await.unwrap();
         }
 
-        assert!(unpack(data.as_slice(), destination).is_ok());
+        assert!(unpack(data.as_slice(), destination).await.is_ok());
 
         let path = destination.join("file.txt");
-        let metadata = fs::metadata(path).unwrap();
+        let metadata = fs::metadata(path).await.unwrap();
         let new_mtime = filetime::FileTime::from_last_modification_time(&metadata);
         assert_eq!(mtime, new_mtime);
+        assert_eq!(metadata.gid(), 10);
+        assert_eq!(metadata.uid(), 10);
+
+        let path = destination.join("link");
+        let metadata = fs::symlink_metadata(path).await.unwrap();
+        let new_mtime = filetime::FileTime::from_last_modification_time(&metadata);
+        assert_eq!(mtime, new_mtime);
+        assert_eq!(metadata.gid(), 10);
+        assert_eq!(metadata.uid(), 10);
 
         let path = destination.join("dir");
-        let metadata = fs::metadata(path).unwrap();
+        let metadata = fs::metadata(path).await.unwrap();
         let new_mtime = filetime::FileTime::from_last_modification_time(&metadata);
         assert_eq!(mtime, new_mtime);
 
         // though destination already exists, it will be deleted
         // and rewrite
-        assert!(unpack(data.as_slice(), destination).is_ok());
+        assert!(unpack(data.as_slice(), destination).await.is_ok());
     }
 }

--- a/image-rs/src/unpack.rs
+++ b/image-rs/src/unpack.rs
@@ -5,8 +5,8 @@
 use anyhow::{bail, Context, Result};
 use filetime::FileTime;
 use futures::StreamExt;
-use libc::timeval;
 use log::warn;
+use nix::libc::timeval;
 use std::{
     collections::HashMap,
     convert::TryInto,
@@ -115,7 +115,7 @@ pub async fn unpack<R: AsyncRead + Unpin>(input: R, destination: &Path) -> Resul
 
     // Directory timestamps need update after all files are extracted.
     for (k, v) in dirs.iter() {
-        let ret = unsafe { libc::utimes(k.as_ptr(), v.as_ptr()) };
+        let ret = unsafe { nix::libc::utimes(k.as_ptr(), v.as_ptr()) };
         if ret != 0 {
             bail!(
                 "change directory: {:?} utime error: {:?}",
@@ -142,7 +142,7 @@ async fn set_perms_ownerships(
 ) -> Result<()> {
     match chown {
         ChownType::FChown(f) => {
-            let ret = unsafe { libc::fchown(f.as_fd().as_raw_fd(), uid, gid) };
+            let ret = unsafe { nix::libc::fchown(f.as_fd().as_raw_fd(), uid, gid) };
             if ret != 0 {
                 bail!(
                     "failed to set ownerships of file: {:?} chown error: {:?}",
@@ -152,7 +152,7 @@ async fn set_perms_ownerships(
             }
         }
         ChownType::LChown => {
-            let ret = unsafe { libc::lchown(dst.as_ptr(), uid, gid) };
+            let ret = unsafe { nix::libc::lchown(dst.as_ptr(), uid, gid) };
             if ret != 0 {
                 bail!(
                     "failed to set ownerships of file: {:?} lchown error: {:?}",


### PR DESCRIPTION
before this commit, tar reader is sync, thus we need a separate os thread for every image layer pulling green thread. This would cost more memory and CPU resource because on linux a thread actually means another process.

This commit replace the tar crate to async version, thus we do not need another thread to handle this to decrease memory occupation.

Also, the original thread way would make the error of `unpack()` function missing because it would not be captured by original thread. Thus always a inclear `Send Error {...}` error message will be returned. The new way will not face such situation. cc @stevenhorsman 

Some abilities like permission maintain, ownership maintain are manually implemented as the original crate does not support well.

cc @arronwy 