### PR TITLE
Add aa option for runtime register

### DIFF
--- a/attestation-agent/attestation-agent/config.example.toml
+++ b/attestation-agent/attestation-agent/config.example.toml
@@ -29,3 +29,6 @@ DYEbQvoZIkUTc1gBUWDcAUS5ztbJg9LCb9WVtvUTqTP2lGuNymOvdsuXq+sAZh9b
 M9QaC1mzQ/OStg==
 -----END CERTIFICATE-----
 '''
+
+[attester]
+default_register_index = 42

--- a/attestation-agent/attestation-agent/src/config/mod.rs
+++ b/attestation-agent/attestation-agent/src/config/mod.rs
@@ -21,12 +21,22 @@ pub struct Config {
     /// configs about token
     pub token_configs: TokenConfigs,
     // TODO: Add more fields that accessing AS needs.
+    #[serde(default)]
+    pub attester: AttesterConfig,
+}
+
+#[derive(Clone, Debug, Deserialize, Default)]
+pub struct AttesterConfig {
+    /// The default register index to use in `extend_runtime_measurement`
+    /// operations.
+    pub default_register_index: Option<u64>,
 }
 
 impl Config {
     pub fn new() -> Result<Self> {
         Ok(Self {
             token_configs: TokenConfigs::new()?,
+            attester: AttesterConfig::default(),
         })
     }
 }
@@ -74,5 +84,15 @@ mod tests {
     #[case("config.example.json")]
     fn parse_config(#[case] config: &str) {
         let _config = super::Config::try_from(config).expect("failed to parse config file");
+    }
+
+    #[test]
+    fn parse_attester_config() {
+        let config_str = "config.example.toml";
+        let config = super::Config::try_from(config_str).expect("failed to parse config file");
+        assert_eq!(config.attester.default_register_index, Some(42));
+        let config_str = "config.example.json";
+        let config = super::Config::try_from(config_str).expect("failed to parse config file");
+        assert!(config.attester.default_register_index.is_none());
     }
 }

--- a/attestation-agent/attestation-agent/src/lib.rs
+++ b/attestation-agent/attestation-agent/src/lib.rs
@@ -149,6 +149,7 @@ impl AttestationAPIs for AttestationAgent {
         events: Vec<Vec<u8>>,
         register_index: Option<u64>,
     ) -> Result<()> {
+        let register_index = register_index.or(self.config.attester.default_register_index);
         self.attester
             .extend_runtime_measurement(events, register_index)
             .await?;


### PR DESCRIPTION
## Why? 

If we use extend_runtime_measurement to measure policy or init-data we need to specify in which register it is measuring into, since the default might not work in each situation.

There is an option to specify it at the caller site, which would be kata-agent. it would be an attestation-related parameter that we would have to pipe through via kata to the attester, which is impractical.

## How

Currently the attester is being initialized in each RPC call that is interacting with the TEE, this change moves the TEE detection into the initialization of the `AttestationAgent` instance.

A `default_register_index` field is now added to the AA configuration, if this per-guest default is not set it will fall back to a hardcoded default.