### PR TITLE
AA: fallback to pcr in configfile in extend operations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -408,7 +408,8 @@ dependencies = [
 [[package]]
 name = "az-cvm-vtpm"
 version = "0.6.0"
-source = "git+http://github.com/mkulke/azure-cvm-tooling?rev=69526229dbb78fe4a5d6e8c6887a146d8c6640b0#69526229dbb78fe4a5d6e8c6887a146d8c6640b0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1940b5a30bbaa585acd365e329c8c4c5c119345fef81830bd5f38f2360caa7d6"
 dependencies = [
  "bincode",
  "jsonwebkey",
@@ -427,7 +428,8 @@ dependencies = [
 [[package]]
 name = "az-snp-vtpm"
 version = "0.6.0"
-source = "git+http://github.com/mkulke/azure-cvm-tooling?rev=69526229dbb78fe4a5d6e8c6887a146d8c6640b0#69526229dbb78fe4a5d6e8c6887a146d8c6640b0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a276bcc39a8cf650ebc32941409f89c751cf8266c67f233872ac8c50ffa5405"
 dependencies = [
  "az-cvm-vtpm",
  "bincode",
@@ -441,7 +443,8 @@ dependencies = [
 [[package]]
 name = "az-tdx-vtpm"
 version = "0.6.0"
-source = "git+http://github.com/mkulke/azure-cvm-tooling?rev=69526229dbb78fe4a5d6e8c6887a146d8c6640b0#69526229dbb78fe4a5d6e8c6887a146d8c6640b0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb795802e685a153ea4906349c86f5760012478a72e349538dd47012409465de"
 dependencies = [
  "az-cvm-vtpm",
  "base64-url",

--- a/attestation-agent/attestation-agent/src/config/mod.rs
+++ b/attestation-agent/attestation-agent/src/config/mod.rs
@@ -7,7 +7,10 @@ use anyhow::Result;
 use serde::Deserialize;
 use sha2::{Digest, Sha256, Sha384, Sha512};
 
-use crate::DEFAULT_PCR_INDEX;
+/// Default PCR index used by AA. `17` is selected for its usage of dynamic root of trust for measurement.
+/// - [Linux TPM PCR Registry](https://uapi-group.org/specifications/specs/linux_tpm_pcr_registry/)
+/// - [TCG TRUSTED BOOT CHAIN IN EDK II](https://tianocore-docs.github.io/edk2-TrustedBootChain/release-1.00/3_TCG_Trusted_Boot_Chain_in_EDKII.html)
+const DEFAULT_PCR_INDEX: u64 = 17;
 
 pub mod aa_kbc_params;
 

--- a/attestation-agent/attestation-agent/src/lib.rs
+++ b/attestation-agent/attestation-agent/src/lib.rs
@@ -18,7 +18,7 @@ pub mod token;
 
 use config::HashAlgorithm;
 use eventlog::{EventEntry, EventLog};
-use log::{info, warn};
+use log::{debug, info, warn};
 use token::*;
 
 use crate::config::Config;
@@ -154,11 +154,6 @@ impl AttestationAgent {
     }
 }
 
-/// Default PCR index used by AA. `17` is selected for its usage of dynamic root of trust for measurement.
-/// - [Linux TPM PCR Registry](https://uapi-group.org/specifications/specs/linux_tpm_pcr_registry/)
-/// - [TCG TRUSTED BOOT CHAIN IN EDK II](https://tianocore-docs.github.io/edk2-TrustedBootChain/release-1.00/3_TCG_Trusted_Boot_Chain_in_EDKII.html)
-const DEFAULT_PCR_INDEX: u64 = 17;
-
 #[async_trait]
 impl AttestationAPIs for AttestationAgent {
     async fn get_token(&mut self, token_type: &str) -> Result<Vec<u8>> {
@@ -200,8 +195,9 @@ impl AttestationAPIs for AttestationAgent {
         register_index: Option<u64>,
     ) -> Result<()> {
         let register_index = register_index.unwrap_or_else(|| {
-            info!("No PCR index provided, use default {DEFAULT_PCR_INDEX}");
-            DEFAULT_PCR_INDEX
+            let pcr = self.config.eventlog_config.init_pcr;
+            debug!("No PCR index provided, use default {pcr}");
+            pcr
         });
 
         let log_entry = EventEntry::new(domain, operation, content);


### PR DESCRIPTION
For the extend runtime measurement op we currently have 2 defaults, one hardcoded and one specified in the configuration file.

Only the initial extend operation will use the PCR in the config, if called via an API (w/o specifying a concrete register) the extend op will default to the hardcoded instead of the value specified in the config file.

This behaviour implies that the caller of the RPC method has knowledge about the internals of the TEE (valid PCR registers), which is unfortunate (would need a kata-agent config, for example)

This PR consolidates the algo to pick a PCR for all extend ops:
1) PCR specified in the call
2) PCR specified in config file
3) Hardcoded default PCR

Drive-by fix: Cargo.lock update