### PR TITLE
cdh:storage: Add `-u` flag to mktemp to avoid file creation

### DIFF
--- a/confidential-data-hub/storage/scripts/luks-encrypt-storage
+++ b/confidential-data-hub/storage/scripts/luks-encrypt-storage
@@ -71,7 +71,7 @@ fi
 device_name=$(sed -e 's/DEVNAME=//g;t;d' "/sys/dev/block/${device_num}/uevent")
 device_path="/dev/$device_name"
 
-opened_device_name=$(mktemp "encrypted_disk_XXXXX")
+opened_device_name=$(mktemp -u "encrypted_disk_XXXXX")
 
 if [[ -n "$device_name" && -b "$device_path" ]]; then
 


### PR DESCRIPTION
Added the `-u` flag to the mktemp command to generate a random name without creating a file in the `luks-encrypt-storage` script. This change ensures that mktemp only produces a unique name, which can be used as an opened device name without the side effect of file creation.

Example usage:
opened_device_name=$(mktemp -u "encrypted_disk_XXXXX")

This update improves the script by preventing unnecessary file creation and potential errors related to file system permissions or read-only states.