### PR TITLE
image-rs: Support to reuse meta_store

### DIFF
--- a/image-rs/src/config.rs
+++ b/image-rs/src/config.rs
@@ -9,7 +9,7 @@ use std::path::{Path, PathBuf};
 
 use crate::snapshots::SnapshotType;
 
-const DEFAULT_WORK_DIR: &str = "/var/lib/image-rs/";
+pub const DEFAULT_WORK_DIR: &str = "/var/lib/image-rs/";
 
 /// Default policy file path.
 pub const POLICY_FILE_PATH: &str = "kbs:///default/security-policy/test";
@@ -33,7 +33,7 @@ pub const AUTH_FILE_PATH: &str = "kbs:///default/credential/test";
 pub const DEFAULT_MAX_CONCURRENT_DOWNLOAD: usize = 3;
 
 /// Path to the configuration file to generate ImageConfiguration
-pub const CONFIGURATION_FILE_PATH: &str = "/var/lib/image-rs/config.json";
+pub const CONFIGURATION_FILE_NAME: &str = "config.json";
 
 /// `image-rs` configuration information.
 #[derive(Clone, Debug, Deserialize)]

--- a/image-rs/src/decoder/mod.rs
+++ b/image-rs/src/decoder/mod.rs
@@ -8,7 +8,7 @@ use std::io;
 use anyhow::{bail, Result};
 use oci_distribution::manifest;
 use oci_spec::image::MediaType;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use tokio::io::{AsyncRead, BufReader};
 
 /// Error message for unhandled media type.
@@ -16,7 +16,7 @@ pub const ERR_BAD_MEDIA_TYPE: &str = "unhandled media type";
 
 /// Represents the layer compression algorithm type,
 /// and allows to decompress corresponding compressed data.
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Deserialize)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub enum Compression {
     Uncompressed,
     #[default]

--- a/image-rs/src/image.rs
+++ b/image-rs/src/image.rs
@@ -7,7 +7,7 @@ use oci_distribution::manifest::{OciDescriptor, OciImageManifest};
 use oci_distribution::secrets::RegistryAuth;
 use oci_distribution::Reference;
 use oci_spec::image::{ImageConfiguration, Os};
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use std::collections::{BTreeSet, HashMap};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -38,7 +38,7 @@ use crate::nydus::{service, utils};
 pub const IMAGE_SECURITY_CONFIG_DIR: &str = "/run/image-security";
 
 /// The metadata info for container image layer.
-#[derive(Clone, Debug, Default, Deserialize, PartialEq, Eq)]
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
 pub struct LayerMeta {
     /// Image layer compression algorithm type.
     pub decoder: Compression,
@@ -57,7 +57,7 @@ pub struct LayerMeta {
 }
 
 /// The metadata info for container image.
-#[derive(Clone, Debug, Default, Deserialize)]
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
 pub struct ImageMeta {
     /// The digest of the image configuration.
     pub id: String,

--- a/image-rs/src/meta_store.rs
+++ b/image-rs/src/meta_store.rs
@@ -1,5 +1,5 @@
 use anyhow::{anyhow, Result};
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::fs::File;
 use std::path::Path;
@@ -9,7 +9,7 @@ use crate::image::{ImageMeta, LayerMeta};
 pub const METAFILE: &str = "meta_store.json";
 
 /// `image-rs` container metadata storage database.
-#[derive(Clone, Default, Deserialize, Debug)]
+#[derive(Clone, Default, Serialize, Deserialize, Debug)]
 pub struct MetaStore {
     // image_db holds map of image ID with image data.
     pub image_db: HashMap<String, ImageMeta>,
@@ -29,5 +29,14 @@ impl TryFrom<&Path> for MetaStore {
             .map_err(|e| anyhow!("failed to open metastore file {}", e.to_string()))?;
         serde_json::from_reader::<File, MetaStore>(file)
             .map_err(|e| anyhow!("failed to parse metastore file {}", e.to_string()))
+    }
+}
+
+impl MetaStore {
+    pub fn write_to_file(&self, path: &str) -> Result<()> {
+        let file = File::create(path)
+            .map_err(|e| anyhow!("failed to create metastore file: {}", e.to_string()))?;
+        serde_json::to_writer(file, &self)
+            .map_err(|e| anyhow!("failed to write metastore to file: {}", e.to_string()))
     }
 }


### PR DESCRIPTION
Support to write `meta_store` to `meta_store.json`.
Set the absolute path for meta store with `meta_store.json`
