### PR TITLE
AA: add flag to enable eventlog

### DIFF
--- a/attestation-agent/attestation-agent/src/config/mod.rs
+++ b/attestation-agent/attestation-agent/src/config/mod.rs
@@ -69,6 +69,9 @@ pub struct EventlogConfig {
 
     /// PCR Register to extend INIT entry
     pub init_pcr: u64,
+
+    /// Flag whether enable eventlog recording
+    pub enable_eventlog: bool,
 }
 
 impl Default for EventlogConfig {
@@ -76,6 +79,7 @@ impl Default for EventlogConfig {
         Self {
             eventlog_algorithm: HashAlgorithm::Sha384,
             init_pcr: DEFAULT_PCR_INDEX,
+            enable_eventlog: false,
         }
     }
 }
@@ -119,6 +123,7 @@ impl TryFrom<&str> for Config {
             .add_source(config::File::with_name(config_path))
             .set_default("eventlog_config.eventlog_algorithm", DEFAULT_EVENTLOG_HASH)?
             .set_default("eventlog_config.init_pcr", DEFAULT_PCR_INDEX)?
+            .set_default("eventlog_config.enable_eventlog", "false")?
             .build()?;
 
         let cfg = c.try_deserialize()?;

--- a/attestation-agent/attestation-agent/src/lib.rs
+++ b/attestation-agent/attestation-agent/src/lib.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-use anyhow::{Context, Result};
+use anyhow::{bail, Context, Result};
 use async_trait::async_trait;
 use attester::{detect_tee_type, BoxedAttester};
 use std::{io::Write, str::FromStr};
@@ -81,20 +81,23 @@ pub struct AttestationAgent {
 
 impl AttestationAgent {
     pub async fn init(&mut self) -> Result<()> {
-        let alg = self.config.eventlog_config.eventlog_algorithm;
-        let pcr = self.config.eventlog_config.init_pcr;
-        let init_entry = LogEntry::Init(alg);
-        let digest = init_entry.digest_with(alg);
-        {
-            // perform atomicly in this block
-            let mut eventlog = self.eventlog.lock().await;
-            self.attester
-                .extend_runtime_measurement(digest, pcr)
-                .await
-                .context("write INIT entry")?;
+        if self.config.eventlog_config.enable_eventlog {
+            let alg = self.config.eventlog_config.eventlog_algorithm;
+            let pcr = self.config.eventlog_config.init_pcr;
+            let init_entry = LogEntry::Init(alg);
+            let digest = init_entry.digest_with(alg);
+            {
+                // perform atomicly in this block
+                let mut eventlog = self.eventlog.lock().await;
+                self.attester
+                    .extend_runtime_measurement(digest, pcr)
+                    .await
+                    .context("write INIT entry")?;
 
-            eventlog.write_log(&init_entry).context("write INIT log")?;
-        };
+                eventlog.write_log(&init_entry).context("write INIT log")?;
+            };
+        }
+
         Ok(())
     }
 
@@ -184,6 +187,10 @@ impl AttestationAPIs for AttestationAgent {
         content: &str,
         register_index: Option<u64>,
     ) -> Result<()> {
+        if !self.config.eventlog_config.enable_eventlog {
+            bail!("Extend eventlog not enabled when launching!");
+        }
+
         let pcr = register_index.unwrap_or_else(|| {
             let pcr = self.config.eventlog_config.init_pcr;
             debug!("No PCR index provided, use default {pcr}");


### PR DESCRIPTION
On most platforms, runtime measurement is now not supported. Thus the init PCR extension will fail.

This commit adds a flag for AA launch config to control whether eventlog is enabled. By default it will be closed.

In future, with initdata, the deployer would specify whether to enable eventlog in AA's config.

fixes #626

cc @ChengyuZhu6 

cc also @arronwy 