### PR TITLE
Improve KBS protocol version handling and bump the version to v0.1.1 due to kbs-types changes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3075,9 +3075,9 @@ dependencies = [
 
 [[package]]
 name = "kbs-types"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "febd73b2b1df274ea454d81ddf76f596af9754410b7ed6f988f2e1782a175da3"
+checksum = "9b6441ed73b0faa50707d4de41c6b45c76654b661b96aaf7b26a41331eedc0a5"
 dependencies = [
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ env_logger = "0.11.3"
 hex = "0.4.3"
 hmac = "0.12.1"
 jwt-simple = { version = "0.12", default-features = false, features = ["pure-rust"] }
-kbs-types = "0.6.0"
+kbs-types = "0.7.0"
 lazy_static = "1.4.0"
 log = "0.4.22"
 nix = "0.28"

--- a/attestation-agent/kbs_protocol/src/client/mod.rs
+++ b/attestation-agent/kbs_protocol/src/client/mod.rs
@@ -48,7 +48,7 @@ pub struct KbsClient<T> {
     pub(crate) token: Option<Token>,
 }
 
-pub const KBS_PROTOCOL_VERSION: &str = "0.1.0";
+pub const KBS_PROTOCOL_VERSION: &str = "0.1.1";
 
 pub const KBS_GET_RESOURCE_MAX_ATTEMPT: u64 = 3;
 

--- a/attestation-agent/kbs_protocol/src/client/rcar_client.rs
+++ b/attestation-agent/kbs_protocol/src/client/rcar_client.rs
@@ -104,7 +104,7 @@ impl KbsClient<Box<dyn EvidenceProvider>> {
         let request = Request {
             version: String::from(KBS_PROTOCOL_VERSION),
             tee,
-            extra_params: String::new(),
+            extra_params: serde_json::Value::String(String::new()),
         };
 
         debug!("send auth request to {auth_endpoint}");
@@ -153,7 +153,7 @@ impl KbsClient<Box<dyn EvidenceProvider>> {
         let attest_endpoint = format!("{}/{KBS_PREFIX}/attest", self.kbs_host_url);
         let attest = Attestation {
             tee_pubkey,
-            tee_evidence: evidence,
+            tee_evidence: serde_json::from_str(&evidence)?, // TODO: change attesters to return Value?
         };
 
         debug!("send attest request.");

--- a/attestation-agent/kbs_protocol/src/error.rs
+++ b/attestation-agent/kbs_protocol/src/error.rs
@@ -42,6 +42,6 @@ pub enum Error {
     #[error("KBS resource not found: {0}")]
     ResourceNotFound(String),
 
-    #[error("request unautorized")]
+    #[error("request unauthorized")]
     UnAuthorized,
 }

--- a/attestation-agent/kbs_protocol/src/keypair.rs
+++ b/attestation-agent/kbs_protocol/src/keypair.rs
@@ -7,7 +7,7 @@ use anyhow::{Context, Result};
 
 use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
 use crypto::{
-    rsa::{PaddingMode, RSAKeyPair, RSA_KTY},
+    rsa::{PaddingMode, RSAKeyPair},
     WrapType,
 };
 use kbs_types::{Response, TeePubKey};
@@ -31,11 +31,10 @@ impl TeeKeyPair {
         let k_mod = URL_SAFE_NO_PAD.encode(self.keypair.n());
         let k_exp = URL_SAFE_NO_PAD.encode(self.keypair.e());
 
-        Ok(TeePubKey {
+        Ok(TeePubKey::RSA {
             alg: PaddingMode::PKCS1v15.as_ref().to_string(),
             k_mod,
             k_exp,
-            kty: RSA_KTY.to_string(),
         })
     }
 


### PR DESCRIPTION
Pull in @Xynnn007's work for https://github.com/confidential-containers/trustee/issues/242#issuecomment-2146864188