### PR TITLE
ci: fix doc_lazy_continuation findings with Rust 1.80.0

### DIFF
--- a/attestation-agent/deps/crypto/src/lib.rs
+++ b/attestation-agent/deps/crypto/src/lib.rs
@@ -10,7 +10,7 @@
 //! underlying implementation is used:
 //! - `rust-crypto`: Use purely rust.
 //! - `openssl`: Use openssl. If `rust-crypto` and `openssl` are both
-//! enabled, use `openssl`.
+//!   enabled, use `openssl`.
 //!
 //! ## Components
 //!

--- a/attestation-agent/kbs_protocol/src/client/mod.rs
+++ b/attestation-agent/kbs_protocol/src/client/mod.rs
@@ -7,11 +7,11 @@
 //!
 //! There are two different kinds of KBS clients:
 //! - `RCAR Client`: s.t. `KbsClient<Box<dyn EvidenceProvider>>`. It can
-//! perform RCAR handshaking, get token and get resource using the
-//! authenticated http session.
+//!   perform RCAR handshaking, get token and get resource using the
+//!   authenticated http session.
 //! - `Token Client`: s.t. `KbsClient<Box<dyn TokenProvider>>`. It is a
-//! simpler client. It can only get resource with a valid token as its
-//! authentication materials.
+//!   simpler client. It can only get resource with a valid token as its
+//!   authentication materials.
 
 #[cfg(feature = "background_check")]
 pub mod rcar_client;

--- a/confidential-data-hub/hub/src/auth/kbs.rs
+++ b/confidential-data-hub/hub/src/auth/kbs.rs
@@ -75,7 +75,8 @@ impl Hub {
 /// - it does not have any `..`
 /// - it does not have any `.`
 /// - it starts with [`KBS_RESOURCE_STORAGE_DIR`]
-/// To avoid unexpected path attacks, such as putting a file
+///
+/// The checks are done avoid unexpected path attacks, such as putting a file
 /// to random path in the guest.
 fn is_path_valid(path: &str) -> bool {
     path.starts_with(KBS_RESOURCE_STORAGE_DIR) && !path.split('/').any(|it| it == ".." || it == ".")

--- a/confidential-data-hub/kms/src/api.rs
+++ b/confidential-data-hub/kms/src/api.rs
@@ -8,16 +8,16 @@
 //! To establish a connection between the client and the KMS/Vault server, two
 //! kinds of parameters are required:
 //! - Public parameters: like Region Id of the KMS/Vault, Instance Id of the KMS,
-//! etc. They are not confidential and can be seen by anyone. [`ProviderSettings`]
-//! is a json object. It is to include all the public parameters. The
-//! hashmap style makes it flexible for different kinds of KMSes/Vaults. There
-//! should be a function that takes a [`ProviderSettings`] as a input parameter
-//! and returns a client instance.
+//!   etc. They are not confidential and can be seen by anyone. [`ProviderSettings`]
+//!   is a json object. It is to include all the public parameters. The
+//!   hashmap style makes it flexible for different kinds of KMSes/Vaults. There
+//!   should be a function that takes a [`ProviderSettings`] as a input parameter
+//!   and returns a client instance.
 //! - Private parameters: like the credential to access (e.g. access key).
-//! These parameters should be captured inside the logic of `new()` rather
-//! than the input parameter. it is strongly recommended that private parameters
-//! be read from the encrypted filesystem, e.g. `/run/*` which is in TEE's
-//! encrypted memory.
+//!   These parameters should be captured inside the logic of `new()` rather
+//!   than the input parameter. it is strongly recommended that private parameters
+//!   be read from the encrypted filesystem, e.g. `/run/*` which is in TEE's
+//!   encrypted memory.
 //!
 //! ## APIs
 //! - `Decrypter`: KMS's decrypt API.
@@ -27,7 +27,7 @@
 //!
 //! The rationality to distinguish these four different traits:
 //! - `Decrypter` and `Getter` are used in-guest, while `Encrypter` and `Setter`
-//! are used userside. They do not need to be implemented by a same object.
+//!   are used userside. They do not need to be implemented by a same object.
 
 use crate::Result;
 

--- a/image-rs/src/resource/kbs/mod.rs
+++ b/image-rs/src/resource/kbs/mod.rs
@@ -57,7 +57,7 @@ trait Client: Send + Sync {
 impl SecureChannel {
     /// Create a new [`SecureChannel`], the input parameter:
     /// * `decrypt_config`: s string with format `provider:attestation-agent:<kbc_name>::<kbs_uri>`.
-    /// This parameter is only used when in native secure channel (for enclave-cc)
+    ///   This parameter is only used when in native secure channel (for enclave-cc)
     pub async fn new(_decrypt_config: &Option<&str>) -> Result<Self> {
         let client: Box<dyn Client> = {
             cfg_if::cfg_if! {

--- a/image-rs/src/signature/mechanism/cosign/mod.rs
+++ b/image-rs/src/signature/mechanism/cosign/mod.rs
@@ -118,9 +118,10 @@ impl CosignParameters {
     /// Verify the cosign-signed image. There will be three steps:
     /// * Get the pub key.
     /// * Download the cosign-signed image's manifest and its digest. Calculate its
-    /// signature's image.
+    ///   signature's image.
     /// * Download the signature image, gather the signatures and verify them
-    /// using the pubkey.
+    ///   using the pubkey.
+    ///
     /// If succeeds, the payloads of the signature will be returned.
     async fn verify_signature_and_get_payload(
         &self,

--- a/image-rs/src/signature/mechanism/simple/sigstore.rs
+++ b/image-rs/src/signature/mechanism/simple/sigstore.rs
@@ -65,10 +65,10 @@ impl SigstoreConfig {
 
     /// Update current [`SigstoreConfig`] using another [`SigstoreConfig`].
     /// - If current [`SigstoreConfig`] does not have a `default_config` but the input [`SigstoreConfig`]
-    /// has one, the current [`SigstoreConfig`] will use the input one's `default_config`.
+    ///   has one, the current [`SigstoreConfig`] will use the input one's `default_config`.
     /// - If no duplicated `docker_namespace_config` is found in the input  [`SigstoreConfig`],
-    /// the current [`SigstoreConfig`] will be added all the input one's `docker_namespace_config`.
-    /// Any error will cause the update fail, and roll back to the original state.
+    ///   the current [`SigstoreConfig`] will be added all the input one's `docker_namespace_config`.
+    ///   Any error will cause the update fail, and roll back to the original state.
     pub fn update_self(&mut self, input: SigstoreConfig) -> Result<()> {
         let mut merged_config = self.clone();
         // The "default-docker" only allowed to be defined in one config file.

--- a/image-rs/src/signature/policy/policy_requirement.rs
+++ b/image-rs/src/signature/policy/policy_requirement.rs
@@ -14,7 +14,7 @@ use crate::signature::mechanism::{cosign::CosignParameters, simple::SimpleParame
 /// * `Accept`: s.t. `insecureAcceptAnything`, skip signature verification, accept the image unconditionally.
 /// * `Reject`: s.t. `reject`, reject the image directly.
 /// * `SignedBy`: s.t. `signBy`, means that the image is signed by `Simple Signing`,
-/// and the related parameters are inside the enum.
+///   and the related parameters are inside the enum.
 #[derive(Deserialize, Debug, PartialEq, Eq, Serialize)]
 #[serde(tag = "type")]
 pub enum PolicyReqType {


### PR DESCRIPTION
The CI builds for 'stable' now point to Rust 1.80.0 and some linter checks started failing with the newly added check for doc_lazy_continuation.