### PR TITLE
ocicrypt-rs: dont't swallow pre_unwrap_key() error

### DIFF
--- a/ocicrypt-rs/src/encryption.rs
+++ b/ocicrypt-rs/src/encryption.rs
@@ -188,10 +188,9 @@ pub fn decrypt_layer_key_opts_data(
                 priv_key_given = true;
             }
 
-            if let Ok(opts_data) = pre_unwrap_key(keywrapper, dc, &b64_annotation) {
-                if !opts_data.is_empty() {
-                    return Ok(opts_data);
-                }
+            let opts_data = pre_unwrap_key(keywrapper, dc, &b64_annotation)?;
+            if !opts_data.is_empty() {
+                return Ok(opts_data);
             }
             // try next keywrapper
         }


### PR DESCRIPTION
The error for encryption::pre_unwrap_key() is silently discarded, which means we get no meaningful error in consumers, like the kata-agent log on ttrpc connectivity problems. I don't think it makes sense to not abort on errors from pre_unwrap_key.