### PR TITLE
attestation-agent: Extend ResourceUri to support query string

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4890,6 +4890,7 @@ name = "resource_uri"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "rstest",
  "serde",
  "serde_json",
  "url",

--- a/attestation-agent/deps/resource_uri/Cargo.toml
+++ b/attestation-agent/deps/resource_uri/Cargo.toml
@@ -5,6 +5,9 @@ authors = ["The Attestation Agent Authors"]
 publish = false
 edition = "2021"
 
+[dev-dependencies]
+rstest.workspace = true
+
 [dependencies]
 anyhow.workspace = true
 serde.workspace = true

--- a/attestation-agent/kbs_protocol/src/client/rcar_client.rs
+++ b/attestation-agent/kbs_protocol/src/client/rcar_client.rs
@@ -198,10 +198,13 @@ impl KbsClient<Box<dyn EvidenceProvider>> {
 #[async_trait]
 impl KbsClientCapabilities for KbsClient<Box<dyn EvidenceProvider>> {
     async fn get_resource(&mut self, resource_uri: ResourceUri) -> Result<Vec<u8>> {
-        let remote_url = format!(
+        let mut remote_url = format!(
             "{}/{KBS_PREFIX}/resource/{}/{}/{}",
             self.kbs_host_url, resource_uri.repository, resource_uri.r#type, resource_uri.tag
         );
+        if let Some(ref q) = resource_uri.query {
+            remote_url = format!("{}?{}", remote_url, q);
+        }
 
         for attempt in 1..=KBS_GET_RESOURCE_MAX_ATTEMPT {
             debug!("KBS client: trying to request KBS, attempt {attempt}");

--- a/attestation-agent/kbs_protocol/src/client/token_client.rs
+++ b/attestation-agent/kbs_protocol/src/client/token_client.rs
@@ -31,10 +31,14 @@ impl KbsClient<Box<dyn TokenProvider>> {
 #[async_trait]
 impl KbsClientCapabilities for KbsClient<Box<dyn TokenProvider>> {
     async fn get_resource(&mut self, resource_uri: ResourceUri) -> Result<Vec<u8>> {
-        let remote_url = format!(
+        let mut remote_url = format!(
             "{}/{KBS_PREFIX}/resource/{}/{}/{}",
             self.kbs_host_url, resource_uri.repository, resource_uri.r#type, resource_uri.tag
         );
+        if let Some(ref q) = resource_uri.query {
+            remote_url = format!("{}?{}", remote_url, q);
+        }
+
         for attempt in 1..=KBS_GET_RESOURCE_MAX_ATTEMPT {
             debug!("KBS client: trying to request KBS, attempt {attempt}");
             if self.token.is_none() {


### PR DESCRIPTION
With this change, the kbs-client is able to send a get-resource request that includes the query string provided e.g.:

kbs-client --url http://127.0.0.1:8080 \
           get-resource \
           --path 'plugin/nebula/credential?ip[ip]=10.11.12.13&ip[netbits]=21&name=pod1'

This is required by the KBS repository plugin interface.