### PR TITLE
GHA: Remove {pre,post}-action steps for self-hosted runners

### DIFF
--- a/.github/workflows/aa_basic.yml
+++ b/.github/workflows/aa_basic.yml
@@ -52,12 +52,6 @@ jobs:
         with:
           fetch-depth: 1
 
-      - name: Take a pre-action for self-hosted runner
-        run: |
-          if [ -f "${HOME}/script/pre_action.sh" ]; then
-            "${HOME}/script/pre_action.sh" cc-guest-components
-          fi
-
       - name: Install Rust toolchain (${{ matrix.rust }})
         uses: actions-rs/toolchain@v1
         with:
@@ -119,10 +113,3 @@ jobs:
           command: clippy
           # We are getting error in generated code due to derive_partial_eq_without_eq check, so ignore it for now
           args: ${{ matrix.cargo_lint_opts }} -- -D warnings -A clippy::derive-partial-eq-without-eq
-
-      - name: Take a post-action for self-hosted runner
-        if: always()
-        run: |
-          if [ -f ${HOME}/script/post_action.sh ]; then
-            ${HOME}/script/post_action.sh cc-guest-components
-          fi

--- a/.github/workflows/api-server-rest-basic.yml
+++ b/.github/workflows/api-server-rest-basic.yml
@@ -43,12 +43,6 @@ jobs:
         with:
           fetch-depth: 1
 
-      - name: Take a pre-action for self-hosted runner
-        run: |
-          if [ -f "${HOME}/script/pre_action.sh" ]; then
-            "${HOME}/script/pre_action.sh" cc-guest-components
-          fi
-
       - name: Install Rust toolchain (${{ matrix.rust }})
         uses: actions-rs/toolchain@v1
         with:
@@ -76,10 +70,3 @@ jobs:
         with:
           command: test
           args: -p api-server-rest
-
-      - name: Take a post-action for self-hosted runner
-        if: always()
-        run: |
-          if [ -f ${HOME}/script/post_action.sh ]; then
-            ${HOME}/script/post_action.sh cc-guest-components
-          fi

--- a/.github/workflows/cdh_basic.yml
+++ b/.github/workflows/cdh_basic.yml
@@ -43,12 +43,6 @@ jobs:
         with:
           fetch-depth: 1
 
-      - name: Take a pre-action for self-hosted runner
-        run: |
-          if [ -f "${HOME}/script/pre_action.sh" ]; then
-            "${HOME}/script/pre_action.sh" cc-guest-components
-          fi
-
       - name: Install Rust toolchain (${{ matrix.rust }})
         uses: actions-rs/toolchain@v1
         with:
@@ -89,10 +83,3 @@ jobs:
           command: clippy
           # We are getting error in generated code due to derive_partial_eq_without_eq check, so ignore it for now
           args: -p kms -p confidential-data-hub -p secret -p image -- -D warnings -A clippy::derive-partial-eq-without-eq 
-
-      - name: Take a post-action for self-hosted runner
-        if: always()
-        run: |
-          if [ -f ${HOME}/script/post_action.sh ]; then
-            ${HOME}/script/post_action.sh cc-guest-components
-          fi

--- a/.github/workflows/image_rs_build.yml
+++ b/.github/workflows/image_rs_build.yml
@@ -43,12 +43,6 @@ jobs:
         with:
           fetch-depth: 1
 
-      - name: Take a pre-action for self-hosted runner
-        run: |
-          if [ -f "${HOME}/script/pre_action.sh" ]; then
-            "${HOME}/script/pre_action.sh" cc-guest-components
-          fi
-
       - name: Install Rust toolchain (${{ matrix.rust }})
         uses: actions-rs/toolchain@v1
         with:
@@ -151,10 +145,3 @@ jobs:
         run: |
           sudo -E PATH=$PATH -s cargo test -p image-rs --no-default-features --features=kata-cc-native-tls,keywrap-jwe,nydus
         if: matrix.instance == 'ubuntu-latest'
-
-      - name: Take a post-action for self-hosted runner
-        if: always()
-        run: |
-          if [ -f ${HOME}/script/post_action.sh ]; then
-            ${HOME}/script/post_action.sh cc-guest-components
-          fi


### PR DESCRIPTION
The following hooks:

- ACTIONS_RUNNER_HOOK_JOB_STARTED
- ACTIONS_RUNNER_HOOK_JOB_COMPLETED

could perfectly replace the existing {pre,post}-action scripts and will make a workflow independent of the runner context. This PR wipes out all GHA steps where the actions are triggered.

Signed-off-by: Hyounggyu Choi <Hyounggyu.Choi@ibm.com>