### PR TITLE
ci: increase open-pull-requests-limit from 1 to 3

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,7 @@ updates:
     directory: "/"
     schedule:
       interval: daily
-    open-pull-requests-limit: 1
+    open-pull-requests-limit: 3
     allow:
     - dependency-type: direct
 


### PR DESCRIPTION
the default value for open-pull-requests-limit is 5, to avoid block by some PR may need rebase source code, change the value from 1 to 3

Signed-off-by: Wang, Arron <arron.wang@intel.com>