### PR TITLE
GHA: Fix condition for duplicate checks post-merge

### DIFF
--- a/.github/workflows/aa_basic.yml
+++ b/.github/workflows/aa_basic.yml
@@ -24,7 +24,7 @@ concurrency:
 
 jobs:
   basic_ci:
-    if: github.event_name != 'push' || github.event.pull_request.merged == false
+    if: github.event_name != 'push'
     name: Check
     defaults:
       run:

--- a/.github/workflows/aa_cc_kbc.yml
+++ b/.github/workflows/aa_cc_kbc.yml
@@ -24,7 +24,7 @@ concurrency:
 
 jobs:
   cc_kbc_ci:
-    if: github.event_name != 'push' || github.event.pull_request.merged == false
+    if: github.event_name != 'push'
     name: Check
     defaults:
       run:

--- a/.github/workflows/aa_crypto.yml
+++ b/.github/workflows/aa_crypto.yml
@@ -20,7 +20,7 @@ concurrency:
 
 jobs:
   crypto_ci:
-    if: github.event_name != 'push' || github.event.pull_request.merged == false
+    if: github.event_name != 'push'
     name: Check
     defaults:
       run:

--- a/.github/workflows/aa_eaa_kbc.yml
+++ b/.github/workflows/aa_eaa_kbc.yml
@@ -20,7 +20,7 @@ concurrency:
 
 jobs:
   eaa_kbc_ci:
-    if: github.event_name != 'push' || github.event.pull_request.merged == false
+    if: github.event_name != 'push'
     name: Check
     defaults:
       run:

--- a/.github/workflows/aa_occlum_sgx.yml
+++ b/.github/workflows/aa_occlum_sgx.yml
@@ -21,7 +21,7 @@ concurrency:
 
 jobs:
   occlum_sgx_ci:
-    if: github.event_name != 'push' || github.event.pull_request.merged == false
+    if: github.event_name != 'push'
     runs-on: sgx
     steps:
       - name: Checkout Code

--- a/.github/workflows/aa_sample_keyprovider.yml
+++ b/.github/workflows/aa_sample_keyprovider.yml
@@ -19,7 +19,7 @@ concurrency:
 
 jobs:
   coco_keyprovider_ci:
-    if: github.event_name != 'push' || github.event.pull_request.merged == false
+    if: github.event_name != 'push'
     name: Check
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/aa_sev_kbc.yml
+++ b/.github/workflows/aa_sev_kbc.yml
@@ -19,7 +19,7 @@ concurrency:
 
 jobs:
   offline_sev_kbc_ci:
-    if: github.event_name != 'push' || github.event.pull_request.merged == false
+    if: github.event_name != 'push'
     name: Check
     defaults:
       run:

--- a/.github/workflows/api-server-rest-basic.yml
+++ b/.github/workflows/api-server-rest-basic.yml
@@ -24,7 +24,7 @@ concurrency:
 
 jobs:
   basic_ci:
-    if: github.event_name != 'push' || github.event.pull_request.merged == false
+    if: github.event_name != 'push'
     name: Check
     defaults:
       run:

--- a/.github/workflows/cdh_basic.yml
+++ b/.github/workflows/cdh_basic.yml
@@ -24,7 +24,7 @@ concurrency:
 
 jobs:
   basic_ci:
-    if: github.event_name != 'push' || github.event.pull_request.merged == false
+    if: github.event_name != 'push'
     name: Check
     defaults:
       run:

--- a/.github/workflows/image_rs_build.yml
+++ b/.github/workflows/image_rs_build.yml
@@ -23,7 +23,7 @@ concurrency:
 
 jobs:
   ci:
-    if: github.event_name != 'push' || github.event.pull_request.merged == false
+    if: github.event_name != 'push'
     name: Check
     defaults:
       run:

--- a/.github/workflows/ocicrypt_rs_build.yml
+++ b/.github/workflows/ocicrypt_rs_build.yml
@@ -23,7 +23,7 @@ concurrency:
 
 jobs:
   ci:
-    if: github.event_name != 'push' || github.event.pull_request.merged == false
+    if: github.event_name != 'push'
     name: Check
     runs-on: ubuntu-latest
     strategy:


### PR DESCRIPTION
Despite #644, duplicate checks are still being triggered post-merge. The following condition seemed intuitive:

- github.event_name != 'push' || github.event.pull_request.merged == false

But it turns out that `pull_request.merged` is still false on merge, which allows the job to proceed. 
(see https://github.com/BbolroC/cc-guest-components/actions/runs/10215060610/workflow)

This commit focuses solely on `github.event_name != 'push'`, which is true on merge. 
(see https://github.com/BbolroC/cc-guest-components/actions/runs/10215137827/workflow)

Signed-off-by: Hyounggyu Choi <Hyounggyu.Choi@ibm.com>