### PR TITLE
deps: upgrade oci-distribution to v0.12.0

### DIFF
--- a/.github/workflows/image_rs_build.yml
+++ b/.github/workflows/image_rs_build.yml
@@ -118,11 +118,11 @@ jobs:
 
       - name: Run cargo test - kata-cc (rust-tls version) with keywrap-grpc + keywrap-jwe
         run: |
-          sudo -E PATH=$PATH -s cargo test -p image-rs --no-default-features --features=encryption-ring,keywrap-grpc,snapshot-overlayfs,signature-cosign-rustls,signature-simple,getresource,oci-distribution/rustls-tls,keywrap-jwe
+          sudo -E PATH=$PATH -s cargo test -p image-rs --no-default-features --features=encryption-ring,keywrap-grpc,snapshot-overlayfs,signature-cosign-rustls,signature-simple,getresource,oci-client/rustls-tls,keywrap-jwe
 
       - name: Run cargo test - kata-cc (native-tls version) with keywrap-grpc + keywrap-jwe
         run: |
-          sudo -E PATH=$PATH -s cargo test -p image-rs --no-default-features --features=encryption-openssl,keywrap-grpc,snapshot-overlayfs,signature-cosign-native,signature-simple,getresource,oci-distribution/native-tls,keywrap-jwe
+          sudo -E PATH=$PATH -s cargo test -p image-rs --no-default-features --features=encryption-openssl,keywrap-grpc,snapshot-overlayfs,signature-cosign-native,signature-simple,getresource,oci-client/native-tls,keywrap-jwe
 
       - name: Run cargo test - kata-cc (rust-tls version) with keywrap-ttrpc (default) + keywrap-jwe
         run: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2754,7 +2754,7 @@ dependencies = [
  "nix 0.28.0",
  "nydus-api",
  "nydus-service",
- "oci-distribution",
+ "oci-client",
  "oci-spec",
  "ocicrypt-rs",
  "prost 0.11.9",
@@ -3862,6 +3862,31 @@ dependencies = [
  "cfg-if",
  "libc",
  "sgx_types",
+]
+
+[[package]]
+name = "oci-client"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce611137700c3ec179993d5357dddde194bd706690b361f2f6b9235d4e29830e"
+dependencies = [
+ "bytes",
+ "chrono",
+ "futures-util",
+ "http 1.1.0",
+ "http-auth",
+ "jwt",
+ "lazy_static",
+ "olpc-cjson",
+ "regex",
+ "reqwest 0.12.4",
+ "serde",
+ "serde_json",
+ "sha2 0.10.8",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "unicase",
 ]
 
 [[package]]

--- a/image-rs/Cargo.toml
+++ b/image-rs/Cargo.toml
@@ -32,7 +32,7 @@ lazy_static = { workspace = true, optional = true }
 log = "0.4.22"
 loopdev = { git = "https://github.com/mdaffin/loopdev", rev = "c9f91e8f0326ce8a3364ac911e81eb32328a5f27" }
 nix = { workspace = true, optional = true, features = ["mount"] }
-oci-distribution = { version = "0.11", default-features = false, optional = true }
+oci-client = { version = "0.12", default-features = false, optional = true }
 oci-spec = "0.6.7"
 ocicrypt-rs = { path = "../ocicrypt-rs", default-features = false, features = [
     "async-io",
@@ -94,7 +94,7 @@ default = [
     "snapshot-overlayfs",
     "signature-cosign-rustls",
     "keywrap-grpc",
-    "oci-distribution-rustls",
+    "oci-client-rustls",
 ]
 
 # This will be based on `ring` dependency
@@ -105,7 +105,7 @@ kata-cc-rustls-tls = [
     "signature-cosign-rustls",
     "signature-simple",
     "getresource",
-    "oci-distribution/rustls-tls",
+    "oci-client/rustls-tls",
     "reqwest?/rustls-tls",
 ]
 enclave-cc-cckbc-rustls-tls = [
@@ -115,7 +115,7 @@ enclave-cc-cckbc-rustls-tls = [
     "signature-simple",
     "getresource",
     "signature-cosign-rustls",
-    "oci-distribution-rustls",
+    "oci-client-rustls",
     "reqwest?/rustls-tls",
 ]
 
@@ -127,7 +127,7 @@ kata-cc-native-tls = [
     "signature-cosign-native",
     "signature-simple",
     "getresource",
-    "oci-distribution/native-tls",
+    "oci-client/native-tls",
     "reqwest?/default-tls",
 ]
 enclave-cc-cckbc-native-tls = [
@@ -137,7 +137,7 @@ enclave-cc-cckbc-native-tls = [
     "signature-simple",
     "getresource",
     "signature-cosign-native",
-    "oci-distribution-native",
+    "oci-client-native",
     "reqwest?/default-tls",
 ]
 
@@ -183,8 +183,8 @@ signature-cosign = ["signature", "futures"]
 signature-cosign-rustls = ["signature-cosign", "sigstore/cosign-rustls-tls"]
 signature-cosign-native = ["signature-cosign", "sigstore/cosign-native-tls"]
 
-oci-distribution-rustls = ["oci-distribution/rustls-tls"]
-oci-distribution-native = ["oci-distribution/native-tls"]
+oci-client-rustls = ["oci-client/rustls-tls"]
+oci-client-native = ["oci-client/native-tls"]
 
 signature-simple-xrss = ["signature-simple", "dep:reqwest"]
 signature-simple = ["signature", "sequoia-openpgp", "serde_yaml"]

--- a/image-rs/src/auth/auth_config.rs
+++ b/image-rs/src/auth/auth_config.rs
@@ -10,7 +10,7 @@ use std::collections::HashMap;
 
 use anyhow::*;
 use base64::Engine;
-use oci_distribution::{secrets::RegistryAuth, Reference};
+use oci_client::{secrets::RegistryAuth, Reference};
 
 use super::DockerAuthConfig;
 
@@ -120,7 +120,7 @@ fn auth_keys_for_key(key: &str) -> Vec<String> {
 mod tests {
     use std::collections::HashMap;
 
-    use oci_distribution::{secrets::RegistryAuth, Reference};
+    use oci_client::{secrets::RegistryAuth, Reference};
     use rstest::rstest;
 
     use crate::auth::DockerAuthConfig;

--- a/image-rs/src/auth/mod.rs
+++ b/image-rs/src/auth/mod.rs
@@ -8,7 +8,7 @@ pub mod auth_config;
 use std::collections::HashMap;
 
 use anyhow::*;
-use oci_distribution::{secrets::RegistryAuth, Reference};
+use oci_client::{secrets::RegistryAuth, Reference};
 use serde::{Deserialize, Serialize};
 
 /// Hard-coded ResourceDescription of `auth.json`.

--- a/image-rs/src/decoder/mod.rs
+++ b/image-rs/src/decoder/mod.rs
@@ -6,7 +6,7 @@ use std::fmt;
 use std::io;
 
 use anyhow::{bail, Result};
-use oci_distribution::manifest;
+use oci_client::manifest;
 use oci_spec::image::MediaType;
 use serde::{Deserialize, Serialize};
 use tokio::io::{AsyncRead, BufReader};

--- a/image-rs/src/decrypt.rs
+++ b/image-rs/src/decrypt.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::{bail, Result};
-use oci_distribution::manifest::{self, OciDescriptor};
+use oci_client::manifest::{self, OciDescriptor};
 use tokio::io::AsyncRead;
 
 /// Image layer encryption type information and associated methods to decrypt image layers.

--- a/image-rs/src/image.rs
+++ b/image-rs/src/image.rs
@@ -3,9 +3,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::{anyhow, bail, Result};
-use oci_distribution::manifest::{OciDescriptor, OciImageManifest};
-use oci_distribution::secrets::RegistryAuth;
-use oci_distribution::Reference;
+use oci_client::manifest::{OciDescriptor, OciImageManifest};
+use oci_client::secrets::RegistryAuth;
+use oci_client::Reference;
 use oci_spec::image::{ImageConfiguration, Os};
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeSet, HashMap};

--- a/image-rs/src/nydus/service.rs
+++ b/image-rs/src/nydus/service.rs
@@ -5,7 +5,7 @@
 use anyhow::{anyhow, bail, Result};
 use log::{error, info};
 use nix::mount::MsFlags;
-use oci_distribution::Reference;
+use oci_client::Reference;
 use oci_spec::image::Os;
 use std::convert::TryInto;
 use std::path::Path;

--- a/image-rs/src/nydus/utils.rs
+++ b/image-rs/src/nydus/utils.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use nydus_api::BuildTimeInfo;
-use oci_distribution::manifest;
+use oci_client::manifest;
 
 pub fn is_nydus_data_layer(desc: &manifest::OciDescriptor) -> bool {
     desc.annotations

--- a/image-rs/src/pull.rs
+++ b/image-rs/src/pull.rs
@@ -4,8 +4,8 @@
 
 use anyhow::{anyhow, bail, Result};
 use futures_util::stream::{self, StreamExt, TryStreamExt};
-use oci_distribution::manifest::{OciDescriptor, OciImageManifest};
-use oci_distribution::{secrets::RegistryAuth, Client, Reference};
+use oci_client::manifest::{OciDescriptor, OciImageManifest};
+use oci_client::{secrets::RegistryAuth, Client, Reference};
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -21,7 +21,7 @@ use crate::stream::stream_processing;
 /// The PullClient connects to remote OCI registry, pulls the container image,
 /// and save the image layers under data_dir and return the layer meta info.
 pub struct PullClient<'a> {
-    /// `oci-distribution` client to talk with remote OCI registry.
+    /// `oci-client` to talk with remote OCI registry.
     pub client: Client,
 
     /// OCI registry auth info.
@@ -100,7 +100,7 @@ impl<'a> PullClient<'a> {
                     .pull_blob_stream(&self.reference, &layer)
                     .await
                     .map_err(|e| anyhow!("failed to async pull blob stream {}", e.to_string()))?;
-                let layer_reader = StreamReader::new(layer_stream);
+                let layer_reader = StreamReader::new(layer_stream.stream);
                 self.async_handle_layer(
                     layer,
                     diff_ids[i].clone(),
@@ -201,7 +201,7 @@ mod tests {
     use crate::decoder::ERR_BAD_MEDIA_TYPE;
     use crate::ERR_BAD_UNCOMPRESSED_DIGEST;
     use flate2::write::GzEncoder;
-    use oci_distribution::manifest::IMAGE_CONFIG_MEDIA_TYPE;
+    use oci_client::manifest::IMAGE_CONFIG_MEDIA_TYPE;
     use oci_spec::image::{ImageConfiguration, MediaType};
     use std::io::Write;
 

--- a/image-rs/src/signature/image/mod.rs
+++ b/image-rs/src/signature/image/mod.rs
@@ -4,7 +4,7 @@
 //
 
 use anyhow::*;
-use oci_distribution::Reference;
+use oci_client::Reference;
 
 pub mod digest;
 

--- a/image-rs/src/signature/mechanism/mod.rs
+++ b/image-rs/src/signature/mechanism/mod.rs
@@ -16,7 +16,7 @@
 
 use anyhow::*;
 use async_trait::async_trait;
-use oci_distribution::secrets::RegistryAuth;
+use oci_client::secrets::RegistryAuth;
 
 use crate::config::Paths;
 

--- a/image-rs/src/signature/mechanism/simple/mod.rs
+++ b/image-rs/src/signature/mechanism/simple/mod.rs
@@ -5,7 +5,7 @@
 
 use anyhow::*;
 use async_trait::async_trait;
-use oci_distribution::secrets::RegistryAuth;
+use oci_client::secrets::RegistryAuth;
 use serde::*;
 use strum_macros::Display;
 use strum_macros::EnumString;

--- a/image-rs/src/signature/mechanism/simple/sigstore.rs
+++ b/image-rs/src/signature/mechanism/simple/sigstore.rs
@@ -4,7 +4,7 @@
 //
 
 use anyhow::{anyhow, bail, Result};
-use oci_distribution::Reference;
+use oci_client::Reference;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::ffi::OsStr;
@@ -195,7 +195,7 @@ pub async fn get_sigs_from_specific_sigstore(sigstore_uri: url::Url) -> Result<V
 #[cfg(test)]
 mod tests {
     use super::*;
-    use oci_distribution::Reference;
+    use oci_client::Reference;
     use std::convert::TryFrom;
     use std::env;
     use std::fs;

--- a/image-rs/src/signature/mechanism/simple/verify.rs
+++ b/image-rs/src/signature/mechanism/simple/verify.rs
@@ -130,7 +130,7 @@ mod tests {
     use crate::signature::policy::ref_match::PolicyReqMatchType;
 
     use super::*;
-    use oci_distribution::Reference;
+    use oci_client::Reference;
     use serde_json::json;
 
     const SIG_PAYLOAD_JSON: &str = r#"{

--- a/image-rs/src/signature/mechanism/simple/xrss.rs
+++ b/image-rs/src/signature/mechanism/simple/xrss.rs
@@ -5,7 +5,7 @@
 
 use anyhow::*;
 use base64::Engine;
-use oci_distribution::{secrets::RegistryAuth, Reference};
+use oci_client::{secrets::RegistryAuth, Reference};
 use reqwest::{header::HeaderValue, Client};
 use serde::*;
 

--- a/image-rs/src/signature/mod.rs
+++ b/image-rs/src/signature/mod.rs
@@ -11,7 +11,7 @@ pub mod policy;
 use crate::{config::Paths, signature::policy::Policy};
 
 use anyhow::Result;
-use oci_distribution::secrets::RegistryAuth;
+use oci_client::secrets::RegistryAuth;
 
 /// `allows_image` will check all the `PolicyRequirements` suitable for
 /// the given image. The `PolicyRequirements` is defined in
@@ -25,7 +25,7 @@ pub async fn allows_image(
 ) -> Result<()> {
     use crate::{resource, signature::image::Image};
 
-    let reference = oci_distribution::Reference::try_from(image_reference)?;
+    let reference = oci_client::Reference::try_from(image_reference)?;
     let mut image = Image::default_with_reference(reference);
     image.set_manifest_digest(image_digest)?;
 

--- a/image-rs/src/signature/payload/simple_signing.rs
+++ b/image-rs/src/signature/payload/simple_signing.rs
@@ -8,7 +8,7 @@
 use std::collections::HashMap;
 
 use anyhow::{bail, Result};
-use oci_distribution::Reference;
+use oci_client::Reference;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 

--- a/image-rs/src/signature/policy/mod.rs
+++ b/image-rs/src/signature/policy/mod.rs
@@ -4,7 +4,7 @@
 //
 
 use anyhow::{bail, Result};
-use oci_distribution::secrets::RegistryAuth;
+use oci_client::secrets::RegistryAuth;
 use serde::Deserialize;
 use std::collections::HashMap;
 use strum_macros::{Display, EnumString};

--- a/image-rs/src/signature/policy/policy_requirement.rs
+++ b/image-rs/src/signature/policy/policy_requirement.rs
@@ -4,7 +4,7 @@
 //
 
 use anyhow::{anyhow, Result};
-use oci_distribution::secrets::RegistryAuth;
+use oci_client::secrets::RegistryAuth;
 use serde::*;
 
 use crate::signature::image::Image;

--- a/image-rs/src/signature/policy/ref_match.rs
+++ b/image-rs/src/signature/policy/ref_match.rs
@@ -4,7 +4,7 @@
 //
 
 use anyhow::{bail, Result};
-use oci_distribution::Reference;
+use oci_client::Reference;
 use serde::*;
 
 use crate::signature::{image, policy::ErrorInfo};
@@ -147,7 +147,7 @@ mod tests {
     fn test_policy_matches_docker_reference() {
         struct TestData<'a> {
             match_policy: PolicyReqMatchType,
-            origin_reference: oci_distribution::Reference,
+            origin_reference: oci_client::Reference,
             signed_reference: &'a str,
         }
 
@@ -158,7 +158,7 @@ mod tests {
                         "type": "matchExact"
                     }"#
                 ).unwrap(),
-                origin_reference: oci_distribution::Reference::try_from("docker.io/example/busybox:latest").unwrap(),
+                origin_reference: oci_client::Reference::try_from("docker.io/example/busybox:latest").unwrap(),
                 signed_reference: "docker.io/example/busybox:latest",
             },
             TestData {
@@ -167,7 +167,7 @@ mod tests {
                         "type": "matchRepoDigestOrExact"
                     }"#
                 ).unwrap(),
-                origin_reference: oci_distribution::Reference::try_from("docker.io/example/busybox:latest").unwrap(),
+                origin_reference: oci_client::Reference::try_from("docker.io/example/busybox:latest").unwrap(),
                 signed_reference: "docker.io/example/busybox:latest",
             },
             TestData {
@@ -176,7 +176,7 @@ mod tests {
                         "type": "matchRepoDigestOrExact"
                     }"#
                 ).unwrap(),
-                origin_reference: oci_distribution::Reference::try_from(
+                origin_reference: oci_client::Reference::try_from(
                     "docker.io/example/busybox@sha256:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
                 ).unwrap(),
                 signed_reference: "docker.io/example/busybox:tag",
@@ -187,7 +187,7 @@ mod tests {
                         "type": "matchRepository"
                     }"#
                 ).unwrap(),
-                origin_reference: oci_distribution::Reference::try_from("docker.io/example/busybox:latest").unwrap(),
+                origin_reference: oci_client::Reference::try_from("docker.io/example/busybox:latest").unwrap(),
                 signed_reference: "docker.io/example/busybox:tag",
             },
             TestData {
@@ -197,7 +197,7 @@ mod tests {
                         "dockerReference": "docker.io/mylib/busybox:latest"
                     }"#
                 ).unwrap(),
-                origin_reference: oci_distribution::Reference::try_from("docker.io/example/busybox:latest").unwrap(),
+                origin_reference: oci_client::Reference::try_from("docker.io/example/busybox:latest").unwrap(),
                 signed_reference: "docker.io/mylib/busybox:latest",
             },
             TestData {
@@ -207,7 +207,7 @@ mod tests {
                         "dockerRepository": "docker.io/mylib/busybox"
                     }"#
                 ).unwrap(),
-                origin_reference: oci_distribution::Reference::try_from("docker.io/example/busybox:latest").unwrap(),
+                origin_reference: oci_client::Reference::try_from("docker.io/example/busybox:latest").unwrap(),
                 signed_reference: "docker.io/mylib/busybox:tag",
             },
             TestData {
@@ -218,7 +218,7 @@ mod tests {
                         "signedPrefix": "quay.io"
                     }"#
                 ).unwrap(),
-                origin_reference: oci_distribution::Reference::try_from("docker.io/example/busybox:latest").unwrap(),
+                origin_reference: oci_client::Reference::try_from("docker.io/example/busybox:latest").unwrap(),
                 signed_reference: "quay.io/example/busybox:latest",
             },
         ];
@@ -230,7 +230,7 @@ mod tests {
                         "type": "matchExact"
                     }"#
                 ).unwrap(),
-                origin_reference: oci_distribution::Reference::try_from("docker.io/example/busybox:latest").unwrap(),
+                origin_reference: oci_client::Reference::try_from("docker.io/example/busybox:latest").unwrap(),
                 signed_reference: "docker.io/example/busybox:tag",
             },
             TestData {
@@ -239,7 +239,7 @@ mod tests {
                         "type": "matchExact"
                     }"#
                 ).unwrap(),
-                origin_reference: oci_distribution::Reference::try_from(
+                origin_reference: oci_client::Reference::try_from(
                     "docker.io/example/busybox@sha256:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
                 ).unwrap(),
                 signed_reference: "docker.io/example/busybox@sha256:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
@@ -250,7 +250,7 @@ mod tests {
                         "type": "matchRepoDigestOrExact"
                     }"#
                 ).unwrap(),
-                origin_reference: oci_distribution::Reference::try_from("docker.io/example/busybox:latest").unwrap(),
+                origin_reference: oci_client::Reference::try_from("docker.io/example/busybox:latest").unwrap(),
                 signed_reference: "docker.io/example/busybox:tag",
             },
             TestData {
@@ -260,7 +260,7 @@ mod tests {
                         "dockerReference": "docker.io/mylib/busybox:latest"
                     }"#
                 ).unwrap(),
-                origin_reference: oci_distribution::Reference::try_from("docker.io/example/busybox:latest").unwrap(),
+                origin_reference: oci_client::Reference::try_from("docker.io/example/busybox:latest").unwrap(),
                 signed_reference: "docker.io/example/busybox:latest",
             },
         ];


### PR DESCRIPTION
This release contains a security fix for confidential pulling of unsigned images: https://github.com/oras-project/rust-oci-client/pull/152. 

The upgrade is not trivial, because the crate has been renamed (https://github.com/oras-project/rust-oci-client/issues/142) and there are breaking changes:

* https://github.com/oras-project/rust-oci-client/issues/157
* https://github.com/oras-project/rust-oci-client/pull/121

Thus, I converted all annotation values from `HashMap` to `BTreeMap`, worked around the `sigstore::registry::Auth` conversion not being implemented for the new crate, and am now passing the  stream wrapped by `SizedStream`.