### PR TITLE
cdh: improves the luks-encrypt-storage script

### DIFF
--- a/confidential-data-hub/storage/scripts/luks-encrypt-storage
+++ b/confidential-data-hub/storage/scripts/luks-encrypt-storage
@@ -99,15 +99,15 @@ if [[ -n "$device_name" && -b "$device_path" ]]; then
 		fi
 	fi
 
-	cryptsetup luksOpen -d "$storage_key_path" "$device_path" $opened_device_name
+	cryptsetup luksOpen -d "$storage_key_path" "$device_path" "$opened_device_name"
 	rm "$storage_key_path"
 
 	if [ "$data_integrity" == "false" ]; then
-		mkfs.ext4 /dev/mapper/$opened_device_name -E lazy_journal_init
+		mkfs.ext4 "/dev/mapper/$opened_device_name" -E lazy_journal_init
 	else
 		# mkfs.ext4 doesn't perform whole sector writes and this will cause checksum failures
 		# with an unwiped integrity device. Therefore, first perform a dry run.
-		output=$(mkfs.ext4 /dev/mapper/$opened_device_name -F -n)
+		output=$(mkfs.ext4 "/dev/mapper/$opened_device_name" -F -n)
 
 		# The above command will produce output like
 		# mke2fs 1.46.5 (30-Dec-2021)
@@ -136,18 +136,18 @@ if [[ -n "$device_name" && -b "$device_path" ]]; then
 		echo "Clearing page at $block_num"
 		# Zero out the page
 		dd if=/dev/zero bs=4k count=1 oflag=direct \
-		of=/dev/mapper/$opened_device_name seek="$block_num"
+		of="/dev/mapper/$opened_device_name" seek="$block_num"
 		done
 
 		# Now perform the actual ext4 format. Use lazy_journal_init so that the journal is
 		# initialized on demand. This is safe for ephemeral storage since we don't expect
 		# ephemeral storage to survice a power cycle.
-		mkfs.ext4 /dev/mapper/$opened_device_name -E lazy_journal_init
+		mkfs.ext4 "/dev/mapper/$opened_device_name" -E lazy_journal_init
 	fi
 
-	[ ! -d "$mount_point" ] && mkdir -p $mount_point
+	[ ! -d "$mount_point" ] && mkdir -p "$mount_point"
 
-	mount /dev/mapper/$opened_device_name $mount_point
+	mount "/dev/mapper/$opened_device_name" "$mount_point"
 else
 	die "Invalid device: '$device_path'"
 fi

--- a/confidential-data-hub/storage/scripts/luks-encrypt-storage
+++ b/confidential-data-hub/storage/scripts/luks-encrypt-storage
@@ -123,6 +123,10 @@ if [[ -n "$device_name" && -b "$device_path" ]]; then
 		# Find list of blocks
 		block_nums=$(echo  "$blocks_list" | grep -Eo '[0-9]{4,}' | sort -n)
 
+		if [ -z "$block_nums" ]; then
+			die "Block numbers not found"
+		fi
+
 		# Add zero to list of blocks
 		block_nums="0 $block_nums"
 


### PR DESCRIPTION
While reviewing https://github.com/kata-containers/kata-containers/pull/9999 I wanted to understand confidential-data-hub/storage/scripts/luks-encrypt-storage better so I took a deep look at this file. I began to worry whether the logic to detect the blocks could fail or not, and in case of failure if it should continue the script as if everything went well (possible not cleaning up the block pages if any). Is it concern? So I decided to add a check for the block numbers, that if empty then the script bails out. Let me know if it is wrong and will introduce another issue that I could anticipate.

While in here, I delinted the script. 

Cc @Xynnn007 @ChengyuZhu6 @fitzthum 