### PR TITLE
AA: deletes `UpdateConfiguration` API and add `--initdata` launch parameter

### DIFF
--- a/attestation-agent/attestation-agent/src/bin/grpc-aa/main.rs
+++ b/attestation-agent/attestation-agent/src/bin/grpc-aa/main.rs
@@ -6,7 +6,8 @@
 mod server;
 
 use anyhow::*;
-use attestation_agent::AttestationAgent;
+use attestation_agent::{AttestationAPIs, AttestationAgent};
+use base64::Engine;
 use clap::Parser;
 use log::{debug, info};
 use tokio::signal::unix::{signal, SignalKind};
@@ -35,6 +36,14 @@ struct Cli {
     /// `--config /etc/attestation-agent.conf`
     #[arg(short, long)]
     config_file: Option<String>,
+
+    /// Initdata to be verified by AA. If initdata check failed, AA will failed to launch.
+    /// The initdata should be base64 standard encoding.
+    ///
+    /// Example:
+    /// `--initdata AAAAAAAAAAAA`
+    #[arg(short, long)]
+    initdata: Option<String>,
 }
 
 #[tokio::main]
@@ -45,6 +54,23 @@ pub async fn main() -> Result<()> {
     let attestation_socket = cli.attestation_sock.parse::<SocketAddr>()?;
 
     let mut aa = AttestationAgent::new(cli.config_file.as_deref()).context("start AA")?;
+    if let Some(initdata) = cli.initdata {
+        info!("Initdata is given by parameter, try to check.");
+        let initdata = base64::engine::general_purpose::STANDARD
+            .decode(&initdata)
+            .context("base64 decode initdata")?;
+        let res = aa
+            .bind_init_data(&initdata)
+            .await
+            .context("The initdata supplied by the parameter is inconsistent with that of the current platform.")?;
+        match res {
+            attester::InitDataResult::Ok => info!("Check initdata passed."),
+            attester::InitDataResult::Unsupported => {
+                info!("Platform does not support initdata checking. Jumping.")
+            }
+        }
+    }
+
     aa.init().await.context("init AA")?;
     debug!(
         "Attestation gRPC service listening on: {:?}",

--- a/attestation-agent/attestation-agent/src/bin/grpc-aa/server.rs
+++ b/attestation-agent/attestation-agent/src/bin/grpc-aa/server.rs
@@ -10,8 +10,7 @@ use attestation::attestation_agent_service_server::{
 use attestation::{
     BindInitDataRequest, BindInitDataResponse, ExtendRuntimeMeasurementRequest,
     ExtendRuntimeMeasurementResponse, GetEvidenceRequest, GetEvidenceResponse, GetTeeTypeRequest,
-    GetTeeTypeResponse, GetTokenRequest, GetTokenResponse, UpdateConfigurationRequest,
-    UpdateConfigurationResponse,
+    GetTeeTypeResponse, GetTokenRequest, GetTokenResponse,
 };
 use attestation_agent::{AttestationAPIs, AttestationAgent};
 use log::{debug, error};
@@ -127,31 +126,6 @@ impl AttestationAgentService for AA {
         debug!("AA (grpc): init data binding successfully!");
 
         let reply = BindInitDataResponse {};
-
-        Result::Ok(Response::new(reply))
-    }
-
-    async fn update_configuration(
-        &self,
-        request: Request<UpdateConfigurationRequest>,
-    ) -> Result<Response<UpdateConfigurationResponse>, Status> {
-        let request = request.into_inner();
-
-        debug!("AA (grpc): update configuration ...");
-
-        self.inner
-            .update_configuration(&request.config)
-            .await
-            .map_err(|e| {
-                error!("AA (grpc): update configuration failed:\n{e:?}");
-                Status::internal(format!(
-                    "[ERROR:{AGENT_NAME}] AA update configuration failed"
-                ))
-            })?;
-
-        debug!("AA (grpc): update configuration successfully!");
-
-        let reply = UpdateConfigurationResponse {};
 
         Result::Ok(Response::new(reply))
     }

--- a/attestation-agent/attestation-agent/src/bin/ttrpc_dep/server.rs
+++ b/attestation-agent/attestation-agent/src/bin/ttrpc_dep/server.rs
@@ -12,7 +12,7 @@ use crate::ttrpc_dep::ttrpc_protocol::{
     attestation_agent::{
         ExtendRuntimeMeasurementRequest, ExtendRuntimeMeasurementResponse, GetEvidenceRequest,
         GetEvidenceResponse, GetTeeTypeRequest, GetTeeTypeResponse, GetTokenRequest,
-        GetTokenResponse, UpdateConfigurationRequest, UpdateConfigurationResponse,
+        GetTokenResponse,
     },
     attestation_agent_ttrpc::AttestationAgentService,
 };
@@ -103,31 +103,6 @@ impl AttestationAgentService for AA {
 
         debug!("AA (ttrpc): extend runtime measurement succeeded.");
         let reply = ExtendRuntimeMeasurementResponse::new();
-        ::ttrpc::Result::Ok(reply)
-    }
-
-    async fn update_configuration(
-        &self,
-        _ctx: &::ttrpc::r#async::TtrpcContext,
-        req: UpdateConfigurationRequest,
-    ) -> ::ttrpc::Result<UpdateConfigurationResponse> {
-        debug!("AA (ttrpc): update configuration ...");
-
-        self.inner
-            .update_configuration(&req.config)
-            .await
-            .map_err(|e| {
-                error!("AA (ttrpc): update configuration failed:\n {e:?}");
-                let mut error_status = ::ttrpc::proto::Status::new();
-                error_status.set_code(Code::INTERNAL);
-                error_status.set_message(format!(
-                    "[ERROR:{AGENT_NAME}] AA update configuration failed"
-                ));
-                ::ttrpc::Error::RpcStatus(error_status)
-            })?;
-
-        debug!("AA (ttrpc): update configuration succeeded.");
-        let reply = UpdateConfigurationResponse::new();
         ::ttrpc::Result::Ok(reply)
     }
 

--- a/attestation-agent/attestation-agent/src/bin/ttrpc_dep/ttrpc_protocol/attestation_agent.rs
+++ b/attestation-agent/attestation-agent/src/bin/ttrpc_dep/ttrpc_protocol/attestation_agent.rs
@@ -1156,231 +1156,6 @@ impl ::protobuf::reflect::ProtobufValue for BindInitDataResponse {
     type RuntimeType = ::protobuf::reflect::rt::RuntimeTypeMessage<Self>;
 }
 
-// @@protoc_insertion_point(message:attestation_agent.UpdateConfigurationRequest)
-#[derive(PartialEq,Clone,Default,Debug)]
-pub struct UpdateConfigurationRequest {
-    // message fields
-    // @@protoc_insertion_point(field:attestation_agent.UpdateConfigurationRequest.config)
-    pub config: ::std::string::String,
-    // special fields
-    // @@protoc_insertion_point(special_field:attestation_agent.UpdateConfigurationRequest.special_fields)
-    pub special_fields: ::protobuf::SpecialFields,
-}
-
-impl<'a> ::std::default::Default for &'a UpdateConfigurationRequest {
-    fn default() -> &'a UpdateConfigurationRequest {
-        <UpdateConfigurationRequest as ::protobuf::Message>::default_instance()
-    }
-}
-
-impl UpdateConfigurationRequest {
-    pub fn new() -> UpdateConfigurationRequest {
-        ::std::default::Default::default()
-    }
-
-    fn generated_message_descriptor_data() -> ::protobuf::reflect::GeneratedMessageDescriptorData {
-        let mut fields = ::std::vec::Vec::with_capacity(1);
-        let mut oneofs = ::std::vec::Vec::with_capacity(0);
-        fields.push(::protobuf::reflect::rt::v2::make_simpler_field_accessor::<_, _>(
-            "config",
-            |m: &UpdateConfigurationRequest| { &m.config },
-            |m: &mut UpdateConfigurationRequest| { &mut m.config },
-        ));
-        ::protobuf::reflect::GeneratedMessageDescriptorData::new_2::<UpdateConfigurationRequest>(
-            "UpdateConfigurationRequest",
-            fields,
-            oneofs,
-        )
-    }
-}
-
-impl ::protobuf::Message for UpdateConfigurationRequest {
-    const NAME: &'static str = "UpdateConfigurationRequest";
-
-    fn is_initialized(&self) -> bool {
-        true
-    }
-
-    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream<'_>) -> ::protobuf::Result<()> {
-        while let Some(tag) = is.read_raw_tag_or_eof()? {
-            match tag {
-                10 => {
-                    self.config = is.read_string()?;
-                },
-                tag => {
-                    ::protobuf::rt::read_unknown_or_skip_group(tag, is, self.special_fields.mut_unknown_fields())?;
-                },
-            };
-        }
-        ::std::result::Result::Ok(())
-    }
-
-    // Compute sizes of nested messages
-    #[allow(unused_variables)]
-    fn compute_size(&self) -> u64 {
-        let mut my_size = 0;
-        if !self.config.is_empty() {
-            my_size += ::protobuf::rt::string_size(1, &self.config);
-        }
-        my_size += ::protobuf::rt::unknown_fields_size(self.special_fields.unknown_fields());
-        self.special_fields.cached_size().set(my_size as u32);
-        my_size
-    }
-
-    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream<'_>) -> ::protobuf::Result<()> {
-        if !self.config.is_empty() {
-            os.write_string(1, &self.config)?;
-        }
-        os.write_unknown_fields(self.special_fields.unknown_fields())?;
-        ::std::result::Result::Ok(())
-    }
-
-    fn special_fields(&self) -> &::protobuf::SpecialFields {
-        &self.special_fields
-    }
-
-    fn mut_special_fields(&mut self) -> &mut ::protobuf::SpecialFields {
-        &mut self.special_fields
-    }
-
-    fn new() -> UpdateConfigurationRequest {
-        UpdateConfigurationRequest::new()
-    }
-
-    fn clear(&mut self) {
-        self.config.clear();
-        self.special_fields.clear();
-    }
-
-    fn default_instance() -> &'static UpdateConfigurationRequest {
-        static instance: UpdateConfigurationRequest = UpdateConfigurationRequest {
-            config: ::std::string::String::new(),
-            special_fields: ::protobuf::SpecialFields::new(),
-        };
-        &instance
-    }
-}
-
-impl ::protobuf::MessageFull for UpdateConfigurationRequest {
-    fn descriptor() -> ::protobuf::reflect::MessageDescriptor {
-        static descriptor: ::protobuf::rt::Lazy<::protobuf::reflect::MessageDescriptor> = ::protobuf::rt::Lazy::new();
-        descriptor.get(|| file_descriptor().message_by_package_relative_name("UpdateConfigurationRequest").unwrap()).clone()
-    }
-}
-
-impl ::std::fmt::Display for UpdateConfigurationRequest {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
-impl ::protobuf::reflect::ProtobufValue for UpdateConfigurationRequest {
-    type RuntimeType = ::protobuf::reflect::rt::RuntimeTypeMessage<Self>;
-}
-
-// @@protoc_insertion_point(message:attestation_agent.UpdateConfigurationResponse)
-#[derive(PartialEq,Clone,Default,Debug)]
-pub struct UpdateConfigurationResponse {
-    // special fields
-    // @@protoc_insertion_point(special_field:attestation_agent.UpdateConfigurationResponse.special_fields)
-    pub special_fields: ::protobuf::SpecialFields,
-}
-
-impl<'a> ::std::default::Default for &'a UpdateConfigurationResponse {
-    fn default() -> &'a UpdateConfigurationResponse {
-        <UpdateConfigurationResponse as ::protobuf::Message>::default_instance()
-    }
-}
-
-impl UpdateConfigurationResponse {
-    pub fn new() -> UpdateConfigurationResponse {
-        ::std::default::Default::default()
-    }
-
-    fn generated_message_descriptor_data() -> ::protobuf::reflect::GeneratedMessageDescriptorData {
-        let mut fields = ::std::vec::Vec::with_capacity(0);
-        let mut oneofs = ::std::vec::Vec::with_capacity(0);
-        ::protobuf::reflect::GeneratedMessageDescriptorData::new_2::<UpdateConfigurationResponse>(
-            "UpdateConfigurationResponse",
-            fields,
-            oneofs,
-        )
-    }
-}
-
-impl ::protobuf::Message for UpdateConfigurationResponse {
-    const NAME: &'static str = "UpdateConfigurationResponse";
-
-    fn is_initialized(&self) -> bool {
-        true
-    }
-
-    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream<'_>) -> ::protobuf::Result<()> {
-        while let Some(tag) = is.read_raw_tag_or_eof()? {
-            match tag {
-                tag => {
-                    ::protobuf::rt::read_unknown_or_skip_group(tag, is, self.special_fields.mut_unknown_fields())?;
-                },
-            };
-        }
-        ::std::result::Result::Ok(())
-    }
-
-    // Compute sizes of nested messages
-    #[allow(unused_variables)]
-    fn compute_size(&self) -> u64 {
-        let mut my_size = 0;
-        my_size += ::protobuf::rt::unknown_fields_size(self.special_fields.unknown_fields());
-        self.special_fields.cached_size().set(my_size as u32);
-        my_size
-    }
-
-    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream<'_>) -> ::protobuf::Result<()> {
-        os.write_unknown_fields(self.special_fields.unknown_fields())?;
-        ::std::result::Result::Ok(())
-    }
-
-    fn special_fields(&self) -> &::protobuf::SpecialFields {
-        &self.special_fields
-    }
-
-    fn mut_special_fields(&mut self) -> &mut ::protobuf::SpecialFields {
-        &mut self.special_fields
-    }
-
-    fn new() -> UpdateConfigurationResponse {
-        UpdateConfigurationResponse::new()
-    }
-
-    fn clear(&mut self) {
-        self.special_fields.clear();
-    }
-
-    fn default_instance() -> &'static UpdateConfigurationResponse {
-        static instance: UpdateConfigurationResponse = UpdateConfigurationResponse {
-            special_fields: ::protobuf::SpecialFields::new(),
-        };
-        &instance
-    }
-}
-
-impl ::protobuf::MessageFull for UpdateConfigurationResponse {
-    fn descriptor() -> ::protobuf::reflect::MessageDescriptor {
-        static descriptor: ::protobuf::rt::Lazy<::protobuf::reflect::MessageDescriptor> = ::protobuf::rt::Lazy::new();
-        descriptor.get(|| file_descriptor().message_by_package_relative_name("UpdateConfigurationResponse").unwrap()).clone()
-    }
-}
-
-impl ::std::fmt::Display for UpdateConfigurationResponse {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
-impl ::protobuf::reflect::ProtobufValue for UpdateConfigurationResponse {
-    type RuntimeType = ::protobuf::reflect::rt::RuntimeTypeMessage<Self>;
-}
-
 // @@protoc_insertion_point(message:attestation_agent.GetTeeTypeRequest)
 #[derive(PartialEq,Clone,Default,Debug)]
 pub struct GetTeeTypeRequest {
@@ -1620,21 +1395,17 @@ static file_descriptor_proto_data: &'static [u8] = b"\
     Response\"K\n\x11InitDataPlaintext\x12\x18\n\x07Content\x18\x01\x20\x01(\
     \x0cR\x07Content\x12\x1c\n\tAlgorithm\x18\x02\x20\x01(\tR\tAlgorithm\"-\
     \n\x13BindInitDataRequest\x12\x16\n\x06Digest\x18\x01\x20\x01(\x0cR\x06D\
-    igest\"\x16\n\x14BindInitDataResponse\"4\n\x1aUpdateConfigurationRequest\
-    \x12\x16\n\x06config\x18\x01\x20\x01(\tR\x06config\"\x1d\n\x1bUpdateConf\
-    igurationResponse\"\x13\n\x11GetTeeTypeRequest\"&\n\x12GetTeeTypeRespons\
-    e\x12\x10\n\x03tee\x18\x01\x20\x01(\tR\x03tee2\x84\x05\n\x17AttestationA\
-    gentService\x12\\\n\x0bGetEvidence\x12%.attestation_agent.GetEvidenceReq\
-    uest\x1a&.attestation_agent.GetEvidenceResponse\x12S\n\x08GetToken\x12\"\
-    .attestation_agent.GetTokenRequest\x1a#.attestation_agent.GetTokenRespon\
-    se\x12\x83\x01\n\x18ExtendRuntimeMeasurement\x122.attestation_agent.Exte\
-    ndRuntimeMeasurementRequest\x1a3.attestation_agent.ExtendRuntimeMeasurem\
-    entResponse\x12_\n\x0cBindInitData\x12&.attestation_agent.BindInitDataRe\
-    quest\x1a'.attestation_agent.BindInitDataResponse\x12t\n\x13UpdateConfig\
-    uration\x12-.attestation_agent.UpdateConfigurationRequest\x1a..attestati\
-    on_agent.UpdateConfigurationResponse\x12Y\n\nGetTeeType\x12$.attestation\
-    _agent.GetTeeTypeRequest\x1a%.attestation_agent.GetTeeTypeResponseb\x06p\
-    roto3\
+    igest\"\x16\n\x14BindInitDataResponse\"\x13\n\x11GetTeeTypeRequest\"&\n\
+    \x12GetTeeTypeResponse\x12\x10\n\x03tee\x18\x01\x20\x01(\tR\x03tee2\x8e\
+    \x04\n\x17AttestationAgentService\x12\\\n\x0bGetEvidence\x12%.attestatio\
+    n_agent.GetEvidenceRequest\x1a&.attestation_agent.GetEvidenceResponse\
+    \x12S\n\x08GetToken\x12\".attestation_agent.GetTokenRequest\x1a#.attesta\
+    tion_agent.GetTokenResponse\x12\x83\x01\n\x18ExtendRuntimeMeasurement\
+    \x122.attestation_agent.ExtendRuntimeMeasurementRequest\x1a3.attestation\
+    _agent.ExtendRuntimeMeasurementResponse\x12_\n\x0cBindInitData\x12&.atte\
+    station_agent.BindInitDataRequest\x1a'.attestation_agent.BindInitDataRes\
+    ponse\x12Y\n\nGetTeeType\x12$.attestation_agent.GetTeeTypeRequest\x1a%.a\
+    ttestation_agent.GetTeeTypeResponseb\x06proto3\
 ";
 
 /// `FileDescriptorProto` object which was a source for this generated file
@@ -1652,7 +1423,7 @@ pub fn file_descriptor() -> &'static ::protobuf::reflect::FileDescriptor {
     file_descriptor.get(|| {
         let generated_file_descriptor = generated_file_descriptor_lazy.get(|| {
             let mut deps = ::std::vec::Vec::with_capacity(0);
-            let mut messages = ::std::vec::Vec::with_capacity(13);
+            let mut messages = ::std::vec::Vec::with_capacity(11);
             messages.push(GetEvidenceRequest::generated_message_descriptor_data());
             messages.push(GetEvidenceResponse::generated_message_descriptor_data());
             messages.push(GetTokenRequest::generated_message_descriptor_data());
@@ -1662,8 +1433,6 @@ pub fn file_descriptor() -> &'static ::protobuf::reflect::FileDescriptor {
             messages.push(InitDataPlaintext::generated_message_descriptor_data());
             messages.push(BindInitDataRequest::generated_message_descriptor_data());
             messages.push(BindInitDataResponse::generated_message_descriptor_data());
-            messages.push(UpdateConfigurationRequest::generated_message_descriptor_data());
-            messages.push(UpdateConfigurationResponse::generated_message_descriptor_data());
             messages.push(GetTeeTypeRequest::generated_message_descriptor_data());
             messages.push(GetTeeTypeResponse::generated_message_descriptor_data());
             let mut enums = ::std::vec::Vec::with_capacity(0);

--- a/attestation-agent/attestation-agent/src/bin/ttrpc_dep/ttrpc_protocol/attestation_agent_ttrpc.rs
+++ b/attestation-agent/attestation-agent/src/bin/ttrpc_dep/ttrpc_protocol/attestation_agent_ttrpc.rs
@@ -51,11 +51,6 @@ impl AttestationAgentServiceClient {
         ::ttrpc::async_client_request!(self, ctx, req, "attestation_agent.AttestationAgentService", "BindInitData", cres);
     }
 
-    pub async fn update_configuration(&self, ctx: ttrpc::context::Context, req: &super::attestation_agent::UpdateConfigurationRequest) -> ::ttrpc::Result<super::attestation_agent::UpdateConfigurationResponse> {
-        let mut cres = super::attestation_agent::UpdateConfigurationResponse::new();
-        ::ttrpc::async_client_request!(self, ctx, req, "attestation_agent.AttestationAgentService", "UpdateConfiguration", cres);
-    }
-
     pub async fn get_tee_type(&self, ctx: ttrpc::context::Context, req: &super::attestation_agent::GetTeeTypeRequest) -> ::ttrpc::Result<super::attestation_agent::GetTeeTypeResponse> {
         let mut cres = super::attestation_agent::GetTeeTypeResponse::new();
         ::ttrpc::async_client_request!(self, ctx, req, "attestation_agent.AttestationAgentService", "GetTeeType", cres);
@@ -106,17 +101,6 @@ impl ::ttrpc::r#async::MethodHandler for BindInitDataMethod {
     }
 }
 
-struct UpdateConfigurationMethod {
-    service: Arc<dyn AttestationAgentService + Send + Sync>,
-}
-
-#[async_trait]
-impl ::ttrpc::r#async::MethodHandler for UpdateConfigurationMethod {
-    async fn handler(&self, ctx: ::ttrpc::r#async::TtrpcContext, req: ::ttrpc::Request) -> ::ttrpc::Result<::ttrpc::Response> {
-        ::ttrpc::async_request_handler!(self, ctx, req, attestation_agent, UpdateConfigurationRequest, update_configuration);
-    }
-}
-
 struct GetTeeTypeMethod {
     service: Arc<dyn AttestationAgentService + Send + Sync>,
 }
@@ -142,9 +126,6 @@ pub trait AttestationAgentService: Sync {
     async fn bind_init_data(&self, _ctx: &::ttrpc::r#async::TtrpcContext, _: super::attestation_agent::BindInitDataRequest) -> ::ttrpc::Result<super::attestation_agent::BindInitDataResponse> {
         Err(::ttrpc::Error::RpcStatus(::ttrpc::get_status(::ttrpc::Code::NOT_FOUND, "/attestation_agent.AttestationAgentService/BindInitData is not supported".to_string())))
     }
-    async fn update_configuration(&self, _ctx: &::ttrpc::r#async::TtrpcContext, _: super::attestation_agent::UpdateConfigurationRequest) -> ::ttrpc::Result<super::attestation_agent::UpdateConfigurationResponse> {
-        Err(::ttrpc::Error::RpcStatus(::ttrpc::get_status(::ttrpc::Code::NOT_FOUND, "/attestation_agent.AttestationAgentService/UpdateConfiguration is not supported".to_string())))
-    }
     async fn get_tee_type(&self, _ctx: &::ttrpc::r#async::TtrpcContext, _: super::attestation_agent::GetTeeTypeRequest) -> ::ttrpc::Result<super::attestation_agent::GetTeeTypeResponse> {
         Err(::ttrpc::Error::RpcStatus(::ttrpc::get_status(::ttrpc::Code::NOT_FOUND, "/attestation_agent.AttestationAgentService/GetTeeType is not supported".to_string())))
     }
@@ -166,9 +147,6 @@ pub fn create_attestation_agent_service(service: Arc<dyn AttestationAgentService
 
     methods.insert("BindInitData".to_string(),
                     Box::new(BindInitDataMethod{service: service.clone()}) as Box<dyn ::ttrpc::r#async::MethodHandler + Send + Sync>);
-
-    methods.insert("UpdateConfiguration".to_string(),
-                    Box::new(UpdateConfigurationMethod{service: service.clone()}) as Box<dyn ::ttrpc::r#async::MethodHandler + Send + Sync>);
 
     methods.insert("GetTeeType".to_string(),
                     Box::new(GetTeeTypeMethod{service: service.clone()}) as Box<dyn ::ttrpc::r#async::MethodHandler + Send + Sync>);

--- a/attestation-agent/attestation-agent/src/lib.rs
+++ b/attestation-agent/attestation-agent/src/lib.rs
@@ -7,7 +7,7 @@ use anyhow::{bail, Context, Result};
 use async_trait::async_trait;
 use attester::{detect_tee_type, BoxedAttester};
 use kbs_types::Tee;
-use std::{io::Write, str::FromStr, sync::Arc};
+use std::{str::FromStr, sync::Arc};
 use tokio::sync::{Mutex, RwLock};
 
 pub use attester::InitDataResult;
@@ -124,27 +124,6 @@ impl AttestationAgent {
             eventlog: None,
             tee,
         })
-    }
-
-    /// This is a workaround API for initdata in CoCo. Once
-    /// a better design is implemented we can deprecate the API.
-    /// See https://github.com/kata-containers/kata-containers/issues/9468
-    pub async fn update_configuration(&self, conf: &str) -> Result<()> {
-        let mut tmpfile = tempfile::NamedTempFile::new()?;
-        let _ = tmpfile.write(conf.as_bytes())?;
-        tmpfile.flush()?;
-
-        let config = Config::try_from(
-            tmpfile
-                .path()
-                .as_os_str()
-                .to_str()
-                .expect("tempfile will not create non-unicode char"),
-            // Here we can use `expect()` because tempfile crate will generate file name
-            // only including numbers and alphabet (0-9, a-z, A-Z)
-        )?;
-        *(self.config.write().await) = config;
-        Ok(())
     }
 }
 

--- a/attestation-agent/kbs_protocol/src/ttrpc_protos/attestation_agent.rs
+++ b/attestation-agent/kbs_protocol/src/ttrpc_protos/attestation_agent.rs
@@ -1156,231 +1156,6 @@ impl ::protobuf::reflect::ProtobufValue for BindInitDataResponse {
     type RuntimeType = ::protobuf::reflect::rt::RuntimeTypeMessage<Self>;
 }
 
-// @@protoc_insertion_point(message:attestation_agent.UpdateConfigurationRequest)
-#[derive(PartialEq,Clone,Default,Debug)]
-pub struct UpdateConfigurationRequest {
-    // message fields
-    // @@protoc_insertion_point(field:attestation_agent.UpdateConfigurationRequest.config)
-    pub config: ::std::string::String,
-    // special fields
-    // @@protoc_insertion_point(special_field:attestation_agent.UpdateConfigurationRequest.special_fields)
-    pub special_fields: ::protobuf::SpecialFields,
-}
-
-impl<'a> ::std::default::Default for &'a UpdateConfigurationRequest {
-    fn default() -> &'a UpdateConfigurationRequest {
-        <UpdateConfigurationRequest as ::protobuf::Message>::default_instance()
-    }
-}
-
-impl UpdateConfigurationRequest {
-    pub fn new() -> UpdateConfigurationRequest {
-        ::std::default::Default::default()
-    }
-
-    fn generated_message_descriptor_data() -> ::protobuf::reflect::GeneratedMessageDescriptorData {
-        let mut fields = ::std::vec::Vec::with_capacity(1);
-        let mut oneofs = ::std::vec::Vec::with_capacity(0);
-        fields.push(::protobuf::reflect::rt::v2::make_simpler_field_accessor::<_, _>(
-            "config",
-            |m: &UpdateConfigurationRequest| { &m.config },
-            |m: &mut UpdateConfigurationRequest| { &mut m.config },
-        ));
-        ::protobuf::reflect::GeneratedMessageDescriptorData::new_2::<UpdateConfigurationRequest>(
-            "UpdateConfigurationRequest",
-            fields,
-            oneofs,
-        )
-    }
-}
-
-impl ::protobuf::Message for UpdateConfigurationRequest {
-    const NAME: &'static str = "UpdateConfigurationRequest";
-
-    fn is_initialized(&self) -> bool {
-        true
-    }
-
-    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream<'_>) -> ::protobuf::Result<()> {
-        while let Some(tag) = is.read_raw_tag_or_eof()? {
-            match tag {
-                10 => {
-                    self.config = is.read_string()?;
-                },
-                tag => {
-                    ::protobuf::rt::read_unknown_or_skip_group(tag, is, self.special_fields.mut_unknown_fields())?;
-                },
-            };
-        }
-        ::std::result::Result::Ok(())
-    }
-
-    // Compute sizes of nested messages
-    #[allow(unused_variables)]
-    fn compute_size(&self) -> u64 {
-        let mut my_size = 0;
-        if !self.config.is_empty() {
-            my_size += ::protobuf::rt::string_size(1, &self.config);
-        }
-        my_size += ::protobuf::rt::unknown_fields_size(self.special_fields.unknown_fields());
-        self.special_fields.cached_size().set(my_size as u32);
-        my_size
-    }
-
-    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream<'_>) -> ::protobuf::Result<()> {
-        if !self.config.is_empty() {
-            os.write_string(1, &self.config)?;
-        }
-        os.write_unknown_fields(self.special_fields.unknown_fields())?;
-        ::std::result::Result::Ok(())
-    }
-
-    fn special_fields(&self) -> &::protobuf::SpecialFields {
-        &self.special_fields
-    }
-
-    fn mut_special_fields(&mut self) -> &mut ::protobuf::SpecialFields {
-        &mut self.special_fields
-    }
-
-    fn new() -> UpdateConfigurationRequest {
-        UpdateConfigurationRequest::new()
-    }
-
-    fn clear(&mut self) {
-        self.config.clear();
-        self.special_fields.clear();
-    }
-
-    fn default_instance() -> &'static UpdateConfigurationRequest {
-        static instance: UpdateConfigurationRequest = UpdateConfigurationRequest {
-            config: ::std::string::String::new(),
-            special_fields: ::protobuf::SpecialFields::new(),
-        };
-        &instance
-    }
-}
-
-impl ::protobuf::MessageFull for UpdateConfigurationRequest {
-    fn descriptor() -> ::protobuf::reflect::MessageDescriptor {
-        static descriptor: ::protobuf::rt::Lazy<::protobuf::reflect::MessageDescriptor> = ::protobuf::rt::Lazy::new();
-        descriptor.get(|| file_descriptor().message_by_package_relative_name("UpdateConfigurationRequest").unwrap()).clone()
-    }
-}
-
-impl ::std::fmt::Display for UpdateConfigurationRequest {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
-impl ::protobuf::reflect::ProtobufValue for UpdateConfigurationRequest {
-    type RuntimeType = ::protobuf::reflect::rt::RuntimeTypeMessage<Self>;
-}
-
-// @@protoc_insertion_point(message:attestation_agent.UpdateConfigurationResponse)
-#[derive(PartialEq,Clone,Default,Debug)]
-pub struct UpdateConfigurationResponse {
-    // special fields
-    // @@protoc_insertion_point(special_field:attestation_agent.UpdateConfigurationResponse.special_fields)
-    pub special_fields: ::protobuf::SpecialFields,
-}
-
-impl<'a> ::std::default::Default for &'a UpdateConfigurationResponse {
-    fn default() -> &'a UpdateConfigurationResponse {
-        <UpdateConfigurationResponse as ::protobuf::Message>::default_instance()
-    }
-}
-
-impl UpdateConfigurationResponse {
-    pub fn new() -> UpdateConfigurationResponse {
-        ::std::default::Default::default()
-    }
-
-    fn generated_message_descriptor_data() -> ::protobuf::reflect::GeneratedMessageDescriptorData {
-        let mut fields = ::std::vec::Vec::with_capacity(0);
-        let mut oneofs = ::std::vec::Vec::with_capacity(0);
-        ::protobuf::reflect::GeneratedMessageDescriptorData::new_2::<UpdateConfigurationResponse>(
-            "UpdateConfigurationResponse",
-            fields,
-            oneofs,
-        )
-    }
-}
-
-impl ::protobuf::Message for UpdateConfigurationResponse {
-    const NAME: &'static str = "UpdateConfigurationResponse";
-
-    fn is_initialized(&self) -> bool {
-        true
-    }
-
-    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream<'_>) -> ::protobuf::Result<()> {
-        while let Some(tag) = is.read_raw_tag_or_eof()? {
-            match tag {
-                tag => {
-                    ::protobuf::rt::read_unknown_or_skip_group(tag, is, self.special_fields.mut_unknown_fields())?;
-                },
-            };
-        }
-        ::std::result::Result::Ok(())
-    }
-
-    // Compute sizes of nested messages
-    #[allow(unused_variables)]
-    fn compute_size(&self) -> u64 {
-        let mut my_size = 0;
-        my_size += ::protobuf::rt::unknown_fields_size(self.special_fields.unknown_fields());
-        self.special_fields.cached_size().set(my_size as u32);
-        my_size
-    }
-
-    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream<'_>) -> ::protobuf::Result<()> {
-        os.write_unknown_fields(self.special_fields.unknown_fields())?;
-        ::std::result::Result::Ok(())
-    }
-
-    fn special_fields(&self) -> &::protobuf::SpecialFields {
-        &self.special_fields
-    }
-
-    fn mut_special_fields(&mut self) -> &mut ::protobuf::SpecialFields {
-        &mut self.special_fields
-    }
-
-    fn new() -> UpdateConfigurationResponse {
-        UpdateConfigurationResponse::new()
-    }
-
-    fn clear(&mut self) {
-        self.special_fields.clear();
-    }
-
-    fn default_instance() -> &'static UpdateConfigurationResponse {
-        static instance: UpdateConfigurationResponse = UpdateConfigurationResponse {
-            special_fields: ::protobuf::SpecialFields::new(),
-        };
-        &instance
-    }
-}
-
-impl ::protobuf::MessageFull for UpdateConfigurationResponse {
-    fn descriptor() -> ::protobuf::reflect::MessageDescriptor {
-        static descriptor: ::protobuf::rt::Lazy<::protobuf::reflect::MessageDescriptor> = ::protobuf::rt::Lazy::new();
-        descriptor.get(|| file_descriptor().message_by_package_relative_name("UpdateConfigurationResponse").unwrap()).clone()
-    }
-}
-
-impl ::std::fmt::Display for UpdateConfigurationResponse {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
-impl ::protobuf::reflect::ProtobufValue for UpdateConfigurationResponse {
-    type RuntimeType = ::protobuf::reflect::rt::RuntimeTypeMessage<Self>;
-}
-
 // @@protoc_insertion_point(message:attestation_agent.GetTeeTypeRequest)
 #[derive(PartialEq,Clone,Default,Debug)]
 pub struct GetTeeTypeRequest {
@@ -1620,21 +1395,17 @@ static file_descriptor_proto_data: &'static [u8] = b"\
     Response\"K\n\x11InitDataPlaintext\x12\x18\n\x07Content\x18\x01\x20\x01(\
     \x0cR\x07Content\x12\x1c\n\tAlgorithm\x18\x02\x20\x01(\tR\tAlgorithm\"-\
     \n\x13BindInitDataRequest\x12\x16\n\x06Digest\x18\x01\x20\x01(\x0cR\x06D\
-    igest\"\x16\n\x14BindInitDataResponse\"4\n\x1aUpdateConfigurationRequest\
-    \x12\x16\n\x06config\x18\x01\x20\x01(\tR\x06config\"\x1d\n\x1bUpdateConf\
-    igurationResponse\"\x13\n\x11GetTeeTypeRequest\"&\n\x12GetTeeTypeRespons\
-    e\x12\x10\n\x03tee\x18\x01\x20\x01(\tR\x03tee2\x84\x05\n\x17AttestationA\
-    gentService\x12\\\n\x0bGetEvidence\x12%.attestation_agent.GetEvidenceReq\
-    uest\x1a&.attestation_agent.GetEvidenceResponse\x12S\n\x08GetToken\x12\"\
-    .attestation_agent.GetTokenRequest\x1a#.attestation_agent.GetTokenRespon\
-    se\x12\x83\x01\n\x18ExtendRuntimeMeasurement\x122.attestation_agent.Exte\
-    ndRuntimeMeasurementRequest\x1a3.attestation_agent.ExtendRuntimeMeasurem\
-    entResponse\x12_\n\x0cBindInitData\x12&.attestation_agent.BindInitDataRe\
-    quest\x1a'.attestation_agent.BindInitDataResponse\x12t\n\x13UpdateConfig\
-    uration\x12-.attestation_agent.UpdateConfigurationRequest\x1a..attestati\
-    on_agent.UpdateConfigurationResponse\x12Y\n\nGetTeeType\x12$.attestation\
-    _agent.GetTeeTypeRequest\x1a%.attestation_agent.GetTeeTypeResponseb\x06p\
-    roto3\
+    igest\"\x16\n\x14BindInitDataResponse\"\x13\n\x11GetTeeTypeRequest\"&\n\
+    \x12GetTeeTypeResponse\x12\x10\n\x03tee\x18\x01\x20\x01(\tR\x03tee2\x8e\
+    \x04\n\x17AttestationAgentService\x12\\\n\x0bGetEvidence\x12%.attestatio\
+    n_agent.GetEvidenceRequest\x1a&.attestation_agent.GetEvidenceResponse\
+    \x12S\n\x08GetToken\x12\".attestation_agent.GetTokenRequest\x1a#.attesta\
+    tion_agent.GetTokenResponse\x12\x83\x01\n\x18ExtendRuntimeMeasurement\
+    \x122.attestation_agent.ExtendRuntimeMeasurementRequest\x1a3.attestation\
+    _agent.ExtendRuntimeMeasurementResponse\x12_\n\x0cBindInitData\x12&.atte\
+    station_agent.BindInitDataRequest\x1a'.attestation_agent.BindInitDataRes\
+    ponse\x12Y\n\nGetTeeType\x12$.attestation_agent.GetTeeTypeRequest\x1a%.a\
+    ttestation_agent.GetTeeTypeResponseb\x06proto3\
 ";
 
 /// `FileDescriptorProto` object which was a source for this generated file
@@ -1652,7 +1423,7 @@ pub fn file_descriptor() -> &'static ::protobuf::reflect::FileDescriptor {
     file_descriptor.get(|| {
         let generated_file_descriptor = generated_file_descriptor_lazy.get(|| {
             let mut deps = ::std::vec::Vec::with_capacity(0);
-            let mut messages = ::std::vec::Vec::with_capacity(13);
+            let mut messages = ::std::vec::Vec::with_capacity(11);
             messages.push(GetEvidenceRequest::generated_message_descriptor_data());
             messages.push(GetEvidenceResponse::generated_message_descriptor_data());
             messages.push(GetTokenRequest::generated_message_descriptor_data());
@@ -1662,8 +1433,6 @@ pub fn file_descriptor() -> &'static ::protobuf::reflect::FileDescriptor {
             messages.push(InitDataPlaintext::generated_message_descriptor_data());
             messages.push(BindInitDataRequest::generated_message_descriptor_data());
             messages.push(BindInitDataResponse::generated_message_descriptor_data());
-            messages.push(UpdateConfigurationRequest::generated_message_descriptor_data());
-            messages.push(UpdateConfigurationResponse::generated_message_descriptor_data());
             messages.push(GetTeeTypeRequest::generated_message_descriptor_data());
             messages.push(GetTeeTypeResponse::generated_message_descriptor_data());
             let mut enums = ::std::vec::Vec::with_capacity(0);

--- a/attestation-agent/kbs_protocol/src/ttrpc_protos/attestation_agent_ttrpc.rs
+++ b/attestation-agent/kbs_protocol/src/ttrpc_protos/attestation_agent_ttrpc.rs
@@ -51,11 +51,6 @@ impl AttestationAgentServiceClient {
         ::ttrpc::async_client_request!(self, ctx, req, "attestation_agent.AttestationAgentService", "BindInitData", cres);
     }
 
-    pub async fn update_configuration(&self, ctx: ttrpc::context::Context, req: &super::attestation_agent::UpdateConfigurationRequest) -> ::ttrpc::Result<super::attestation_agent::UpdateConfigurationResponse> {
-        let mut cres = super::attestation_agent::UpdateConfigurationResponse::new();
-        ::ttrpc::async_client_request!(self, ctx, req, "attestation_agent.AttestationAgentService", "UpdateConfiguration", cres);
-    }
-
     pub async fn get_tee_type(&self, ctx: ttrpc::context::Context, req: &super::attestation_agent::GetTeeTypeRequest) -> ::ttrpc::Result<super::attestation_agent::GetTeeTypeResponse> {
         let mut cres = super::attestation_agent::GetTeeTypeResponse::new();
         ::ttrpc::async_client_request!(self, ctx, req, "attestation_agent.AttestationAgentService", "GetTeeType", cres);
@@ -106,17 +101,6 @@ impl ::ttrpc::r#async::MethodHandler for BindInitDataMethod {
     }
 }
 
-struct UpdateConfigurationMethod {
-    service: Arc<dyn AttestationAgentService + Send + Sync>,
-}
-
-#[async_trait]
-impl ::ttrpc::r#async::MethodHandler for UpdateConfigurationMethod {
-    async fn handler(&self, ctx: ::ttrpc::r#async::TtrpcContext, req: ::ttrpc::Request) -> ::ttrpc::Result<::ttrpc::Response> {
-        ::ttrpc::async_request_handler!(self, ctx, req, attestation_agent, UpdateConfigurationRequest, update_configuration);
-    }
-}
-
 struct GetTeeTypeMethod {
     service: Arc<dyn AttestationAgentService + Send + Sync>,
 }
@@ -142,9 +126,6 @@ pub trait AttestationAgentService: Sync {
     async fn bind_init_data(&self, _ctx: &::ttrpc::r#async::TtrpcContext, _: super::attestation_agent::BindInitDataRequest) -> ::ttrpc::Result<super::attestation_agent::BindInitDataResponse> {
         Err(::ttrpc::Error::RpcStatus(::ttrpc::get_status(::ttrpc::Code::NOT_FOUND, "/attestation_agent.AttestationAgentService/BindInitData is not supported".to_string())))
     }
-    async fn update_configuration(&self, _ctx: &::ttrpc::r#async::TtrpcContext, _: super::attestation_agent::UpdateConfigurationRequest) -> ::ttrpc::Result<super::attestation_agent::UpdateConfigurationResponse> {
-        Err(::ttrpc::Error::RpcStatus(::ttrpc::get_status(::ttrpc::Code::NOT_FOUND, "/attestation_agent.AttestationAgentService/UpdateConfiguration is not supported".to_string())))
-    }
     async fn get_tee_type(&self, _ctx: &::ttrpc::r#async::TtrpcContext, _: super::attestation_agent::GetTeeTypeRequest) -> ::ttrpc::Result<super::attestation_agent::GetTeeTypeResponse> {
         Err(::ttrpc::Error::RpcStatus(::ttrpc::get_status(::ttrpc::Code::NOT_FOUND, "/attestation_agent.AttestationAgentService/GetTeeType is not supported".to_string())))
     }
@@ -166,9 +147,6 @@ pub fn create_attestation_agent_service(service: Arc<dyn AttestationAgentService
 
     methods.insert("BindInitData".to_string(),
                     Box::new(BindInitDataMethod{service: service.clone()}) as Box<dyn ::ttrpc::r#async::MethodHandler + Send + Sync>);
-
-    methods.insert("UpdateConfiguration".to_string(),
-                    Box::new(UpdateConfigurationMethod{service: service.clone()}) as Box<dyn ::ttrpc::r#async::MethodHandler + Send + Sync>);
 
     methods.insert("GetTeeType".to_string(),
                     Box::new(GetTeeTypeMethod{service: service.clone()}) as Box<dyn ::ttrpc::r#async::MethodHandler + Send + Sync>);

--- a/attestation-agent/protos/attestation-agent.proto
+++ b/attestation-agent/protos/attestation-agent.proto
@@ -47,12 +47,6 @@ message BindInitDataRequest {
 
 message BindInitDataResponse {}
 
-message UpdateConfigurationRequest {
-    string config = 1;
-}
-
-message UpdateConfigurationResponse {}
-
 message GetTeeTypeRequest {}
 
 message GetTeeTypeResponse {
@@ -64,11 +58,5 @@ service AttestationAgentService {
     rpc GetToken(GetTokenRequest) returns (GetTokenResponse) {};
     rpc ExtendRuntimeMeasurement(ExtendRuntimeMeasurementRequest) returns (ExtendRuntimeMeasurementResponse) {};
     rpc BindInitData(BindInitDataRequest) returns (BindInitDataResponse) {};
-
-    // This is a workaround API for initdata in CoCo. Once
-    // a better design is implemented we can deprecate the API.
-    // See https://github.com/kata-containers/kata-containers/issues/9468
-    rpc UpdateConfiguration(UpdateConfigurationRequest) returns (UpdateConfigurationResponse) {};
-
     rpc GetTeeType(GetTeeTypeRequest) returns (GetTeeTypeResponse) {};
 }


### PR DESCRIPTION
This commit deletes `UpdateConfiguration` API for AA, also adds a new cmdline parameter `--initdata` for AA to check initdata when launching. The two changes are for initdata feature.

The deletion of `UpdateConfiguration` would help avoid a partial initialized AA.
