### PR TITLE
ci: fix the CoCoKeyprovider image pushing logic

### DIFF
--- a/.github/workflows/aa_release.yml
+++ b/.github/workflows/aa_release.yml
@@ -6,6 +6,8 @@ on:
 
 jobs:
   build-and-push-images:
+    permissions:
+      packages: write
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -25,4 +27,4 @@ jobs:
           file: ./attestation-agent/docker/Dockerfile.keyprovider
           platforms: linux/amd64
           push: true
-          tags: ghcr.io/confidential-containers/coco-keyprovider:${{ github.ref_name }}, ghcr.io/confidential-containers/coco-keyprovider:latest
+          tags: ghcr.io/confidential-containers/staged-images/coco-keyprovider:${{ github.sha }}, ghcr.io/confidential-containers/staged-images/coco-keyprovider:latest

--- a/attestation-agent/coco_keyprovider/README.md
+++ b/attestation-agent/coco_keyprovider/README.md
@@ -29,7 +29,7 @@ This example will encrypt an image from docker/library and buffer the resulting 
 ```bash
 head -c 32 /dev/urandom | openssl enc > image_key
 mkdir output
-docker run -v "$PWD/output:/output" ghcr.io/confidential-containers/coco-keyprovider /encrypt.sh \
+docker run -v "$PWD/output:/output" ghcr.io/confidential-containers/staged-images/coco-keyprovider:latest /encrypt.sh \
 	-k "$(base64 < image_key)" \
 	-i kbs:///some/key/id \
 	-s docker://nginx:stable \
@@ -45,7 +45,7 @@ skopeo copy dir:output docker://ghcr.io/confidential-containers/nginx-encrypted
 Alternatively, an authorization file can be mounted to the container to be able to access private registries directly:
 
 ```bash
-docker run -v ~/.docker/config.json:/root/.docker/config.json ghcr.io/confidential-containers/coco-keyprovider /encrypt.sh \
+docker run -v ~/.docker/config.json:/root/.docker/config.json ghcr.io/confidential-containers/staged-images/coco-keyprovider:latest /encrypt.sh \
 	-k "$(base64 < image_key)" \
 	-i kbs:///some/key/id \
 	-s docker://private.registry.io/nginx:stable \


### PR DESCRIPTION
As the original  repo is now archived, thus we havenot been able to publish the coco keyprovider image for a long time. This commit fixes this issue by changing the image repo.

Fixes #672