### PR TITLE
image-rs: check xattrs for target dir when image unpacking

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2783,6 +2783,7 @@ dependencies = [
  "ttrpc-codegen",
  "url",
  "walkdir",
+ "xattr",
  "zstd 0.12.4",
 ]
 

--- a/image-rs/Cargo.toml
+++ b/image-rs/Cargo.toml
@@ -61,6 +61,7 @@ tonic = { workspace = true, optional = true }
 ttrpc = { workspace = true, features = ["async"], optional = true }
 url = "2.5.2"
 walkdir = "2"
+xattr = "1"
 zstd = "0.12"
 
 nydus-api = { version = "0.3.0", optional = true }


### PR DESCRIPTION
Some platforms/file-systems do not support xattrs, this would make the image pull fail because of failing to set xattr. This commit will check whether the target path supports xattr. If yes, the unpacking will maintain xattrs; if not, it will not set xattrs.

Fixes #690