### PR TITLE
docs: add coco_keyprovider to tools section

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,9 @@ A tool for exercising CDH endpoints
 [CDH Go Client](confidential-data-hub/golang)
 A Go tool for exercising CDH endpoints
 
+[CoCo Keyprovider](attestation-agent/coco_keyprovider)
+Keyprovider endpoint for encrypting images
+
 ## Build
 
 A `Makefile` is provided to quickly build Attestation Agent/Api Server Rest/Confidential Data Hub for a given platform.


### PR DESCRIPTION
It always takes me a while to find the CoCo keyprovider since it is in the attestation-agent dir. Let's add it to the tools section, which lists all the tools provided in this repo. We might also think about moving the keyprovider itself at some point.