### PR TITLE
cdh:golang: Add support for SecureMount in the go client tool

### DIFF
--- a/confidential-data-hub/golang/cmd/grpc-client/main.go
+++ b/confidential-data-hub/golang/cmd/grpc-client/main.go
@@ -5,8 +5,10 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"flag"
 	"fmt"
+	"log"
 	"os"
 
 	common "github.com/confidential-containers/guest-components/confidential-data-hub/golang/pkg/core"
@@ -30,8 +32,8 @@ func main() {
 	}
 	defer c.Close()
 
-	// The client currently supports only UnsealSecret operation.
-	// We need to implement the following operations: GetResource, SecureMount, and UnwrapKey.
+	// The client currently supports only UnsealSecret and SecureMount operation.
+	// We need to implement the following operations: GetResource and UnwrapKey.
 	switch common.OperationType {
 	case "UnsealSecret":
 		if common.OperationInterface == "UnsealEnv" {
@@ -49,6 +51,26 @@ func main() {
 			}
 			fmt.Printf("unsealed value from file = %s", unsealedValue)
 		}
+	case "SecureMount":
+		input_file_path := common.OperationInput
+		jsonInput, err := os.ReadFile(input_file_path)
+
+		var storage common.Storage
+
+		// Unmarshal the JSON data into the struct
+		err = json.Unmarshal(jsonInput, &storage)
+		if err != nil {
+			log.Fatalf("Error unmarshaling JSON: %s", err)
+			os.Exit(1)
+		}
+
+		mountPath, err := common.SecureMount(context.Background(), c, storage.VolumeType, storage.Options, storage.Flags, storage.Mountpoint)
+		if err != nil {
+			fmt.Printf("failed to secure mount! err = %v", err)
+			os.Exit(1)
+		}
+		fmt.Printf("Successfully secure mount to %s", mountPath)
+
 	default:
 		fmt.Printf("The operation type %s is not support yet", common.OperationType)
 		os.Exit(1)

--- a/confidential-data-hub/golang/cmd/ttrpc-client/main.go
+++ b/confidential-data-hub/golang/cmd/ttrpc-client/main.go
@@ -5,8 +5,10 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"flag"
 	"fmt"
+	"log"
 	"os"
 
 	common "github.com/confidential-containers/guest-components/confidential-data-hub/golang/pkg/core"
@@ -31,8 +33,8 @@ func main() {
 	}
 	defer c.Close()
 
-	// The client currently supports only UnsealSecret operation.
-	// We need to implement the following operations: GetResource, SecureMount, and UnwrapKey.
+	// The client currently supports UnsealSecret and SecureMount operation.
+	// We need to implement the following operations: GetResource and UnwrapKey.
 	switch common.OperationType {
 	case "UnsealSecret":
 		if common.OperationInterface == "UnsealEnv" {
@@ -50,6 +52,25 @@ func main() {
 			}
 			fmt.Printf("unsealed value from file = %s", unsealedValue)
 		}
+	case "SecureMount":
+		input_file_path := common.OperationInput
+		jsonInput, err := os.ReadFile(input_file_path)
+
+		var storage common.Storage
+
+		// Unmarshal the JSON data into the struct
+		err = json.Unmarshal(jsonInput, &storage)
+		if err != nil {
+			log.Fatalf("Error unmarshaling JSON: %s", err)
+			os.Exit(1)
+		}
+
+		mountPath, err := common.SecureMount(context.Background(), c, storage.VolumeType, storage.Options, storage.Flags, storage.Mountpoint)
+		if err != nil {
+			fmt.Printf("failed to secure mount! err = %v", err)
+			os.Exit(1)
+		}
+		fmt.Printf("Successfully secure mount to %s", mountPath)
 	default:
 		fmt.Printf("The operation type %s is not support yet", common.OperationType)
 		os.Exit(1)

--- a/confidential-data-hub/golang/pkg/core/common.go
+++ b/confidential-data-hub/golang/pkg/core/common.go
@@ -44,3 +44,16 @@ func UnsealFile(ctx context.Context, su SecretUnsealer, sealedFile string) (stri
 
 	return su.UnsealSecret(ctx, string(contents))
 }
+
+// Common interface for clients that can secure mount
+type SecureMounter interface {
+	SecureMount(ctx context.Context, volume_type string, options map[string]string, flags []string, mountpoint string) (string, error)
+}
+
+func SecureMount(ctx context.Context, sm SecureMounter, volume_type string, options map[string]string, flags []string, mountpoint string) (string, error) {
+	mountPath, err := sm.SecureMount(ctx, volume_type, options, flags, mountpoint)
+	if err != nil {
+		return "", fmt.Errorf("failed to secure mount, err: %w", err)
+	}
+	return mountPath, nil
+}

--- a/confidential-data-hub/golang/pkg/core/common.go
+++ b/confidential-data-hub/golang/pkg/core/common.go
@@ -15,6 +15,14 @@ const (
 	SealedSecretPrefix = "sealed."
 )
 
+// Storage is derived from the Rust struct in confidential-data-hub/storage/src/volume_type/mod.rs
+type Storage struct {
+	VolumeType string            `json:"volume_type"`
+	Options    map[string]string `json:"options"`
+	Flags      []string          `json:"flags"`
+	Mountpoint string            `json:"mountpoint"`
+}
+
 // Common interface for clients that can unseal secrets
 type SecretUnsealer interface {
 	UnsealSecret(ctx context.Context, secret string) (string, error)

--- a/confidential-data-hub/golang/pkg/grpc/api_grpc_test.go
+++ b/confidential-data-hub/golang/pkg/grpc/api_grpc_test.go
@@ -79,3 +79,23 @@ func TestGrpcUnsealFile(t *testing.T) {
 	assert.Nil(err)
 	assert.Equal("unsealed-value:unsealed content", resp)
 }
+
+func TestGrpcSecureMount(t *testing.T) {
+	assert := assert.New(t)
+
+	cdhMockServer := mock.CDHGrpcMockServer{}
+	err := cdhMockServer.Start(":8043")
+	assert.NoError(err)
+	defer cdhMockServer.Stop()
+
+	c, err := CreateCDHGrpcClient(CDHGrpcSocket)
+	assert.NoError(err)
+	assert.NotNil(c)
+	defer c.Close()
+
+	ctx := context.Background()
+	options := map[string]string{"deviceId": "0:1", "encryptType": "LUKS", "dataIntegrity": "True"}
+	resp, err := common.SecureMount(ctx, c, "BlockDevice", options, []string{}, "/tmp/test-mount")
+	assert.Nil(err)
+	assert.Equal("/tmp/test-mount", resp)
+}

--- a/confidential-data-hub/golang/pkg/grpc/mock/mock_grpc.go
+++ b/confidential-data-hub/golang/pkg/grpc/mock/mock_grpc.go
@@ -19,11 +19,18 @@ const (
 
 type CDHGrpcMockServerImp struct {
 	cdhapi.UnimplementedSealedSecretServiceServer
+	cdhapi.UnimplementedSecureMountServiceServer
 }
 
 func (p *CDHGrpcMockServerImp) UnsealSecret(ctx context.Context, input *cdhapi.UnsealSecretInput) (*cdhapi.UnsealSecretOutput, error) {
 	secret := string(input.GetSecret())
 	output := cdhapi.UnsealSecretOutput{Plaintext: []byte("unsealed-value:" + strings.TrimPrefix(secret, SealedSecretPrefix))}
+	return &output, nil
+}
+
+func (p *CDHGrpcMockServerImp) SecureMount(ctx context.Context, input *cdhapi.SecureMountRequest) (*cdhapi.SecureMountResponse, error) {
+	mountpoint := input.GetMountPoint()
+	output := cdhapi.SecureMountResponse{MountPath: mountpoint}
 	return &output, nil
 }
 
@@ -34,6 +41,7 @@ type CDHGrpcMockServer struct {
 
 func (cv *CDHGrpcMockServer) grpcRegister(s *grpc.Server) {
 	cdhapi.RegisterSealedSecretServiceServer(s, &CDHGrpcMockServerImp{})
+	cdhapi.RegisterSecureMountServiceServer(s, &CDHGrpcMockServerImp{})
 }
 
 func (cv *CDHGrpcMockServer) Start(socketAddr string) error {

--- a/confidential-data-hub/golang/pkg/ttrpc/api_ttrpc_test.go
+++ b/confidential-data-hub/golang/pkg/ttrpc/api_ttrpc_test.go
@@ -102,3 +102,30 @@ func TestTtrpcUnsealFile(t *testing.T) {
 	assert.Nil(err)
 	assert.Equal("unsealed-value:unsealed content", resp)
 }
+
+func TestGrpcSecureMount(t *testing.T) {
+	assert := assert.New(t)
+
+	mockURL, err := mock.GenerateCDHTtrpcMockVSock()
+	assert.NoError(err)
+	defer mock.RemoveCDHTtrpcMockVSock(mockURL)
+
+	cdhMockServer := mock.CDHTtrpcMockServer{}
+	err = cdhMockServer.Start(mockURL)
+	assert.NoError(err)
+	defer cdhMockServer.Stop()
+
+	sockurl, err := url.Parse(mockURL)
+	assert.NoError(err)
+
+	c, err := CreateCDHTtrpcClient(sockurl.Path)
+	assert.NoError(err)
+	assert.NotNil(c)
+	defer c.Close()
+
+	ctx := context.Background()
+	options := map[string]string{"deviceId": "0:1", "encryptType": "LUKS", "dataIntegrity": "True"}
+	resp, err := common.SecureMount(ctx, c, "BlockDevice", options, []string{}, "/tmp/test-mount")
+	assert.Nil(err)
+	assert.Equal("/tmp/test-mount", resp)
+}

--- a/confidential-data-hub/golang/pkg/ttrpc/mock/mock_ttrpc.go
+++ b/confidential-data-hub/golang/pkg/ttrpc/mock/mock_ttrpc.go
@@ -49,6 +49,7 @@ type CDHTtrpcMockServer struct {
 
 func (cv *CDHTtrpcMockServer) ttrpcRegister(s *ttrpc.Server) {
 	cdhapi.RegisterSealedSecretServiceService(s, &cv.CDHTtrpcMockServerImp)
+	cdhapi.RegisterSecureMountServiceService(s, &cv.CDHTtrpcMockServerImp)
 }
 
 func (cv *CDHTtrpcMockServer) Start(socketAddr string) error {
@@ -94,5 +95,11 @@ type CDHTtrpcMockServerImp struct{}
 func (p *CDHTtrpcMockServerImp) UnsealSecret(ctx context.Context, input *cdhapi.UnsealSecretInput) (*cdhapi.UnsealSecretOutput, error) {
 	secret := string(input.GetSecret())
 	output := cdhapi.UnsealSecretOutput{Plaintext: []byte("unsealed-value:" + strings.TrimPrefix(secret, SealedSecretPrefix))}
+	return &output, nil
+}
+
+func (p *CDHTtrpcMockServerImp) SecureMount(ctx context.Context, input *cdhapi.SecureMountRequest) (*cdhapi.SecureMountResponse, error) {
+	mountpoint := input.GetMountPoint()
+	output := cdhapi.SecureMountResponse{MountPath: mountpoint}
 	return &output, nil
 }


### PR DESCRIPTION
Add support for SecureMount in the go client tool.