### PR TITLE
update CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,6 +1,2 @@
-# Global owner for changes not matched by more specific rules
-* @sameo
-
-/attestation-agent/ @jialez0
-/image-rs/ @sameo @jiangliu @arronwy @lumjjb @jialez0 @Xynnn007
-/ocicrypt-rs/ @sameo @jiangliu @arronwy @lumjjb
+# https://github.com/orgs/confidential-containers/teams/guest-components-maintainers
+* @confidential-containers/guest-components-maintainers


### PR DESCRIPTION
Make guest-components-maintainers the CODEOWNERS of this repo.

Ref: https://github.com/confidential-containers/confidential-containers/issues/31
Ref: https://github.com/confidential-containers/confidential-containers/pull/235