### PR TITLE
AA: kbs: Add supported hash algorithms to Request

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -291,6 +291,7 @@ dependencies = [
  "clap 4.2.7",
  "config",
  "const_format",
+ "crypto",
  "env_logger 0.11.5",
  "kbs-types",
  "kbs_protocol",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -74,14 +74,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "algorithms"
-version = "0.1.0"
-dependencies = [
- "serde",
- "sha2 0.10.8",
-]
-
-[[package]]
 name = "android-tzdata"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -292,7 +284,6 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 name = "attestation-agent"
 version = "0.1.0"
 dependencies = [
- "algorithms",
  "anyhow",
  "async-trait",
  "attester",
@@ -3138,7 +3129,6 @@ dependencies = [
 name = "kbs_protocol"
 version = "0.1.0"
 dependencies = [
- "algorithms",
  "anyhow",
  "async-trait",
  "attester",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -74,6 +74,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "algorithms"
+version = "0.1.0"
+dependencies = [
+ "serde",
+ "sha2 0.10.8",
+]
+
+[[package]]
 name = "android-tzdata"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -284,6 +292,7 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 name = "attestation-agent"
 version = "0.1.0"
 dependencies = [
+ "algorithms",
  "anyhow",
  "async-trait",
  "attester",
@@ -3129,6 +3138,7 @@ dependencies = [
 name = "kbs_protocol"
 version = "0.1.0"
 dependencies = [
+ "algorithms",
  "anyhow",
  "async-trait",
  "attester",

--- a/attestation-agent/attestation-agent/Cargo.toml
+++ b/attestation-agent/attestation-agent/Cargo.toml
@@ -17,6 +17,7 @@ required-features = ["bin", "ttrpc"]
 anyhow.workspace = true
 async-trait.workspace = true
 attester = { path = "../attester", default-features = false }
+crypto = { path = "../deps/crypto", default-features = false }
 base64.workspace = true
 clap = { workspace = true, features = ["derive"], optional = true }
 config.workspace = true

--- a/attestation-agent/attestation-agent/Cargo.toml
+++ b/attestation-agent/attestation-agent/Cargo.toml
@@ -17,7 +17,7 @@ required-features = ["bin", "ttrpc"]
 anyhow.workspace = true
 async-trait.workspace = true
 attester = { path = "../attester", default-features = false }
-crypto = { path = "../deps/crypto", default-features = false }
+crypto = { path = "../deps/crypto" }
 base64.workspace = true
 clap = { workspace = true, features = ["derive"], optional = true }
 config.workspace = true

--- a/attestation-agent/attestation-agent/src/config/mod.rs
+++ b/attestation-agent/attestation-agent/src/config/mod.rs
@@ -4,8 +4,8 @@
 //
 
 use anyhow::Result;
+use crypto::HashAlgorithm;
 use serde::Deserialize;
-use sha2::{Digest, Sha256, Sha384, Sha512};
 
 /// Default PCR index used by AA. `17` is selected for its usage of dynamic root of trust for measurement.
 /// - [Linux TPM PCR Registry](https://uapi-group.org/specifications/specs/linux_tpm_pcr_registry/)
@@ -23,35 +23,6 @@ pub mod kbs;
 pub const DEFAULT_AA_CONFIG_PATH: &str = "/etc/attestation-agent.conf";
 
 pub const DEFAULT_EVENTLOG_HASH: &str = "sha384";
-
-/// Hash algorithms used to calculate runtime/init data binding
-#[derive(Deserialize, Clone, Debug, Copy)]
-#[serde(rename_all = "lowercase")]
-pub enum HashAlgorithm {
-    Sha256,
-    Sha384,
-    Sha512,
-}
-
-impl Default for HashAlgorithm {
-    fn default() -> Self {
-        Self::Sha384
-    }
-}
-
-fn hash_reportdata<D: Digest>(material: &[u8]) -> Vec<u8> {
-    D::new().chain_update(material).finalize().to_vec()
-}
-
-impl HashAlgorithm {
-    pub fn digest(&self, material: &[u8]) -> Vec<u8> {
-        match self {
-            HashAlgorithm::Sha256 => hash_reportdata::<Sha256>(material),
-            HashAlgorithm::Sha384 => hash_reportdata::<Sha384>(material),
-            HashAlgorithm::Sha512 => hash_reportdata::<Sha512>(material),
-        }
-    }
-}
 
 #[derive(Clone, Debug, Deserialize)]
 pub struct Config {

--- a/attestation-agent/attestation-agent/src/eventlog.rs
+++ b/attestation-agent/attestation-agent/src/eventlog.rs
@@ -8,7 +8,7 @@ use std::{fmt::Display, fs::File, io::Write};
 use anyhow::{bail, Context, Result};
 use const_format::concatcp;
 
-use crate::config::HashAlgorithm;
+use crypto::HashAlgorithm;
 
 /// AA's eventlog will be put into this parent directory
 pub const EVENTLOG_PARENT_DIR_PATH: &str = "/run/attestation-agent";
@@ -109,7 +109,6 @@ impl<'a> Display for LogEntry<'a> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::config::HashAlgorithm;
     use rstest::rstest;
     use std::sync::{Arc, Mutex};
 

--- a/attestation-agent/deps/crypto/src/algorithms.rs
+++ b/attestation-agent/deps/crypto/src/algorithms.rs
@@ -1,0 +1,75 @@
+// Copyright (c) 2024 Alibaba Cloud
+// Copyright (c) 2024 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256, Sha384, Sha512};
+use std::fmt;
+use std::str::FromStr;
+
+/// Hash algorithms used to calculate runtime/init data binding
+#[derive(Serialize, Deserialize, Clone, Debug, Display, Copy)]
+#[serde(rename_all = "lowercase")]
+pub enum HashAlgorithm {
+    Sha256,
+    Sha384,
+    Sha512,
+}
+
+impl Default for HashAlgorithm {
+    fn default() -> Self {
+        Self::Sha384
+    }
+}
+
+fn hash_reportdata<D: Digest>(material: &[u8]) -> Vec<u8> {
+    D::new().chain_update(material).finalize().to_vec()
+}
+
+impl HashAlgorithm {
+    pub fn digest(&self, material: &[u8]) -> Vec<u8> {
+        match self {
+            HashAlgorithm::Sha256 => hash_reportdata::<Sha256>(material),
+            HashAlgorithm::Sha384 => hash_reportdata::<Sha384>(material),
+            HashAlgorithm::Sha512 => hash_reportdata::<Sha512>(material),
+        }
+    }
+
+    /// Return a list of all supported hash algorithms.
+    pub fn list_all() -> Vec<Self> {
+        vec![
+            HashAlgorithm::Sha256,
+            HashAlgorithm::Sha384,
+            HashAlgorithm::Sha512,
+        ]
+    }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct ParseHashAlgorithmError;
+
+// XXX: Required to allow conversion to a std::error::Error by `anyhow!()`.
+impl fmt::Display for ParseHashAlgorithmError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "ParseHashAlgorithmError")
+    }
+}
+
+impl FromStr for HashAlgorithm {
+    type Err = ParseHashAlgorithmError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let cleaned = s.replace('-', "").to_lowercase();
+
+        let result = match cleaned.as_str() {
+            "sha256" => HashAlgorithm::Sha256,
+            "sha384" => HashAlgorithm::Sha384,
+            "sha512" => HashAlgorithm::Sha512,
+            _ => return Err(ParseHashAlgorithmError),
+        };
+
+        Ok(result)
+    }
+}

--- a/attestation-agent/deps/crypto/src/lib.rs
+++ b/attestation-agent/deps/crypto/src/lib.rs
@@ -31,3 +31,6 @@ pub use symmetric::*;
 
 mod asymmetric;
 pub use asymmetric::*;
+
+mod algorithms;
+pub use algorithms::*;

--- a/attestation-agent/kbs_protocol/src/client/rcar_client.rs
+++ b/attestation-agent/kbs_protocol/src/client/rcar_client.rs
@@ -38,6 +38,16 @@ struct AttestationResponseData {
     token: String,
 }
 
+async fn build_request(tee: Tee) -> Request {
+    let extra_params = serde_json::Value::String(String::new());
+
+    Request {
+        version: String::from(KBS_PROTOCOL_VERSION),
+        tee,
+        extra_params,
+    }
+}
+
 impl KbsClient<Box<dyn EvidenceProvider>> {
     /// Get a [`TeeKeyPair`] and a [`Token`] that certifies the [`TeeKeyPair`].
     /// If the client does not already have token or the token is invalid,
@@ -101,11 +111,7 @@ impl KbsClient<Box<dyn EvidenceProvider>> {
             ClientTee::_Initializated(tee) => *tee,
         };
 
-        let request = Request {
-            version: String::from(KBS_PROTOCOL_VERSION),
-            tee,
-            extra_params: serde_json::Value::String(String::new()),
-        };
+        let request = build_request(tee).await;
 
         debug!("send auth request to {auth_endpoint}");
 

--- a/attestation-agent/kbs_protocol/src/error.rs
+++ b/attestation-agent/kbs_protocol/src/error.rs
@@ -44,4 +44,7 @@ pub enum Error {
 
     #[error("request unauthorized")]
     UnAuthorized,
+
+    #[error("invalid hash algorithm: {0}")]
+    InvalidHashAlgorithm(String),
 }


### PR DESCRIPTION
Add a `supported-hash-algorithms` list to the `Request` to allow the
returned `Challenge` to select an appropriate TEE-specific algorithm
from the list.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>