### PR TITLE
dep: update krata-tokio-tar to v0.4.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3196,13 +3196,14 @@ dependencies = [
 
 [[package]]
 name = "krata-tokio-tar"
-version = "0.4.0"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba844968838c1c5892da2116e5f744bceab2b43af34539abdd6cd3975eaca973"
+checksum = "e8bd5fee9b96acb5fc36b401896d601e6fdcce52b0e651ce24a3b21fb524e79f"
 dependencies = [
  "filetime",
  "futures-core",
  "libc",
+ "portable-atomic",
  "redox_syscall 0.3.5",
  "tokio",
  "tokio-stream",
@@ -4462,6 +4463,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "portable-atomic"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da544ee218f0d287a911e9c99a39a8c9bc8fcad3cb8db5959940044ecfc67265"
+
+[[package]]
 name = "powerfmt"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5459,7 +5466,7 @@ dependencies = [
  "aes",
  "aes-gcm",
  "anyhow",
- "base64 0.21.7",
+ "base64 0.22.1",
  "block-padding",
  "blowfish",
  "buffered-reader",

--- a/image-rs/Cargo.toml
+++ b/image-rs/Cargo.toml
@@ -54,7 +54,7 @@ sha2.workspace = true
 sigstore = { git = "https://github.com/sigstore/sigstore-rs.git", rev = "1b6ccf0f64d173350ec5515bd69ab48a26a9c0a3", default-features = false, optional = true }
 strum.workspace = true
 strum_macros = "0.26"
-krata-tokio-tar = "0.4.0"
+krata-tokio-tar = "0.4.2"
 tokio.workspace = true
 tokio-util = "0.7.11"
 tonic = { workspace = true, optional = true }


### PR DESCRIPTION
The new version of krata-tokio-tar supports long link name.

Fixes #689

cc @bpradipt @JakubLedworowski 