### PR TITLE
release: Publish vendored code

### DIFF
--- a/.github/workflows/vendor_release.yml
+++ b/.github/workflows/vendor_release.yml
@@ -1,0 +1,24 @@
+name: Generate vendored content for the release
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  generate-and-publish-vendored-code:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Generate and publish cargo vendored tarball
+        run: |
+          tag=$(echo $GITHUB_REF | sed 's|refs/tags/||')
+          tarball_name="guest-components-${tag}-vendor.tar.gz"
+          mkdir -p .cargo
+          cargo vendor --locked >> .cargo/config.toml
+
+          tar -cvzf ${tarball_name} vendor .cargo/config.toml 
+          gh release upload ${tag} ${tarball_name}
+        env:
+          GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
Currently we're not publishing the vendored code as part of the release, which leads to all the downstream which do not have access to internet whilst building their components to do this process manually.

Let's be nice to the downstreams, let's publish the vendors ourselves.

Here's one release that I cut, on my own branch, showing the result of this action: https://github.com/fidencio/guest-components/releases/tag/v0.0.0-test-vendored-tarball