### PR TITLE
AA: kbs: Improve handling of invalid RCAR JSON

### DIFF
--- a/attestation-agent/deps/crypto/src/algorithms.rs
+++ b/attestation-agent/deps/crypto/src/algorithms.rs
@@ -10,7 +10,7 @@ use std::fmt;
 use std::str::FromStr;
 
 /// Hash algorithms used to calculate runtime/init data binding
-#[derive(Serialize, Deserialize, Clone, Debug, Display, Copy)]
+#[derive(Serialize, Deserialize, Clone, Debug, Display, Copy, PartialEq)]
 #[serde(rename_all = "lowercase")]
 pub enum HashAlgorithm {
     Sha256,

--- a/attestation-agent/kbs_protocol/src/error.rs
+++ b/attestation-agent/kbs_protocol/src/error.rs
@@ -47,4 +47,7 @@ pub enum Error {
 
     #[error("invalid hash algorithm: {0}")]
     InvalidHashAlgorithm(String),
+
+    #[error("unexpected JSON data type: expected {0}, got {1}")]
+    UnexpectedJSONDataType(String, String),
 }


### PR DESCRIPTION
Create a new error to handle the scenario where the RCAR JSON specifies the selected hash algorithm
using the wrong data type (any type other than 'string').

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>