### PR TITLE
attestation-agent: default to ttrpc in Makefile

### DIFF
--- a/attestation-agent/Makefile
+++ b/attestation-agent/Makefile
@@ -37,14 +37,14 @@ ifeq ($(ARCH), $(filter $(ARCH), s390x powerpc64le))
   OPENSSL=1
 endif
 
-ifeq ($(ttrpc), true)
-    binary = --bin ttrpc-aa
-    features += bin,ttrpc
-    binary_name = ttrpc-aa
-else
+ifeq ($(ttrpc), false)
     binary = --bin grpc-aa
     features += bin,grpc
     binary_name = grpc-aa
+else
+    binary = --bin ttrpc-aa
+    features += bin,ttrpc
+    binary_name = ttrpc-aa
 endif
 
 ifdef ATTESTER


### PR DESCRIPTION
CDH already does this and ASR doesn't work with GRPC. This change shouldn't break any existing invocations of the makefile with ttrpc=true, only builds that rely on grpc being implicitly picked. Due to the CDH's default and ASR being ttrpc-only I don't think we break anything downstream.