### PR TITLE
attestation-agent: add flag 'enable_eventlog' to aa example config

### DIFF
--- a/attestation-agent/attestation-agent/config.example.json
+++ b/attestation-agent/attestation-agent/config.example.json
@@ -10,6 +10,7 @@
     },
     "eventlog_config": {
         "eventlog_algorithm": "sha384",
-        "init_pcr": 17
+        "init_pcr": 17,
+        "enable_eventlog": false
     }
 }

--- a/attestation-agent/attestation-agent/config.example.toml
+++ b/attestation-agent/attestation-agent/config.example.toml
@@ -34,3 +34,4 @@ M9QaC1mzQ/OStg==
 
 eventlog_algorithm = "sha384"
 init_pcr = 17
+enable_eventlog = false


### PR DESCRIPTION
add flag 'enable_eventlog' to aa example config according to the related PR: #627