### PR TITLE
CI: Publish binaries with ORAS

### DIFF
--- a/.github/actions/install-intel-dcap/action.yml
+++ b/.github/actions/install-intel-dcap/action.yml
@@ -9,7 +9,7 @@ runs:
     id: install-tdx-dependencies
     shell: bash
     run: |
-      sudo curl -sL https://download.01.org/intel-sgx/sgx_repo/ubuntu/intel-sgx-deb.key | sudo gpg --dearmor --output /usr/share/keyrings/intel-sgx.gpg
-      sudo echo 'deb [arch=amd64 signed-by=/usr/share/keyrings/intel-sgx.gpg] https://download.01.org/intel-sgx/sgx_repo/ubuntu ${{ inputs.ubuntu-version }} main' | sudo tee /etc/apt/sources.list.d/intel-sgx.list
+      curl -sL https://download.01.org/intel-sgx/sgx_repo/ubuntu/intel-sgx-deb.key | sudo gpg --dearmor --output /usr/share/keyrings/intel-sgx.gpg
+      echo 'deb [arch=amd64 signed-by=/usr/share/keyrings/intel-sgx.gpg] https://download.01.org/intel-sgx/sgx_repo/ubuntu ${{ inputs.ubuntu-version }} main' | sudo tee /etc/apt/sources.list.d/intel-sgx.list
       sudo apt-get update
       sudo apt-get install -y --no-install-recommends libtdx-attest-dev

--- a/.github/actions/install-intel-dcap/action.yml
+++ b/.github/actions/install-intel-dcap/action.yml
@@ -1,0 +1,15 @@
+name: 'Install Intel DCAP libraries'
+inputs:
+  ubuntu-version:
+    required: true
+runs:
+  using: "composite"
+  steps:
+  - name: Install TDX dependencies
+    id: install-tdx-dependencies
+    shell: bash
+    run: |
+      sudo curl -sL https://download.01.org/intel-sgx/sgx_repo/ubuntu/intel-sgx-deb.key | sudo gpg --dearmor --output /usr/share/keyrings/intel-sgx.gpg
+      sudo echo 'deb [arch=amd64 signed-by=/usr/share/keyrings/intel-sgx.gpg] https://download.01.org/intel-sgx/sgx_repo/ubuntu ${{ inputs.ubuntu-version }} main' | sudo tee /etc/apt/sources.list.d/intel-sgx.list
+      sudo apt-get update
+      sudo apt-get install -y --no-install-recommends libtdx-attest-dev

--- a/.github/workflows/aa_basic.yml
+++ b/.github/workflows/aa_basic.yml
@@ -65,12 +65,9 @@ jobs:
         run: |
           sudo apt-get update && sudo apt-get install -y protobuf-compiler
 
-      - name: Install TDX dependencies
-        run: |
-          sudo curl -sL https://download.01.org/intel-sgx/sgx_repo/ubuntu/intel-sgx-deb.key | sudo gpg --dearmor --output /usr/share/keyrings/intel-sgx.gpg
-          sudo echo 'deb [arch=amd64 signed-by=/usr/share/keyrings/intel-sgx.gpg] https://download.01.org/intel-sgx/sgx_repo/ubuntu jammy main' | sudo tee /etc/apt/sources.list.d/intel-sgx.list
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends libtdx-attest-dev
+      - uses: ./.github/actions/install-intel-dcap
+        with:
+          ubuntu-version: jammy
         if: matrix.instance == 'ubuntu-22.04'
 
       - name: Install TPM dependencies

--- a/.github/workflows/aa_cc_kbc.yml
+++ b/.github/workflows/aa_cc_kbc.yml
@@ -55,12 +55,9 @@ jobs:
           override: true
           components: rustfmt
 
-      - name: Install TDX dependencies
-        run: |
-          sudo curl -sL https://download.01.org/intel-sgx/sgx_repo/ubuntu/intel-sgx-deb.key | sudo gpg --dearmor --output /usr/share/keyrings/intel-sgx.gpg
-          sudo echo 'deb [arch=amd64 signed-by=/usr/share/keyrings/intel-sgx.gpg] https://download.01.org/intel-sgx/sgx_repo/ubuntu jammy main' | sudo tee /etc/apt/sources.list.d/intel-sgx.list
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends libtdx-attest-dev
+      - uses: ./.github/actions/install-intel-dcap
+        with:
+          ubuntu-version: jammy
 
       - name: Install TPM dependencies
         run: |

--- a/.github/workflows/image_rs_build.yml
+++ b/.github/workflows/image_rs_build.yml
@@ -56,12 +56,9 @@ jobs:
         run: |
           sudo apt install -y clang llvm pkg-config nettle-dev protobuf-compiler libprotobuf-dev
 
-      - name: Install TDX dependencies
-        run: |
-          sudo curl -sL https://download.01.org/intel-sgx/sgx_repo/ubuntu/intel-sgx-deb.key | sudo gpg --dearmor --output /usr/share/keyrings/intel-sgx.gpg
-          sudo echo 'deb [arch=amd64 signed-by=/usr/share/keyrings/intel-sgx.gpg] https://download.01.org/intel-sgx/sgx_repo/ubuntu jammy main' | sudo tee /etc/apt/sources.list.d/intel-sgx.list
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends libtdx-attest-dev
+      - uses: ./.github/actions/install-intel-dcap
+        with:
+          ubuntu-version: jammy
         if: matrix.instance == 'ubuntu-latest'
 
       - name: Install TPM dependencies

--- a/.github/workflows/publish-artifacts.yml
+++ b/.github/workflows/publish-artifacts.yml
@@ -1,0 +1,186 @@
+name: Publish artifacts to ORAS
+
+on:
+  push:
+    branches:
+    - main
+
+env:
+  RUST_TOOLCHAIN: 1.76.0
+
+jobs:
+  publish-aa:
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+    strategy:
+      matrix:
+        tee:
+        - none
+        - amd
+        - az-cvm-vtpm
+        - tdx
+        - se
+        - cca
+        arch:
+        - x86_64
+        - s390x
+        exclude:
+        - tee: amd
+          arch: s390x
+        - tee: az-cvm-vtpm
+          arch: s390x
+        - tee: tdx
+          arch: s390x
+        - tee: se
+          arch: x86_64
+        - tee: cca
+          arch: s390x
+        include:
+        - tee: none
+          arch: x86_64
+          libc: musl
+        - tee: none
+          arch: s390x
+          libc: gnu
+        - tee: amd
+          arch: x86_64
+          libc: musl
+        - tee: az-cvm-vtpm
+          arch: x86_64
+          libc: gnu
+        - tee: tdx
+          arch: x86_64
+          libc: gnu
+        - tee: se
+          arch: s390x
+          libc: gnu
+        - tee: cca
+          arch: x86_64
+          libc: musl
+    runs-on: ${{ matrix.arch == 's390x' && 's390x' || 'ubuntu-22.04' }}
+    env:
+      TEE_PLATFORM: ${{ matrix.tee }}
+      LIBC: ${{ matrix.libc }}
+      REGISTRY: ghcr.io
+      IMAGE_NAME: ${{ github.repository }}
+    steps:
+    - name: Log in to the Container registry
+      uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
+      with:
+        registry: ${{ env.REGISTRY }}
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - uses: oras-project/setup-oras@v1
+      with:
+        version: 1.2.0
+
+    - uses: actions/checkout@v4
+
+    - uses: actions-rust-lang/setup-rust-toolchain@v1
+      with:
+        toolchain: ${{ env.RUST_TOOLCHAIN }}
+        target: ${{ matrix.arch }}-unknown-linux-${{ matrix.libc }}
+        override: true
+
+    - name: Install tpm dependencies
+      if: matrix.tee == 'az-cvm-vtpm'
+      run: |
+        sudo apt-get install -y --no-install-recommends libtss2-dev
+
+    - name: Install tdx dependencies
+      if: matrix.tee == 'tdx'
+      run: |
+        sudo curl -sL https://download.01.org/intel-sgx/sgx_repo/ubuntu/intel-sgx-deb.key | sudo gpg --dearmor --output /usr/share/keyrings/intel-sgx.gpg
+        sudo echo 'deb [arch=amd64 signed-by=/usr/share/keyrings/intel-sgx.gpg] https://download.01.org/intel-sgx/sgx_repo/ubuntu jammy main' | sudo tee /etc/apt/sources.list.d/intel-sgx.list
+        sudo apt-get update
+        sudo apt-get install -y --no-install-recommends libtdx-attest-dev
+
+    - uses: actions/checkout@v4
+
+    - name: Build
+      run: make ./target/${{ matrix.arch }}-unknown-linux-${{ matrix.libc}}/release/attestation-agent
+
+    - name: Publish to ORAS
+      env:
+        ARCH: ${{ matrix.arch == 'x86_64' && 'amd64' || matrix.arch }}
+      run: |
+        mkdir oras
+        cd oras
+        cp ../target/${{ matrix.arch }}-unknown-linux-${{ matrix.libc}}/release/attestation-agent .
+        tar cJf attestation-agent.tar.xz attestation-agent
+        arch_tag="${{ github.sha }}-${{ matrix.tee }}_${{ matrix.arch }}"
+        image="${REGISTRY}/${IMAGE_NAME}/attestation-agent"
+        tag="${{ github.sha }}-${{ matrix.tee }}"
+        arch_tag="${tag}_${ARCH}"
+        oras push "${image}:${arch_tag}" attestation-agent.tar.xz
+        # We need to create the platform annotations with docker, since oras 1.2 doesn't support
+        # pushing with platform yet.
+        docker manifest create "${image}:${tag}" --amend "${image}:${arch_tag}"
+        docker manifest annotate --arch "$ARCH" --os linux "${image}:${tag}" "${image}:${arch_tag}"
+        docker manifest push "${image}:${tag}"
+
+  publish-cdh-and-asr:
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+    strategy:
+      matrix:
+        arch:
+        - x86_64
+        - s390x
+        include:
+        - arch: x86_64
+          libc: musl
+        - arch: s390x
+          libc: gnu
+    runs-on: ${{ matrix.arch == 's390x' && 's390x' || 'ubuntu-22.04' }}
+    env:
+      LIBC: ${{ matrix.libc }}
+      REGISTRY: ghcr.io
+      IMAGE_NAME: ${{ github.repository }}
+    steps:
+    - name: Log in to the Container registry
+      uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
+      with:
+        registry: ${{ env.REGISTRY }}
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - uses: oras-project/setup-oras@v1
+      with:
+        version: 1.2.0
+
+    - uses: actions-rust-lang/setup-rust-toolchain@v1
+      with:
+        toolchain: ${{ env.RUST_TOOLCHAIN }}
+        target: ${{ matrix.arch }}-unknown-linux-${{ matrix.libc }}
+        override: true
+
+    - name: Install dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y --no-install-recommends \
+          libdevmapper-dev \
+          protobuf-compiler
+
+    - uses: actions/checkout@v4
+
+    - name: Build CDH
+      run: make ./target/${{ matrix.arch }}-unknown-linux-${{ matrix.libc}}/release/confidential-data-hub
+
+    - name: Build ASR
+      run: make ./target/${{ matrix.arch }}-unknown-linux-${{ matrix.libc}}/release/api-server-rest
+
+    - name: Publish to ORAS
+      run: |
+        mkdir oras
+        cd oras
+        cp ../target/${{ matrix.arch }}-unknown-linux-${{ matrix.libc}}/release/{confidential-data-hub,api-server-rest} .
+        tar cJf confidential-data-hub.tar.xz confidential-data-hub
+        tar cJf api-server-rest.tar.xz api-server-rest
+        oras push ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/confidential-data-hub:${{ github.sha }}-${{ matrix.arch }} confidential-data-hub.tar.xz
+        oras push ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/api-server-rest:${{ github.sha }}-${{ matrix.arch }} api-server-rest.tar.xz

--- a/.github/workflows/publish-artifacts.yml
+++ b/.github/workflows/publish-artifacts.yml
@@ -90,13 +90,10 @@ jobs:
       run: |
         sudo apt-get install -y --no-install-recommends libtss2-dev
 
-    - name: Install tdx dependencies
+    - uses: ./.github/actions/install-intel-dcap
+      with:
+        ubuntu-version: jammy
       if: matrix.tee == 'tdx'
-      run: |
-        sudo curl -sL https://download.01.org/intel-sgx/sgx_repo/ubuntu/intel-sgx-deb.key | sudo gpg --dearmor --output /usr/share/keyrings/intel-sgx.gpg
-        sudo echo 'deb [arch=amd64 signed-by=/usr/share/keyrings/intel-sgx.gpg] https://download.01.org/intel-sgx/sgx_repo/ubuntu jammy main' | sudo tee /etc/apt/sources.list.d/intel-sgx.list
-        sudo apt-get update
-        sudo apt-get install -y --no-install-recommends libtdx-attest-dev
 
     - uses: actions/checkout@v4
 

--- a/.github/workflows/publish-artifacts.yml
+++ b/.github/workflows/publish-artifacts.yml
@@ -153,7 +153,7 @@ jobs:
     - name: Build ASR
       run: make ./target/${{ env.RUST_TARGET }}/release/api-server-rest
 
-    - name: Publish CDH + ASR to ORAS
+    - name: Publish CDH + ASR with ORAS
       id: publish
       run: |
         tag="${{ github.sha }}-${{ matrix.arch }}"

--- a/.github/workflows/publish-artifacts.yml
+++ b/.github/workflows/publish-artifacts.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
     - main
+    - mkulke/test
 
 env:
   RUST_TOOLCHAIN: 1.76.0
@@ -14,6 +15,7 @@ jobs:
       contents: read
       packages: write
       id-token: write
+      attestations: write
     strategy:
       matrix:
         tee:
@@ -101,6 +103,7 @@ jobs:
       run: make ./target/${{ matrix.arch }}-unknown-linux-${{ matrix.libc}}/release/attestation-agent
 
     - name: Publish to ORAS
+      id: publish
       env:
         ARCH: ${{ matrix.arch == 'x86_64' && 'amd64' || matrix.arch }}
       run: |
@@ -118,12 +121,23 @@ jobs:
         docker manifest create "${image}:${tag}" --amend "${image}:${arch_tag}"
         docker manifest annotate --arch "$ARCH" --os linux "${image}:${tag}" "${image}:${arch_tag}"
         docker manifest push "${image}:${tag}"
+        # add image and digest to output for attestation
+        echo "image=${image}" >> "$GITHUB_OUTPUT"
+        digest="$(oras manifest fetch "${image}:${arch_tag}" --descriptor | jq -r .digest)"
+        echo "digest=${digest}" >> "$GITHUB_OUTPUT"
+
+    - uses: actions/attest-build-provenance@v1
+      with:
+        subject-name: ${{ steps.publish.outputs.image }}
+        subject-digest: ${{ steps.publish.outputs.digest }}
+        push-to-registry: true
 
   publish-cdh-and-asr:
     permissions:
       contents: read
       packages: write
       id-token: write
+      attestations: write
     strategy:
       matrix:
         arch:
@@ -172,12 +186,36 @@ jobs:
     - name: Build ASR
       run: make ./target/${{ matrix.arch }}-unknown-linux-${{ matrix.libc}}/release/api-server-rest
 
-    - name: Publish to ORAS
+    - name: Publish CDH + ASR to ORAS
+      id: publish
       run: |
+        tag="${{ github.sha }}-${{ matrix.arch }}"
         mkdir oras
         cd oras
         cp ../target/${{ matrix.arch }}-unknown-linux-${{ matrix.libc}}/release/{confidential-data-hub,api-server-rest} .
+
         tar cJf confidential-data-hub.tar.xz confidential-data-hub
+        image="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/confidential-data-hub"
+        oras push "${image}:${tag}" confidential-data-hub.tar.xz
+        echo "cdh-image=${image}" >> "$GITHUB_OUTPUT"
+        digest="$(oras manifest fetch "${image}:${tag}" --descriptor | jq -r .digest)"
+        echo "cdh-digest=${digest}" >> "$GITHUB_OUTPUT"
+
         tar cJf api-server-rest.tar.xz api-server-rest
-        oras push ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/confidential-data-hub:${{ github.sha }}-${{ matrix.arch }} confidential-data-hub.tar.xz
-        oras push ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/api-server-rest:${{ github.sha }}-${{ matrix.arch }} api-server-rest.tar.xz
+        image="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/api-server-rest"
+        oras push "${image}:${tag}" api-server-rest.tar.xz
+        echo "asr-image=${image}" >> "$GITHUB_OUTPUT"
+        digest="$(oras manifest fetch "${image}:${tag}" --descriptor | jq -r .digest)"
+        echo "asr-digest=${digest}" >> "$GITHUB_OUTPUT"
+
+    - uses: actions/attest-build-provenance@v1
+      with:
+        subject-name: ${{ steps.publish.outputs.cdh-image }}
+        subject-digest: ${{ steps.publish.outputs.cdh-digest }}
+        push-to-registry: true
+
+    - uses: actions/attest-build-provenance@v1
+      with:
+        subject-name: ${{ steps.publish.outputs.asr-image }}
+        subject-digest: ${{ steps.publish.outputs.asr-digest }}
+        push-to-registry: true

--- a/.github/workflows/publish-artifacts.yml
+++ b/.github/workflows/publish-artifacts.yml
@@ -68,7 +68,7 @@ jobs:
     - name: Build
       run: make ./target/${{ env.RUST_TARGET }}/release/attestation-agent
 
-    - name: Publish to ORAS
+    - name: Publish with ORAS
       id: publish
       env:
         OCI_ARCH: ${{ matrix.platform.arch == 'x86_64' && 'amd64' || matrix.platform.arch }}

--- a/.github/workflows/publish-artifacts.yml
+++ b/.github/workflows/publish-artifacts.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
     - main
-    - mkulke/test
 
 env:
   RUST_TOOLCHAIN: 1.76.0
@@ -18,55 +17,22 @@ jobs:
       attestations: write
     strategy:
       matrix:
-        tee:
-        - none
-        - amd
-        - az-cvm-vtpm
-        - tdx
-        - se
-        - cca
-        arch:
-        - x86_64
-        - s390x
-        exclude:
-        - tee: amd
-          arch: s390x
-        - tee: az-cvm-vtpm
-          arch: s390x
-        - tee: tdx
-          arch: s390x
-        - tee: se
-          arch: x86_64
-        - tee: cca
-          arch: s390x
-        include:
-        - tee: none
-          arch: x86_64
-          libc: musl
-        - tee: none
-          arch: s390x
-          libc: gnu
-        - tee: amd
-          arch: x86_64
-          libc: musl
-        - tee: az-cvm-vtpm
-          arch: x86_64
-          libc: gnu
-        - tee: tdx
-          arch: x86_64
-          libc: gnu
-        - tee: se
-          arch: s390x
-          libc: gnu
-        - tee: cca
-          arch: x86_64
-          libc: musl
-    runs-on: ${{ matrix.arch == 's390x' && 's390x' || 'ubuntu-22.04' }}
+        platform: [
+          { tee: none,        arch: x86_64, libc: musl },
+          { tee: none,        arch: s390x,  libc: gnu  },
+          { tee: amd,         arch: x86_64, libc: musl },
+          { tee: az-cvm-vtpm, arch: x86_64, libc: gnu  },
+          { tee: tdx,         arch: x86_64, libc: gnu  },
+          { tee: cca,         arch: x86_64, libc: musl },
+          { tee: se,          arch: s390x,  libc: gnu  },
+        ]
+    runs-on: ${{ matrix.platform.arch == 's390x' && 's390x' || 'ubuntu-22.04' }}
     env:
-      TEE_PLATFORM: ${{ matrix.tee }}
-      LIBC: ${{ matrix.libc }}
+      TEE_PLATFORM: ${{ matrix.platform.tee }}
+      LIBC: ${{ matrix.platform.libc }}
       REGISTRY: ghcr.io
       IMAGE_NAME: ${{ github.repository }}
+      RUST_TARGET: ${{ matrix.platform.arch }}-unknown-linux-${{ matrix.platform.libc }}
     steps:
     - name: Log in to the Container registry
       uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
@@ -84,32 +50,32 @@ jobs:
     - uses: actions-rust-lang/setup-rust-toolchain@v1
       with:
         toolchain: ${{ env.RUST_TOOLCHAIN }}
-        target: ${{ matrix.arch }}-unknown-linux-${{ matrix.libc }}
+        target: ${{ env.RUST_TARGET }}
         override: true
 
     - name: Install tpm dependencies
-      if: matrix.tee == 'az-cvm-vtpm'
+      if: matrix.platform.tee == 'az-cvm-vtpm'
       run: |
         sudo apt-get install -y --no-install-recommends libtss2-dev
 
     - uses: ./.github/actions/install-intel-dcap
       with:
         ubuntu-version: jammy
-      if: matrix.tee == 'tdx'
+      if: matrix.platform.tee == 'tdx'
 
     - uses: actions/checkout@v4
 
     - name: Build
-      run: make ./target/${{ matrix.arch }}-unknown-linux-${{ matrix.libc}}/release/attestation-agent
+      run: make ./target/${{ env.RUST_TARGET }}/release/attestation-agent
 
     - name: Publish to ORAS
       id: publish
       env:
-        ARCH: ${{ matrix.arch == 'x86_64' && 'amd64' || matrix.arch }}
+        OCI_ARCH: ${{ matrix.platform.arch == 'x86_64' && 'amd64' || matrix.platform.arch }}
       run: |
         mkdir oras
         cd oras
-        cp ../target/${{ matrix.arch }}-unknown-linux-${{ matrix.libc}}/release/attestation-agent .
+        cp ../target/${{ env.RUST_TARGET }}/release/attestation-agent .
         tar cJf attestation-agent.tar.xz attestation-agent
         arch_tag="${{ github.sha }}-${{ matrix.tee }}_${{ matrix.arch }}"
         image="${REGISTRY}/${IMAGE_NAME}/attestation-agent"
@@ -119,7 +85,7 @@ jobs:
         # We need to create the platform annotations with docker, since oras 1.2 doesn't support
         # pushing with platform yet.
         docker manifest create "${image}:${tag}" --amend "${image}:${arch_tag}"
-        docker manifest annotate --arch "$ARCH" --os linux "${image}:${tag}" "${image}:${arch_tag}"
+        docker manifest annotate --arch "$OCI_ARCH" --os linux "${image}:${tag}" "${image}:${arch_tag}"
         docker manifest push "${image}:${tag}"
         # add image and digest to output for attestation
         echo "image=${image}" >> "$GITHUB_OUTPUT"
@@ -153,6 +119,7 @@ jobs:
       LIBC: ${{ matrix.libc }}
       REGISTRY: ghcr.io
       IMAGE_NAME: ${{ github.repository }}
+      RUST_TARGET: ${{ matrix.arch }}-unknown-linux-${{ matrix.libc }}
     steps:
     - name: Log in to the Container registry
       uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
@@ -168,7 +135,7 @@ jobs:
     - uses: actions-rust-lang/setup-rust-toolchain@v1
       with:
         toolchain: ${{ env.RUST_TOOLCHAIN }}
-        target: ${{ matrix.arch }}-unknown-linux-${{ matrix.libc }}
+        target: ${{ env.RUST_TARGET }}
         override: true
 
     - name: Install dependencies
@@ -181,10 +148,10 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Build CDH
-      run: make ./target/${{ matrix.arch }}-unknown-linux-${{ matrix.libc}}/release/confidential-data-hub
+      run: make ./target/${{ env.RUST_TARGET }}/release/confidential-data-hub
 
     - name: Build ASR
-      run: make ./target/${{ matrix.arch }}-unknown-linux-${{ matrix.libc}}/release/api-server-rest
+      run: make ./target/${{ env.RUST_TARGET }}/release/api-server-rest
 
     - name: Publish CDH + ASR to ORAS
       id: publish
@@ -192,7 +159,7 @@ jobs:
         tag="${{ github.sha }}-${{ matrix.arch }}"
         mkdir oras
         cd oras
-        cp ../target/${{ matrix.arch }}-unknown-linux-${{ matrix.libc}}/release/{confidential-data-hub,api-server-rest} .
+        cp ../target/${{ env.RUST_TARGET }}/release/{confidential-data-hub,api-server-rest} .
 
         tar cJf confidential-data-hub.tar.xz confidential-data-hub
         image="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/confidential-data-hub"

--- a/.github/workflows/publish-artifacts.yml
+++ b/.github/workflows/publish-artifacts.yml
@@ -1,4 +1,4 @@
-name: Publish artifacts to ORAS
+name: Publish artifacts with ORAS
 
 on:
   push:

--- a/Makefile
+++ b/Makefile
@@ -21,8 +21,8 @@ else ifeq ($(TEE_PLATFORM), fs)
   ATTESTER = none
 else ifeq ($(TEE_PLATFORM), tdx)
   ATTESTER = tdx-attester
-else ifeq ($(TEE_PLATFORM), az-tdx-vtpm)
-  ATTESTER = az-tdx-vtpm-attester
+else ifeq ($(TEE_PLATFORM), az-cvm-vtpm)
+  ATTESTER = az-snp-vtpm-attester,az-tdx-vtpm-attester
 else ifeq ($(TEE_PLATFORM), sev)
   ATTESTER = none
   ifeq ($(NO_RESOURCE_PROVIDER), true)
@@ -32,8 +32,6 @@ else ifeq ($(TEE_PLATFORM), sev)
   endif
 else ifeq ($(TEE_PLATFORM), snp)
   ATTESTER = snp-attester
-else ifeq ($(TEE_PLATFORM), az-snp-vtpm)
-  ATTESTER = az-snp-vtpm-attester
 else ifeq ($(TEE_PLATFORM), se)
   ATTESTER = se-attester
 else ifeq ($(TEE_PLATFORM), all)


### PR DESCRIPTION
Pushing artifacts as binaries to the project's GHCR. The build job is split between AA and CDH+ASR. AA has specific build and runtimerequirements depending on the TEE, while the CDH+ASR are generic per arch.

Hence $AA is tagged with $sha-$tee ($arch is implicit in $tee) while CDH+ASR are tagged with $sha-$arch.

## Why

Peerpod as a downstream project currently builds GC binaries as part of their pipeline. This is rather costly, the project is written in golang and needs to maintain a complex rust build infra for GC that often drifts in terms of rust-versions, feature-toggles and makes it hard to keep up to date with recent GC. There's also considerable overhead in terms of build-time.

It makes sense to have canonical cache of build-artifacts that can be consumed downstream. 