### PR TITLE
CI: Add azure tdx feature to aa_kbc build

### DIFF
--- a/.github/workflows/aa_cc_kbc.yml
+++ b/.github/workflows/aa_cc_kbc.yml
@@ -40,6 +40,7 @@ jobs:
           - cc_kbc_tdx
           - cc_kbc_sgx
           - cc_kbc_az_snp_vtpm
+          - cc_kbc_az_tdx_vtpm
           - cc_kbc_snp
     steps:
       - name: Code checkout


### PR DESCRIPTION
This attester/kbc combination was missing so far.