### PR TITLE
gha: Do not use oras-project/setup-oras for s390x

### DIFF
--- a/.github/workflows/publish-artifacts.yml
+++ b/.github/workflows/publish-artifacts.yml
@@ -44,6 +44,7 @@ jobs:
     - uses: oras-project/setup-oras@v1
       with:
         version: 1.2.0
+      if: matrix.platform.arch != 's390x'
 
     - uses: actions/checkout@v4
 


### PR DESCRIPTION
`oras-project/setup-oras` (raised by #731) does not support s390x like:

```
Error: Error: unsupported architecture: s390x
```

https://github.com/confidential-containers/guest-components/actions/runs/11223420868/job/31198020471
https://github.com/confidential-containers/guest-components/actions/runs/11223420868/job/31198020098

But the package is already installed and maintained by the self-hosted runner admin.
Let's skip installing it for the platform.

Signed-off-by: Hyounggyu Choi <Hyounggyu.Choi@ibm.com>