### PR TITLE
ci: skip oras setup for s390x builds

### DIFF
--- a/.github/workflows/publish-artifacts.yml
+++ b/.github/workflows/publish-artifacts.yml
@@ -132,6 +132,7 @@ jobs:
     - uses: oras-project/setup-oras@v1
       with:
         version: 1.2.0
+      if: matrix.platform.arch != 's390x'
 
     - uses: actions-rust-lang/setup-rust-toolchain@v1
       with:


### PR DESCRIPTION
We missed the 2nd invocation of setup-oras in the prior PR #739

CDH and ASR builds do not need to setup oras on s390x self-hosted runners, since the setup is currently broken and it's provided on the self-hosted runners anyway.

