### PR TITLE
gha: Fix condition for skipping ORAS installation on s390x

### DIFF
--- a/.github/workflows/publish-artifacts.yml
+++ b/.github/workflows/publish-artifacts.yml
@@ -132,7 +132,7 @@ jobs:
     - uses: oras-project/setup-oras@v1
       with:
         version: 1.2.0
-      if: matrix.platform.arch != 's390x'
+      if: matrix.arch != 's390x'
 
     - uses: actions-rust-lang/setup-rust-toolchain@v1
       with:


### PR DESCRIPTION
For CDH, the skipping condition for ORAS on s390x must have been

`if: matrix.arch != 's390x'` instead of `if: matrix.platform.arch != 's390x'`

Signed-off-by: Hyounggyu Choi <Hyounggyu.Choi@ibm.com>