### PR TITLE
ci: fix multi-arch oci publish for AA

### DIFF
--- a/.github/workflows/publish-artifacts.yml
+++ b/.github/workflows/publish-artifacts.yml
@@ -78,10 +78,9 @@ jobs:
         cd oras
         cp ../target/${{ env.RUST_TARGET }}/release/attestation-agent .
         tar cJf attestation-agent.tar.xz attestation-agent
-        arch_tag="${{ github.sha }}-${{ matrix.tee }}_${{ matrix.arch }}"
+        arch_tag="${{ github.sha }}-${{ matrix.platform.tee }}_${{ matrix.platform.arch }}"
         image="${REGISTRY}/${IMAGE_NAME}/attestation-agent"
-        tag="${{ github.sha }}-${{ matrix.tee }}"
-        arch_tag="${tag}_${ARCH}"
+        tag="${{ github.sha }}-${{ matrix.platform.tee }}"
         oras push "${image}:${arch_tag}" attestation-agent.tar.xz
         # We need to create the platform annotations with docker, since oras 1.2 doesn't support
         # pushing with platform yet.


### PR DESCRIPTION
The matrix parameters were not properly referenced and the tag variable wasn't referencing the TEE_PLATFORM for the AA publish job.