### PR TITLE
kbs_protocol: update KBS config for test_client tests

### DIFF
--- a/attestation-agent/kbs_protocol/test/kbs-config.toml
+++ b/attestation-agent/kbs_protocol/test/kbs-config.toml
@@ -1,6 +1,30 @@
+[http_server]
 insecure_http = true
-insecure_api = true
 sockets = ["0.0.0.0:8085"]
 
-[attestation_token_config]
-attestation_token_type = "CoCo"
+[attestation_token]
+insecure_key = true
+
+[policy_engine]
+policy_path = "/opa/confidential-containers/kbs/policy.rego"
+
+[attestation_service]
+type = "coco_as_builtin"
+work_dir = "/opt/confidential-containers/attestation-service"
+policy_engine = "opa"
+attestation_token_broker = "Simple"
+
+    [attestation_service.attestation_token_config]
+    duration_min = 5
+
+    [attestation_service.rvps_config]
+    store_type = "LocalFs"
+    remote_addr = ""
+
+[admin]
+insecure_api = true
+
+[[plugins]]
+name = "resource"
+type = "LocalFs"
+dir_path = "/opt/confidential-containers/kbs/repository"


### PR DESCRIPTION
client::rcar_client::test::test_client pulls kbs:latest image for tests but the local kbs-config.toml is oudated and tests won't run.

Update the config to get CI tests passing again.