### PR TITLE
CDH/KMS: remove ehsm from defaut features

### DIFF
--- a/confidential-data-hub/README.md
+++ b/confidential-data-hub/README.md
@@ -57,7 +57,7 @@ KMS_PROVIDER plugins (flag `KMS_PROVIDER`)
 | Feature name        |           Note                                                     |
 | ------------------- | -----------------------------------------------------------------  |
 | aliyun              | Use aliyun KMS_PROVIDER suites to unseal secrets, etc.                      |
-| ehsm                | Use Intel eHSM KMS_PROVIDER suites to unseal secrets, etc.                  |
+| ehsm(no longer maintained) | Use Intel eHSM KMS_PROVIDER suites to unseal secrets, etc.                  |
 
 Note:
 - If no `KMS_PROVIDER` flag is given, then all the KMS providers will be enabled by default.

--- a/confidential-data-hub/kms/Cargo.toml
+++ b/confidential-data-hub/kms/Cargo.toml
@@ -48,7 +48,7 @@ anyhow.workspace = true
 tonic-build.workspace = true
 
 [features]
-default = ["aliyun", "kbs", "ehsm"]
+default = ["aliyun", "kbs"]
 
 aliyun = ["chrono", "hex", "p12", "prost", "rand", "reqwest/rustls-tls", "sha2", "tonic", "url", "yasna"]
 kbs = ["kbs_protocol"]

--- a/confidential-data-hub/kms/src/plugins/ehsm/README.md
+++ b/confidential-data-hub/kms/src/plugins/ehsm/README.md
@@ -1,4 +1,4 @@
-# eHSM-KMS
+# eHSM-KMS (No longer maintained)
 
 eHSM-KMS is a SGX-based Key Managment Service (KMS) that provides the near-equivalent hardware protection level of cryptographic functionalities including key generation, management inside the SGX enclave. More information about eHSM-KMS can be found [here](https://github.com/intel/ehsm).
 


### PR DESCRIPTION
eHSM crate is no longer maintained and archived. Also, it requires openssl to be built thus cannot be built with musl.

This patch removes it from default features of `kms` crate. If one wants to build CDH with eHSM support, `KMS_PROVIDER=ehsm` can be used when executing Makefile of CDH.