### PR TITLE
AA: fix CoCoAS Token getter

### DIFF
--- a/attestation-agent/attestation-agent/src/token/coco_as.rs
+++ b/attestation-agent/attestation-agent/src/token/coco_as.rs
@@ -24,8 +24,9 @@ impl GetToken for CoCoASTokenGetter {
         let evidence = attester.get_evidence(vec![]).await?;
 
         let request_body = serde_json::json!({
-            "tee": serde_json::to_string(&tee_type)?,
+            "tee": tee_type,
             "evidence": URL_SAFE_NO_PAD.encode(evidence.as_bytes()),
+            "policy_ids": [],
         });
 
         let client = reqwest::Client::new();


### PR DESCRIPTION
The API should include `policy_ids` (which will be parsed on the CoCoAS side into `default` if no value is given). Also, `tee_type` being serialized would contain extra `"` chars.