### PR TITLE
ci: use rustlang gh wf to install rust in cdh/aa/asr ci

### DIFF
--- a/.github/workflows/aa_basic.yml
+++ b/.github/workflows/aa_basic.yml
@@ -52,9 +52,8 @@ jobs:
           fetch-depth: 1
 
       - name: Install Rust toolchain (${{ matrix.rust }})
-        uses: actions-rs/toolchain@v1
+        uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          profile: minimal
           toolchain: ${{ matrix.rust }}
           override: true
           components: rustfmt, clippy

--- a/.github/workflows/api-server-rest-basic.yml
+++ b/.github/workflows/api-server-rest-basic.yml
@@ -45,9 +45,8 @@ jobs:
           fetch-depth: 1
 
       - name: Install Rust toolchain (${{ matrix.rust }})
-        uses: actions-rs/toolchain@v1
+        uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          profile: minimal
           toolchain: ${{ matrix.rust }}
           override: true
           components: rustfmt, clippy

--- a/.github/workflows/cdh_basic.yml
+++ b/.github/workflows/cdh_basic.yml
@@ -45,11 +45,11 @@ jobs:
           fetch-depth: 1
 
       - name: Install Rust toolchain (${{ matrix.rust }})
-        run: |
-          rustup update --no-self-update ${{ matrix.rust }}
-          rustup component add --toolchain ${{ matrix.rust }} rustfmt rustc clippy
-          rustup target add x86_64-unknown-linux-gnu
-          rustup default ${{ matrix.rust }}
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: ${{ matrix.rust }}
+          override: true
+          components: rustfmt, clippy
 
       - name: Install protoc
         run: |


### PR DESCRIPTION
This will also set up build cache and is consistent with the AA CI workflow.