### PR TITLE
AA | Fix kbs_client test config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -366,7 +366,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
- "sev 3.1.1",
+ "sev 4.0.0",
  "sha2 0.10.8",
  "strum",
  "tdx-attest-rs",
@@ -5786,30 +5786,6 @@ name = "sev"
 version = "0.1.0"
 dependencies = [
  "anyhow",
-]
-
-[[package]]
-name = "sev"
-version = "3.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2890179f8ef689340f441ba05f0b268bc14f672ae4b36d629cc2266d0d747ab"
-dependencies = [
- "base64 0.21.7",
- "bincode",
- "bitfield 0.13.2",
- "bitflags 1.3.2",
- "byteorder",
- "codicon",
- "dirs",
- "hex",
- "iocuddle",
- "lazy_static",
- "libc",
- "serde",
- "serde-big-array",
- "serde_bytes",
- "static_assertions",
- "uuid",
 ]
 
 [[package]]

--- a/attestation-agent/kbs_protocol/test/kbs-config.toml
+++ b/attestation-agent/kbs_protocol/test/kbs-config.toml
@@ -18,8 +18,8 @@ attestation_token_broker = "Simple"
     duration_min = 5
 
     [attestation_service.rvps_config]
+    type = "BuiltIn"
     store_type = "LocalFs"
-    remote_addr = ""
 
 [admin]
 insecure_api = true


### PR DESCRIPTION
This patch updates the kbs config due to https://github.com/confidential-containers/trustee/pull/553

cc @mythi 