### PR TITLE
AA/kbs_protocol: Update to 0.2.0 to fix JWE decryption logic due to RFC7516

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -383,7 +383,7 @@ dependencies = [
  "sha2 0.10.8",
  "strum",
  "tempfile",
- "thiserror 2.0.11",
+ "thiserror 2.0.9",
  "tokio",
  "toml 0.8.20",
  "tonic",
@@ -423,7 +423,7 @@ dependencies = [
  "strum",
  "tdx-attest-rs",
  "tempfile",
- "thiserror 2.0.11",
+ "thiserror 2.0.9",
  "tokio",
 ]
 
@@ -506,7 +506,7 @@ dependencies = [
  "serde_json",
  "sev 4.0.0",
  "sha2 0.10.8",
- "thiserror 2.0.11",
+ "thiserror 2.0.9",
  "tss-esapi",
  "zerocopy 0.7.32",
 ]
@@ -522,7 +522,7 @@ dependencies = [
  "clap 4.2.7",
  "serde",
  "sev 4.0.0",
- "thiserror 2.0.11",
+ "thiserror 2.0.9",
  "ureq",
 ]
 
@@ -1183,7 +1183,7 @@ dependencies = [
  "sha2 0.10.8",
  "strum",
  "tempfile",
- "thiserror 2.0.11",
+ "thiserror 2.0.9",
  "tokio",
  "toml 0.8.20",
  "tonic",
@@ -3358,7 +3358,7 @@ dependencies = [
  "serde",
  "serde_json",
  "superboring",
- "thiserror 2.0.11",
+ "thiserror 2.0.9",
  "zeroize",
 ]
 
@@ -3404,12 +3404,14 @@ dependencies = [
 
 [[package]]
 name = "kbs-types"
-version = "0.7.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b6441ed73b0faa50707d4de41c6b45c76654b661b96aaf7b26a41331eedc0a5"
+checksum = "6db954f164e19a63a1eb7c04c46511167d68a5eb5025d4a435c1ba297f00dbf4"
 dependencies = [
+ "base64 0.22.1",
  "serde",
  "serde_json",
+ "thiserror 2.0.9",
 ]
 
 [[package]]
@@ -3436,7 +3438,7 @@ dependencies = [
  "sha2 0.10.8",
  "tempfile",
  "testcontainers",
- "thiserror 2.0.11",
+ "thiserror 2.0.9",
  "tokio",
  "ttrpc",
  "ttrpc-codegen",
@@ -6457,11 +6459,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.11"
+version = "2.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d452f284b73e6d76dd36758a0c8684b1d5be31f92b89d07fd5822175732206fc"
+checksum = "f072643fd0190df67a8bab670c20ef5d8737177d6ac6b2e9a236cb096206b2cc"
 dependencies = [
- "thiserror-impl 2.0.11",
+ "thiserror-impl 2.0.9",
 ]
 
 [[package]]
@@ -6477,9 +6479,9 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.11"
+version = "2.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26afc1baea8a989337eeb52b6e72a039780ce45c3edfcc9c5b9d112feeb173c2"
+checksum = "7b50fa271071aae2e6ee85f842e2e28ba8cd2c5fb67f11fcb1fd70b276f9e7d4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7085,9 +7087,9 @@ checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
 name = "utoipa"
-version = "5.3.1"
+version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "435c6f69ef38c9017b4b4eea965dfb91e71e53d869e896db40d1cf2441dd75c0"
+checksum = "68e76d357bc95c7d0939c92c04c9269871a8470eea39cb1f0231eeadb0c47d0f"
 dependencies = [
  "indexmap 2.7.1",
  "serde",
@@ -7097,9 +7099,9 @@ dependencies = [
 
 [[package]]
 name = "utoipa-gen"
-version = "5.3.1"
+version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a77d306bc75294fd52f3e99b13ece67c02c1a2789190a6f31d32f736624326f7"
+checksum = "564b03f8044ad6806bdc0d635e88be24967e785eef096df6b2636d2cc1e05d4b"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -383,7 +383,7 @@ dependencies = [
  "sha2 0.10.8",
  "strum",
  "tempfile",
- "thiserror 2.0.9",
+ "thiserror 2.0.11",
  "tokio",
  "toml 0.8.20",
  "tonic",
@@ -423,7 +423,7 @@ dependencies = [
  "strum",
  "tdx-attest-rs",
  "tempfile",
- "thiserror 2.0.9",
+ "thiserror 2.0.11",
  "tokio",
 ]
 
@@ -506,7 +506,7 @@ dependencies = [
  "serde_json",
  "sev 4.0.0",
  "sha2 0.10.8",
- "thiserror 2.0.9",
+ "thiserror 2.0.11",
  "tss-esapi",
  "zerocopy 0.7.32",
 ]
@@ -522,7 +522,7 @@ dependencies = [
  "clap 4.2.7",
  "serde",
  "sev 4.0.0",
- "thiserror 2.0.9",
+ "thiserror 2.0.11",
  "ureq",
 ]
 
@@ -1183,7 +1183,7 @@ dependencies = [
  "sha2 0.10.8",
  "strum",
  "tempfile",
- "thiserror 2.0.9",
+ "thiserror 2.0.11",
  "tokio",
  "toml 0.8.20",
  "tonic",
@@ -3358,7 +3358,7 @@ dependencies = [
  "serde",
  "serde_json",
  "superboring",
- "thiserror 2.0.9",
+ "thiserror 2.0.11",
  "zeroize",
 ]
 
@@ -3411,7 +3411,7 @@ dependencies = [
  "base64 0.22.1",
  "serde",
  "serde_json",
- "thiserror 2.0.9",
+ "thiserror 2.0.11",
 ]
 
 [[package]]
@@ -3438,7 +3438,7 @@ dependencies = [
  "sha2 0.10.8",
  "tempfile",
  "testcontainers",
- "thiserror 2.0.9",
+ "thiserror 2.0.11",
  "tokio",
  "ttrpc",
  "ttrpc-codegen",
@@ -6459,11 +6459,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.9"
+version = "2.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f072643fd0190df67a8bab670c20ef5d8737177d6ac6b2e9a236cb096206b2cc"
+checksum = "d452f284b73e6d76dd36758a0c8684b1d5be31f92b89d07fd5822175732206fc"
 dependencies = [
- "thiserror-impl 2.0.9",
+ "thiserror-impl 2.0.11",
 ]
 
 [[package]]
@@ -6479,9 +6479,9 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.9"
+version = "2.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b50fa271071aae2e6ee85f842e2e28ba8cd2c5fb67f11fcb1fd70b276f9e7d4"
+checksum = "26afc1baea8a989337eeb52b6e72a039780ce45c3edfcc9c5b9d112feeb173c2"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -60,6 +60,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "aes-kw"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69fa2b352dcefb5f7f3a5fb840e02665d311d878955380515e4fd50095dd3d8c"
+dependencies = [
+ "aes",
+]
+
+[[package]]
 name = "ahash"
 version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1127,6 +1136,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "concat-kdf"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d72c1252426a83be2092dd5884a5f6e3b8e7180f6891b6263d2c21b92ec8816"
+dependencies = [
+ "digest 0.10.7",
+]
+
+[[package]]
 name = "confidential-data-hub"
 version = "0.1.0"
 dependencies = [
@@ -1393,11 +1411,15 @@ name = "crypto"
 version = "0.1.0"
 dependencies = [
  "aes-gcm",
+ "aes-kw",
  "anyhow",
  "base64 0.22.1",
+ "concat-kdf",
  "ctr",
  "kbs-types",
  "openssl",
+ "p256",
+ "rand 0.8.5",
  "rand 0.9.0",
  "rsa",
  "rstest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ hmac = "0.12.1"
 jwt-simple = { version = "0.12", default-features = false, features = [
     "pure-rust",
 ] }
-kbs-types = "0.7.0"
+kbs-types = "0.10.0"
 log = "0.4.25"
 nix = "0.29"
 openssl = "0.10"

--- a/attestation-agent/attestation-agent/src/token/kbs.rs
+++ b/attestation-agent/attestation-agent/src/token/kbs.rs
@@ -40,7 +40,7 @@ impl GetToken for KbsTokenGetter {
         let (token, tee_keypair) = client.get_token().await?;
         let message = Message {
             token: token.content,
-            tee_keypair: tee_keypair.to_pkcs1_pem()?.to_string(),
+            tee_keypair: tee_keypair.to_pem()?.to_string(),
         };
 
         let res = serde_json::to_vec(&message)?;

--- a/attestation-agent/deps/crypto/Cargo.toml
+++ b/attestation-agent/deps/crypto/Cargo.toml
@@ -8,12 +8,18 @@ license = "Apache-2.0"
 
 [dependencies]
 aes-gcm = { workspace = true, optional = true }
+aes-kw = { version = "0.2.1", optional = true }
 anyhow.workspace = true
 base64.workspace = true
+concat-kdf = { version = "0.1.0", optional = true }
 ctr = { workspace = true, optional = true }
 kbs-types.workspace = true
-openssl = { workspace = true, features = ["vendored"], optional = true}
+openssl = { workspace = true, features = ["vendored"], optional = true }
+p256 = { version = "0.13.1", features = ["ecdh", "pem"], optional = true }
 rand.workspace = true
+
+# This is for API compability of p256 who is using the old version of `rand`
+rand_08 = { package = "rand", version = "0.8", optional = true }
 rsa = { workspace = true, optional = true }
 serde.workspace = true
 serde_json.workspace = true
@@ -26,5 +32,13 @@ rstest.workspace = true
 
 [features]
 default = ["rust-crypto"]
-rust-crypto = ["dep:aes-gcm", "ctr", "rsa"]
+rust-crypto = [
+    "dep:aes-gcm",
+    "ctr",
+    "rsa/sha2",
+    "aes-kw",
+    "concat-kdf",
+    "p256",
+    "rand_08",
+]
 openssl = ["dep:openssl"]

--- a/attestation-agent/deps/crypto/src/asymmetric.rs
+++ b/attestation-agent/deps/crypto/src/asymmetric.rs
@@ -3,6 +3,9 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+// This lint checker is for [`rsa::PaddingMode::PKCS1v15`]
+// TODO: remove this when the deprecated attribute is removed
+#[allow(deprecated)]
 pub mod rsa {
     #[cfg(feature = "openssl")]
     pub use crate::native::rsa::*;
@@ -10,14 +13,17 @@ pub mod rsa {
     #[cfg(all(feature = "rust-crypto", not(feature = "openssl")))]
     pub use crate::rust::rsa::*;
 
-    /// Definations of different Padding mode for encryption. Refer to
+    /// Definitions of different Padding mode for encryption. Refer to
     /// <https://datatracker.ietf.org/doc/html/rfc7518#section-4.1> for
     /// more information.
     #[derive(EnumString, AsRefStr)]
     pub enum PaddingMode {
-        #[strum(serialize = "RSA-OAEP")]
+        /// RSAES OAEP using SHA-256 and MGF1 with SHA-256
+        #[strum(serialize = "RSA-OAEP-256")]
         OAEP,
 
+        /// RSA PKCS#1 v1.5
+        #[deprecated(note = "This algorithm is no longer recommended.")]
         #[strum(serialize = "RSA1_5")]
         PKCS1v15,
     }
@@ -25,4 +31,31 @@ pub mod rsa {
     pub const RSA_PUBKEY_LENGTH: usize = 2048;
 
     pub const RSA_KTY: &str = "RSA";
+}
+
+pub mod ec {
+    #[cfg(feature = "openssl")]
+    pub use crate::native::ec::*;
+
+    #[cfg(all(feature = "rust-crypto", not(feature = "openssl")))]
+    pub use crate::rust::ec::*;
+
+    /// The elliptic curve key type
+    pub const EC_KTY: &str = "EC";
+
+    /// Definitions of different key wrapping algorithms. Refer to
+    /// <https://datatracker.ietf.org/doc/html/rfc7518> for
+    /// more information.
+    #[derive(EnumString, AsRefStr)]
+    pub enum KeyWrapAlgorithm {
+        /// ECDH-ES using Concat KDF and CEK wrapped with "A256KW"
+        #[strum(serialize = "ECDH-ES+A256KW")]
+        EcdhEsA256Kw,
+    }
+
+    #[derive(EnumString, AsRefStr)]
+    pub enum Curve {
+        #[strum(serialize = "P-256")]
+        P256,
+    }
 }

--- a/attestation-agent/deps/crypto/src/native/aes256ctr.rs
+++ b/attestation-agent/deps/crypto/src/native/aes256ctr.rs
@@ -8,14 +8,14 @@
 use anyhow::*;
 use openssl::symm::Cipher;
 
-pub fn decrypt(encrypted_data: &[u8], key: &[u8], iv: &[u8]) -> Result<Vec<u8>> {
+pub fn decrypt(key: &[u8], encrypted_data: &[u8], iv: &[u8]) -> Result<Vec<u8>> {
     let cipher = Cipher::aes_256_ctr();
 
     openssl::symm::decrypt(cipher, key, Some(iv), encrypted_data)
         .map_err(|e| anyhow!(e.to_string()))
 }
 
-pub fn encrypt(data: &[u8], key: &[u8], iv: &[u8]) -> Result<Vec<u8>> {
+pub fn encrypt(key: &[u8], data: &[u8], iv: &[u8]) -> Result<Vec<u8>> {
     let cipher = Cipher::aes_256_ctr();
     let ciphertext =
         openssl::symm::encrypt(cipher, key, Some(iv), data).map_err(|e| anyhow!(e.to_string()))?;
@@ -40,8 +40,8 @@ mod tests {
         b"16bytes ivlength"
     )]
     fn en_decrypt(#[case] plaintext: &[u8], #[case] key: &[u8], #[case] iv: &[u8]) {
-        let ciphertext = encrypt(plaintext, key, iv).expect("encryption failed");
-        let plaintext_de = decrypt(&ciphertext, key, iv).expect("decryption failed");
+        let ciphertext = encrypt(key, plaintext, iv).expect("encryption failed");
+        let plaintext_de = decrypt(key, &ciphertext, iv).expect("decryption failed");
         assert_eq!(plaintext, plaintext_de);
     }
 }

--- a/attestation-agent/deps/crypto/src/native/aes256gcm.rs
+++ b/attestation-agent/deps/crypto/src/native/aes256gcm.rs
@@ -8,9 +8,36 @@
 use anyhow::*;
 use openssl::symm::Cipher;
 
+use crate::AeadCipher;
+
 const TAG_LENGTH: usize = 16;
 
-pub fn decrypt(encrypted_data: &[u8], key: &[u8], iv: &[u8]) -> Result<Vec<u8>> {
+pub fn encrypt_with_aad_detached_tag(
+    key: &[u8],
+    data: &[u8],
+    iv: &[u8],
+    aad: &[u8],
+) -> Result<AeadCipher> {
+    let cipher = Cipher::aes_256_gcm();
+    let mut tag = vec![0; TAG_LENGTH];
+    let ciphertext = openssl::symm::encrypt_aead(cipher, key, Some(iv), aad, data, &mut tag)
+        .map_err(|e| anyhow!("{e:?}"))?;
+    Ok(AeadCipher { tag, ciphertext })
+}
+pub fn decrypt_with_aad_detached_tag(
+    key: &[u8],
+    encrypted_data: &[u8],
+    iv: &[u8],
+    aad: &[u8],
+    tag: &[u8],
+) -> Result<Vec<u8>> {
+    let cipher = Cipher::aes_256_gcm();
+
+    openssl::symm::decrypt_aead(cipher, key, Some(iv), aad, encrypted_data, tag)
+        .map_err(|e| anyhow!("{e:?}"))
+}
+
+pub fn decrypt(key: &[u8], encrypted_data: &[u8], iv: &[u8]) -> Result<Vec<u8>> {
     let cipher = Cipher::aes_256_gcm();
     if encrypted_data.len() < TAG_LENGTH {
         bail!("Illegal length of ciphertext");
@@ -21,7 +48,7 @@ pub fn decrypt(encrypted_data: &[u8], key: &[u8], iv: &[u8]) -> Result<Vec<u8>> 
         .map_err(|e| anyhow!(e.to_string()))
 }
 
-pub fn encrypt(data: &[u8], key: &[u8], iv: &[u8]) -> Result<Vec<u8>> {
+pub fn encrypt(key: &[u8], data: &[u8], iv: &[u8]) -> Result<Vec<u8>> {
     let cipher = Cipher::aes_256_gcm();
     let mut tag = [0u8; TAG_LENGTH];
     let mut ciphertext = openssl::symm::encrypt_aead(cipher, key, Some(iv), &[], data, &mut tag)
@@ -34,14 +61,41 @@ pub fn encrypt(data: &[u8], key: &[u8], iv: &[u8]) -> Result<Vec<u8>> {
 mod tests {
     use rstest::rstest;
 
-    use super::{decrypt, encrypt};
+    use super::{decrypt, decrypt_with_aad_detached_tag, encrypt, encrypt_with_aad_detached_tag};
 
     #[rstest]
-    #[case(b"plaintext1", b"0123456789abcdefghijklmnopqrstuv", b"unique nonce")]
-    #[case(b"plaintext2", b"hijklmnopqrstuv0123456789abcdefg", b"unique2nonce")]
-    fn en_decrypt(#[case] plaintext: &[u8], #[case] key: &[u8], #[case] iv: &[u8]) {
-        let ciphertext = encrypt(plaintext, key, iv).expect("encryption failed");
-        let plaintext_de = decrypt(&ciphertext, key, iv).expect("decryption failed");
+    #[case(b"0123456789abcdefghijklmnopqrstuv", b"plaintext1", b"unique nonce")]
+    #[case(b"hijklmnopqrstuv0123456789abcdefg", b"plaintext2", b"unique2nonce")]
+    fn en_decrypt(#[case] key: &[u8], #[case] plaintext: &[u8], #[case] iv: &[u8]) {
+        let ciphertext = encrypt(key, plaintext, iv).expect("encryption failed");
+        let plaintext_de = decrypt(key, &ciphertext, iv).expect("decryption failed");
+        assert_eq!(plaintext, plaintext_de);
+    }
+
+    #[rstest]
+    #[case(
+        b"0123456789abcdefghijklmnopqrstuv",
+        b"plaintext1",
+        b"unique nonce",
+        b"test-aad"
+    )]
+    #[case(
+        b"hijklmnopqrstuv0123456789abcdefg",
+        b"plaintext2",
+        b"unique2nonce",
+        b"test-aad"
+    )]
+    fn en_decrypt_with_aad(
+        #[case] key: &[u8],
+        #[case] plaintext: &[u8],
+        #[case] iv: &[u8],
+        #[case] aad: &[u8],
+    ) {
+        let ciphertext =
+            encrypt_with_aad_detached_tag(key, plaintext, iv, aad).expect("encryption failed");
+        let plaintext_de =
+            decrypt_with_aad_detached_tag(key, &ciphertext.ciphertext, iv, aad, &ciphertext.tag)
+                .expect("decryption failed");
         assert_eq!(plaintext, plaintext_de);
     }
 }

--- a/attestation-agent/deps/crypto/src/native/ec.rs
+++ b/attestation-agent/deps/crypto/src/native/ec.rs
@@ -1,0 +1,194 @@
+// Copyright (c) 2024 Alibaba Cloud
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+use anyhow::{anyhow, bail, Context, Result};
+use openssl::{
+    aes::{self, AesKey},
+    bn::{BigNum, BigNumContext},
+    derive::Deriver,
+    ec::{EcGroup, EcKey},
+    hash::{Hasher, MessageDigest},
+    nid::Nid,
+    pkey::{PKey, Private},
+};
+use zeroize::Zeroizing;
+
+use crate::{
+    ec::{Curve, KeyWrapAlgorithm},
+    AES_GCM_256_KEY_BITS,
+};
+
+#[derive(Clone, Debug)]
+pub enum EcKeyPair {
+    P256(P256EcKeyPair),
+}
+
+impl Default for EcKeyPair {
+    fn default() -> Self {
+        Self::P256(P256EcKeyPair::default())
+    }
+}
+
+impl EcKeyPair {
+    fn private_key(&self) -> &PKey<Private> {
+        match self {
+            Self::P256(p256) => p256.private_key(),
+        }
+    }
+
+    pub fn curve(&self) -> Curve {
+        match self {
+            Self::P256(_) => Curve::P256,
+        }
+    }
+
+    pub fn x(&self) -> Result<Vec<u8>> {
+        match self {
+            Self::P256(p256) => p256.x(),
+        }
+    }
+
+    pub fn y(&self) -> Result<Vec<u8>> {
+        match self {
+            Self::P256(p256) => p256.y(),
+        }
+    }
+
+    pub fn to_pkcs8_pem(&self) -> Result<Zeroizing<String>> {
+        let pem = self.private_key().private_key_to_pem_pkcs8()?;
+        let pem = String::from_utf8(pem).map_err(|_| anyhow!("invalid pem"))?;
+        Ok(Zeroizing::new(pem))
+    }
+
+    pub fn from_pkcs8_pem(pem: &str) -> Result<Self> {
+        let private_key = PKey::private_key_from_pem(pem.as_bytes())?;
+        let ec_key = private_key.ec_key().context("must be a ec key")?;
+        let curve_nid = ec_key
+            .group()
+            .curve_name()
+            .ok_or(anyhow!("failed to get curve name"))?;
+        match curve_nid {
+            Nid::X9_62_PRIME256V1 => Ok(Self::P256(P256EcKeyPair { private_key })),
+            _ => bail!("unsupported EC curve with NID {curve_nid:?}"),
+        }
+    }
+
+    pub fn unwrap_key(
+        &self,
+        encrypted_key: Vec<u8>,
+        epk_x: Vec<u8>,
+        epk_y: Vec<u8>,
+        wrapping_algorithm: KeyWrapAlgorithm,
+    ) -> Result<Vec<u8>> {
+        let group = match self.curve() {
+            Curve::P256 => EcGroup::from_curve_name(Nid::X9_62_PRIME256V1)?,
+        };
+        let point = group.generator();
+        let mut point = point.to_owned(&group)?;
+
+        let epk_x = BigNum::from_slice(&epk_x)?;
+        let epk_y = BigNum::from_slice(&epk_y)?;
+
+        let mut ctx = BigNumContext::new()?;
+        point.set_affine_coordinates_gfp(&group, &epk_x, &epk_y, &mut ctx)?;
+
+        let epk = EcKey::from_public_key(&group, &point)?;
+        let epk = PKey::from_ec_key(epk)?;
+        match wrapping_algorithm {
+            KeyWrapAlgorithm::EcdhEsA256Kw => {
+                let mut deriver = Deriver::new(self.private_key())?;
+                deriver.set_peer(&epk)?;
+                let z = deriver.derive_to_vec()?;
+                let shared_key = concat_kdf(
+                    KeyWrapAlgorithm::EcdhEsA256Kw.as_ref(),
+                    AES_GCM_256_KEY_BITS as usize / 8,
+                    &z,
+                )?;
+                let mut key = vec![0; encrypted_key.len() - 8];
+                let unwrapping_key = AesKey::new_decrypt(&shared_key)
+                    .map_err(|e| anyhow!("failed to create AES unwrapping key: {e:?}"))?;
+                aes::unwrap_key(&unwrapping_key, None, &mut key, &encrypted_key)
+                    .map_err(|e| anyhow!("failed to unwrap key: {e:?}"))?;
+                Ok(key)
+            }
+        }
+    }
+}
+
+fn concat_kdf(alg: &str, target_length: usize, z: &[u8]) -> Result<Vec<u8>> {
+    let target_length_bytes = ((target_length * 8) as u32).to_be_bytes();
+    let alg_len_bytes = (alg.len() as u32).to_be_bytes();
+
+    let mut output = Vec::new();
+    let md = MessageDigest::sha256();
+    let count = target_length.div_ceil(md.size());
+    for i in 0..count {
+        let mut hasher = Hasher::new(md)?;
+        hasher.update(&((i + 1) as u32).to_be_bytes())?;
+        hasher.update(z)?;
+        hasher.update(&alg_len_bytes)?;
+        hasher.update(alg.as_bytes())?;
+        hasher.update(&0_u32.to_be_bytes())?;
+        hasher.update(&0_u32.to_be_bytes())?;
+        hasher.update(&target_length_bytes)?;
+
+        let digest = hasher.finish()?;
+        output.extend(digest.to_vec());
+    }
+
+    if output.len() > target_length {
+        output.truncate(target_length);
+    }
+
+    Ok(output)
+}
+
+#[derive(Clone, Debug)]
+pub struct P256EcKeyPair {
+    private_key: PKey<Private>,
+}
+
+impl Default for P256EcKeyPair {
+    fn default() -> Self {
+        Self::new().expect("Create P256 key pair failed")
+    }
+}
+
+impl P256EcKeyPair {
+    fn private_key(&self) -> &PKey<Private> {
+        &self.private_key
+    }
+
+    pub fn new() -> Result<Self> {
+        let ec_group = EcGroup::from_curve_name(Nid::X9_62_PRIME256V1)?;
+        let ec_key = EcKey::generate(&ec_group)?;
+        let private_key = PKey::from_ec_key(ec_key)?;
+        Ok(Self { private_key })
+    }
+
+    pub fn x(&self) -> Result<Vec<u8>> {
+        let private_key = self.private_key.ec_key().context("must be a ec key")?;
+        let public_key = private_key.public_key();
+        let mut x = BigNum::new()?;
+        let mut _y = BigNum::new()?;
+        let mut ctx = BigNumContext::new()?;
+        public_key.affine_coordinates_gfp(private_key.group(), &mut x, &mut _y, &mut ctx)?;
+        let mut x = x.to_vec();
+        x.resize(32, b'0');
+        Ok(x)
+    }
+
+    pub fn y(&self) -> Result<Vec<u8>> {
+        let private_key = self.private_key.ec_key().context("must be a ec key")?;
+        let public_key = private_key.public_key();
+        let mut _x = BigNum::new()?;
+        let mut y = BigNum::new()?;
+        let mut ctx = BigNumContext::new()?;
+        public_key.affine_coordinates_gfp(private_key.group(), &mut _x, &mut y, &mut ctx)?;
+        let mut y = y.to_vec();
+        y.resize(32, b'0');
+        Ok(y)
+    }
+}

--- a/attestation-agent/deps/crypto/src/native/mod.rs
+++ b/attestation-agent/deps/crypto/src/native/mod.rs
@@ -8,4 +8,5 @@
 pub mod aes256ctr;
 pub mod aes256gcm;
 
+pub mod ec;
 pub mod rsa;

--- a/attestation-agent/deps/crypto/src/rust/aes256ctr.rs
+++ b/attestation-agent/deps/crypto/src/rust/aes256ctr.rs
@@ -12,7 +12,7 @@ use ctr::{
     Ctr128BE,
 };
 
-pub fn decrypt(encrypted_data: &[u8], key: &[u8], iv: &[u8]) -> Result<Vec<u8>> {
+pub fn decrypt(key: &[u8], encrypted_data: &[u8], iv: &[u8]) -> Result<Vec<u8>> {
     let mut decryptor = Ctr128BE::<Aes256>::new(key.into(), iv.into());
     let mut buf = Vec::new();
     buf.resize(encrypted_data.len(), b' ');
@@ -22,7 +22,7 @@ pub fn decrypt(encrypted_data: &[u8], key: &[u8], iv: &[u8]) -> Result<Vec<u8>> 
     Ok(buf)
 }
 
-pub fn encrypt(data: &[u8], key: &[u8], iv: &[u8]) -> Result<Vec<u8>> {
+pub fn encrypt(key: &[u8], data: &[u8], iv: &[u8]) -> Result<Vec<u8>> {
     let mut encryptor = Ctr128BE::<Aes256>::new(key.into(), iv.into());
     let mut ciphertext = data.to_vec();
     encryptor.apply_keystream(&mut ciphertext);
@@ -36,18 +36,18 @@ mod tests {
 
     #[rstest]
     #[case(
-        b"plaintext1",
         b"0123456789abcdefghijklmnopqrstuv",
+        b"plaintext1",
         b"16bytes ivlength"
     )]
     #[case(
-        b"plaintext2",
         b"hijklmnopqrstuv0123456789abcdefg",
+        b"plaintext2",
         b"16bytes ivlength"
     )]
-    fn en_decrypt(#[case] plaintext: &[u8], #[case] key: &[u8], #[case] iv: &[u8]) {
-        let ciphertext = encrypt(plaintext, key, iv).expect("encryption failed");
-        let plaintext_de = decrypt(&ciphertext, key, iv).expect("decryption failed");
+    fn en_decrypt(#[case] key: &[u8], #[case] plaintext: &[u8], #[case] iv: &[u8]) {
+        let ciphertext = encrypt(key, plaintext, iv).expect("encryption failed");
+        let plaintext_de = decrypt(key, &ciphertext, iv).expect("decryption failed");
         assert_eq!(plaintext, plaintext_de);
     }
 }

--- a/attestation-agent/deps/crypto/src/rust/aes256gcm.rs
+++ b/attestation-agent/deps/crypto/src/rust/aes256gcm.rs
@@ -4,11 +4,46 @@
 //
 
 //! This mod implements aes-256-gcm encryption & decryption.
-
-use aes_gcm::{aead::Aead, Aes256Gcm, Key, KeyInit, Nonce};
+use crate::AeadCipher;
+use aes_gcm::{aead::Aead, AeadInPlace, Aes256Gcm, Key, KeyInit, Nonce};
 use anyhow::*;
 
-pub fn decrypt(encrypted_data: &[u8], key: &[u8], iv: &[u8]) -> Result<Vec<u8>> {
+pub fn encrypt_with_aad_detached_tag(
+    key: &[u8],
+    data: &[u8],
+    iv: &[u8],
+    aad: &[u8],
+) -> Result<AeadCipher> {
+    let encrypting_key = Key::<Aes256Gcm>::from_slice(key);
+    let cipher = Aes256Gcm::new(encrypting_key);
+    let nonce = Nonce::from_slice(iv);
+    let mut ciphertext = data.to_vec();
+    let tag = cipher
+        .encrypt_in_place_detached(nonce, aad, &mut ciphertext)
+        .map_err(|e| anyhow!("aes-256-gcm encrypt failed: {:?}", e))?
+        .to_vec();
+    Ok(AeadCipher { tag, ciphertext })
+}
+
+pub fn decrypt_with_aad_detached_tag(
+    key: &[u8],
+    encrypted_data: &[u8],
+    iv: &[u8],
+    aad: &[u8],
+    tag: &[u8],
+) -> Result<Vec<u8>> {
+    let decrypting_key = Key::<Aes256Gcm>::from_slice(key);
+    let cipher = Aes256Gcm::new(decrypting_key);
+    let nonce = Nonce::from_slice(iv);
+    let mut plaintext = encrypted_data.to_vec();
+    cipher
+        .decrypt_in_place_detached(nonce, aad, &mut plaintext, tag.into())
+        .map_err(|e| anyhow!("aes-256-gcm decrypt failed: {:?}", e))?;
+
+    Ok(plaintext)
+}
+
+pub fn decrypt(key: &[u8], encrypted_data: &[u8], iv: &[u8]) -> Result<Vec<u8>> {
     let decrypting_key = Key::<Aes256Gcm>::from_slice(key);
     let cipher = Aes256Gcm::new(decrypting_key);
     let nonce = Nonce::from_slice(iv);
@@ -19,7 +54,7 @@ pub fn decrypt(encrypted_data: &[u8], key: &[u8], iv: &[u8]) -> Result<Vec<u8>> 
     Ok(plain_text)
 }
 
-pub fn encrypt(data: &[u8], key: &[u8], iv: &[u8]) -> Result<Vec<u8>> {
+pub fn encrypt(key: &[u8], data: &[u8], iv: &[u8]) -> Result<Vec<u8>> {
     let encrypting_key = Key::<Aes256Gcm>::from_slice(key);
     let cipher = Aes256Gcm::new(encrypting_key);
     let nonce = Nonce::from_slice(iv);
@@ -34,14 +69,41 @@ pub fn encrypt(data: &[u8], key: &[u8], iv: &[u8]) -> Result<Vec<u8>> {
 mod tests {
     use rstest::rstest;
 
-    use super::{decrypt, encrypt};
+    use super::{decrypt, decrypt_with_aad_detached_tag, encrypt, encrypt_with_aad_detached_tag};
 
     #[rstest]
-    #[case(b"plaintext1", b"0123456789abcdefghijklmnopqrstuv", b"unique nonce")]
-    #[case(b"plaintext2", b"hijklmnopqrstuv0123456789abcdefg", b"unique2nonce")]
-    fn en_decrypt(#[case] plaintext: &[u8], #[case] key: &[u8], #[case] iv: &[u8]) {
-        let ciphertext = encrypt(plaintext, key, iv).expect("encryption failed");
-        let plaintext_de = decrypt(&ciphertext, key, iv).expect("decryption failed");
+    #[case(b"0123456789abcdefghijklmnopqrstuv", b"plaintext1", b"unique nonce")]
+    #[case(b"hijklmnopqrstuv0123456789abcdefg", b"plaintext2", b"unique2nonce")]
+    fn en_decrypt(#[case] key: &[u8], #[case] plaintext: &[u8], #[case] iv: &[u8]) {
+        let ciphertext = encrypt(key, plaintext, iv).expect("encryption failed");
+        let plaintext_de = decrypt(key, &ciphertext, iv).expect("decryption failed");
+        assert_eq!(plaintext, plaintext_de);
+    }
+
+    #[rstest]
+    #[case(
+        b"0123456789abcdefghijklmnopqrstuv",
+        b"plaintext1",
+        b"unique nonce",
+        b"test-aad"
+    )]
+    #[case(
+        b"hijklmnopqrstuv0123456789abcdefg",
+        b"plaintext2",
+        b"unique2nonce",
+        b"test-aad"
+    )]
+    fn en_decrypt_with_aad(
+        #[case] key: &[u8],
+        #[case] plaintext: &[u8],
+        #[case] iv: &[u8],
+        #[case] aad: &[u8],
+    ) {
+        let ciphertext =
+            encrypt_with_aad_detached_tag(key, plaintext, iv, aad).expect("encryption failed");
+        let plaintext_de =
+            decrypt_with_aad_detached_tag(key, &ciphertext.ciphertext, iv, aad, &ciphertext.tag)
+                .expect("decryption failed");
         assert_eq!(plaintext, plaintext_de);
     }
 }

--- a/attestation-agent/deps/crypto/src/rust/ec.rs
+++ b/attestation-agent/deps/crypto/src/rust/ec.rs
@@ -1,0 +1,177 @@
+// Copyright (c) 2024 Alibaba Cloud
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+use crate::{
+    ec::{Curve, KeyWrapAlgorithm},
+    AES_GCM_256_KEY_BITS,
+};
+
+use aes_gcm::aead::generic_array::GenericArray;
+use aes_kw::{Kek, KekAes256};
+use anyhow::{anyhow, Result};
+use p256::{
+    ecdh::diffie_hellman,
+    elliptic_curve::sec1::FromEncodedPoint,
+    pkcs8::{DecodePrivateKey, EncodePrivateKey, LineEnding},
+    EncodedPoint, PublicKey as P256PublicKey, SecretKey,
+};
+use zeroize::Zeroizing;
+
+#[derive(Clone, Debug)]
+pub enum EcKeyPair {
+    P256(P256EcKeyPair),
+}
+
+impl Default for EcKeyPair {
+    fn default() -> Self {
+        Self::P256(P256EcKeyPair::default())
+    }
+}
+
+impl EcKeyPair {
+    pub fn curve(&self) -> Curve {
+        match self {
+            Self::P256(_) => Curve::P256,
+        }
+    }
+
+    pub fn secret_key(&self) -> &SecretKey {
+        match self {
+            Self::P256(p256) => p256.secret_key(),
+        }
+    }
+
+    pub fn x(&self) -> Result<Vec<u8>> {
+        match self {
+            Self::P256(p256) => p256.x(),
+        }
+    }
+
+    pub fn y(&self) -> Result<Vec<u8>> {
+        match self {
+            Self::P256(p256) => p256.y(),
+        }
+    }
+
+    pub fn to_pkcs8_pem(&self) -> Result<Zeroizing<String>> {
+        let pem = self.secret_key().to_pkcs8_pem(LineEnding::default())?;
+        Ok(pem)
+    }
+
+    pub fn from_pkcs8_pem(pem: &str) -> Result<Self> {
+        if let Ok(p256) = P256EcKeyPair::from_pkcs8_pem(pem) {
+            return Ok(Self::P256(p256));
+        };
+
+        Err(anyhow!("invalid key type"))
+    }
+
+    pub fn unwrap_key(
+        &self,
+        encrypted_key: Vec<u8>,
+        epk_x: Vec<u8>,
+        epk_y: Vec<u8>,
+        wrapping_algorithm: KeyWrapAlgorithm,
+    ) -> Result<Vec<u8>> {
+        match wrapping_algorithm {
+            KeyWrapAlgorithm::EcdhEsA256Kw => {
+                let secret_key = self.secret_key();
+                let epk_x: [u8; 32] = epk_x
+                    .try_into()
+                    .map_err(|_| anyhow!("invalid bytes length of coordinates X"))?;
+                let epk_y: [u8; 32] = epk_y
+                    .try_into()
+                    .map_err(|_| anyhow!("invalid bytes length of coordinates Y"))?;
+                let epk_point = EncodedPoint::from_affine_coordinates(
+                    &GenericArray::from(epk_x),
+                    &GenericArray::from(epk_y),
+                    false,
+                );
+                let public_key =
+                    Into::<Option<_>>::into(P256PublicKey::from_encoded_point(&epk_point));
+                let public_key: P256PublicKey = public_key.ok_or(anyhow!("invalid public key"))?;
+
+                let z = diffie_hellman(secret_key.to_nonzero_scalar(), public_key.as_affine())
+                    .raw_secret_bytes()
+                    .to_vec();
+
+                let mut key_derivation_materials = Vec::new();
+                let algorithm_str = KeyWrapAlgorithm::EcdhEsA256Kw.as_ref();
+                key_derivation_materials
+                    .extend_from_slice(&(algorithm_str.len() as u32).to_be_bytes());
+                key_derivation_materials.extend_from_slice(algorithm_str.as_bytes());
+                key_derivation_materials.extend_from_slice(&(0_u32).to_be_bytes());
+                key_derivation_materials.extend_from_slice(&(0_u32).to_be_bytes());
+                key_derivation_materials.extend_from_slice(&AES_GCM_256_KEY_BITS.to_be_bytes());
+                let mut unwrapping_key = vec![0; 32];
+                concat_kdf::derive_key_into::<rsa::sha2::Sha256>(
+                    &z,
+                    &key_derivation_materials,
+                    &mut unwrapping_key,
+                )
+                .map_err(|e| anyhow!("failed to do concat KDF: {e:?}"))?;
+                let unwrapping_key: [u8; 32] = unwrapping_key
+                    .try_into()
+                    .map_err(|_| anyhow!("invalid bytes length of AES wrapping key"))?;
+                let unwrapping_key: KekAes256 = Kek::new(&GenericArray::from(unwrapping_key));
+                let mut decrypted_key = vec![0; encrypted_key.len() - 8];
+                unwrapping_key
+                    .unwrap(&encrypted_key, &mut decrypted_key)
+                    .map_err(|e| anyhow!("failed to unwrap key: {e:?}"))?;
+
+                Ok(decrypted_key)
+            }
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct P256EcKeyPair {
+    secret_key: SecretKey,
+    public_key: P256PublicKey,
+}
+
+impl Default for P256EcKeyPair {
+    fn default() -> Self {
+        let mut rng = rand_08::thread_rng();
+        let secret_key = SecretKey::random(&mut rng);
+        let public_key = secret_key.public_key();
+        Self {
+            secret_key,
+            public_key,
+        }
+    }
+}
+
+impl P256EcKeyPair {
+    pub fn secret_key(&self) -> &SecretKey {
+        &self.secret_key
+    }
+
+    pub fn from_pkcs8_pem(pem: &str) -> Result<Self> {
+        let secret_key = SecretKey::from_pkcs8_pem(pem)?;
+        let public_key = secret_key.public_key();
+        Ok(Self {
+            secret_key,
+            public_key,
+        })
+    }
+
+    pub fn x(&self) -> Result<Vec<u8>> {
+        let x = EncodedPoint::from(self.public_key)
+            .x()
+            .ok_or(anyhow!("invalid public key: without coordinate X"))?
+            .to_vec();
+        Ok(x)
+    }
+
+    pub fn y(&self) -> Result<Vec<u8>> {
+        let y = EncodedPoint::from(self.public_key)
+            .y()
+            .ok_or(anyhow!("invalid public key: without coordinate Y"))?
+            .to_vec();
+        Ok(y)
+    }
+}

--- a/attestation-agent/deps/crypto/src/rust/mod.rs
+++ b/attestation-agent/deps/crypto/src/rust/mod.rs
@@ -8,4 +8,5 @@
 pub mod aes256ctr;
 pub mod aes256gcm;
 
+pub mod ec;
 pub mod rsa;

--- a/attestation-agent/deps/crypto/src/rust/rsa.rs
+++ b/attestation-agent/deps/crypto/src/rust/rsa.rs
@@ -41,6 +41,7 @@ impl RSAKeyPair {
                 .private_key
                 .decrypt(Oaep::new::<sha2::Sha256>(), &cipher_text)
                 .map_err(|e| anyhow!("RSA key decrypt OAEP failed: {:?}", e)),
+            #[allow(deprecated)]
             PaddingMode::PKCS1v15 => self
                 .private_key
                 .decrypt(Pkcs1v15Encrypt, &cipher_text)

--- a/attestation-agent/deps/crypto/src/symmetric.rs
+++ b/attestation-agent/deps/crypto/src/symmetric.rs
@@ -5,7 +5,7 @@
 
 //! APIs for symmetric keys
 
-use anyhow::Result;
+use anyhow::{bail, Result};
 use serde::{Deserialize, Serialize};
 use zeroize::Zeroizing;
 
@@ -14,6 +14,8 @@ use crate::native::*;
 
 #[cfg(all(feature = "rust-crypto", not(feature = "openssl")))]
 use crate::rust::*;
+
+pub const AES_GCM_256_KEY_BITS: u32 = 256;
 
 /// Supported WrapType, s.t. encryption algorithm using to encrypt the
 /// [PLBCO](https://github.com/confidential-containers/guest-components/blob/main/attestation-agent/docs/IMPLEMENTATION.md#encryption-and-decryption-of-container-image).
@@ -43,8 +45,25 @@ pub fn decrypt(
     wrap_type: WrapType,
 ) -> Result<Vec<u8>> {
     match wrap_type {
-        WrapType::Aes256Gcm => aes256gcm::decrypt(&ciphertext, &key, &iv),
-        WrapType::Aes256Ctr => aes256ctr::decrypt(&ciphertext, &key, &iv),
+        WrapType::Aes256Gcm => aes256gcm::decrypt(&key, &ciphertext, &iv),
+        WrapType::Aes256Ctr => aes256ctr::decrypt(&key, &ciphertext, &iv),
+    }
+}
+
+/// Decrypt the given `ciphertext` with AES256-GCM algorithm.
+pub fn decrypt_aead(
+    key: Zeroizing<Vec<u8>>,
+    ciphertext: Vec<u8>,
+    iv: Vec<u8>,
+    aad: Vec<u8>,
+    tag: Vec<u8>,
+    wrap_type: WrapType,
+) -> Result<Vec<u8>> {
+    match wrap_type {
+        WrapType::Aes256Gcm => {
+            aes256gcm::decrypt_with_aad_detached_tag(&key, &ciphertext, &iv, &aad, &tag)
+        }
+        others => bail!("Algorithm {} is not an AEAD algorithm.", others.as_ref()),
     }
 }
 
@@ -59,7 +78,31 @@ pub fn encrypt(
     wrap_type: WrapType,
 ) -> Result<Vec<u8>> {
     match wrap_type {
-        WrapType::Aes256Gcm => aes256gcm::encrypt(&plaintext, &key, &iv),
-        WrapType::Aes256Ctr => aes256ctr::encrypt(&plaintext, &key, &iv),
+        WrapType::Aes256Gcm => aes256gcm::encrypt(&key, &plaintext, &iv),
+        WrapType::Aes256Ctr => aes256ctr::encrypt(&key, &plaintext, &iv),
+    }
+}
+
+pub struct AeadCipher {
+    pub tag: Vec<u8>,
+    pub ciphertext: Vec<u8>,
+}
+
+/// Encrypt the given `plaintext`.
+/// Note:
+/// - IV length for A256GCM: 12 bytes
+/// - IV length for A256CTR: 16 bytes
+pub fn encrypt_aead(
+    key: Zeroizing<Vec<u8>>,
+    plaintext: Vec<u8>,
+    iv: Vec<u8>,
+    aad: Vec<u8>,
+    wrap_type: WrapType,
+) -> Result<AeadCipher> {
+    match wrap_type {
+        WrapType::Aes256Gcm => {
+            aes256gcm::encrypt_with_aad_detached_tag(&key, &plaintext, &iv, &aad)
+        }
+        others => bail!("Algorithm {} is not an AEAD algorithm.", others.as_ref()),
     }
 }

--- a/attestation-agent/kbs_protocol/src/builder.rs
+++ b/attestation-agent/kbs_protocol/src/builder.rs
@@ -91,7 +91,7 @@ impl<T> KbsClientBuilder<T> {
         }
 
         let tee_key = match self.tee_key {
-            Some(key) => TeeKeyPair::from_pkcs1_pem(&key[..]).context("read tee public key")?,
+            Some(key) => TeeKeyPair::from_pem(&key[..]).context("read tee public key")?,
             None => TeeKeyPair::new()?,
         };
 

--- a/attestation-agent/kbs_protocol/src/client/mod.rs
+++ b/attestation-agent/kbs_protocol/src/client/mod.rs
@@ -48,7 +48,7 @@ pub struct KbsClient<T> {
     pub(crate) token: Option<Token>,
 }
 
-pub const KBS_PROTOCOL_VERSION: &str = "0.1.1";
+pub const KBS_PROTOCOL_VERSION: &str = "0.2.0";
 
 pub const KBS_GET_RESOURCE_MAX_ATTEMPT: u64 = 3;
 

--- a/attestation-agent/kbs_protocol/src/keypair.rs
+++ b/attestation-agent/kbs_protocol/src/keypair.rs
@@ -3,80 +3,161 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-use anyhow::{Context, Result};
+use anyhow::{anyhow, bail, Context, Result};
 
 use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
 use crypto::{
+    ec::{Curve, EcKeyPair, KeyWrapAlgorithm},
     rsa::{PaddingMode, RSAKeyPair},
-    WrapType,
 };
-use kbs_types::{Response, TeePubKey};
-use serde::Deserialize;
+use kbs_types::{ProtectedHeader, Response, TeePubKey};
+use log::warn;
 use zeroize::Zeroizing;
 
 #[derive(Clone, Debug)]
 pub struct TeeKeyPair {
-    keypair: RSAKeyPair,
+    key: TeeKey,
+}
+
+#[derive(Clone, Debug)]
+pub enum TeeKey {
+    Rsa(Box<RSAKeyPair>),
+    Ec(Box<EcKeyPair>),
 }
 
 impl TeeKeyPair {
+    /// Create a new Tee key pair. We by default to use EC key pair.
     pub fn new() -> Result<Self> {
-        Ok(Self {
-            keypair: RSAKeyPair::new()?,
-        })
+        let key = TeeKey::Ec(Box::default());
+        Ok(Self { key })
     }
 
     /// Export TEE public key as specific structure.
     pub fn export_pubkey(&self) -> Result<TeePubKey> {
-        let k_mod = URL_SAFE_NO_PAD.encode(self.keypair.n());
-        let k_exp = URL_SAFE_NO_PAD.encode(self.keypair.e());
+        match &self.key {
+            TeeKey::Rsa(key) => {
+                let k_mod = URL_SAFE_NO_PAD.encode(key.n());
+                let k_exp = URL_SAFE_NO_PAD.encode(key.e());
 
-        Ok(TeePubKey::RSA {
-            alg: PaddingMode::PKCS1v15.as_ref().to_string(),
-            k_mod,
-            k_exp,
+                Ok(TeePubKey::RSA {
+                    alg: PaddingMode::OAEP.as_ref().to_string(),
+                    k_mod,
+                    k_exp,
+                })
+            }
+            TeeKey::Ec(key) => {
+                let x = URL_SAFE_NO_PAD.encode(key.x()?);
+                let y = URL_SAFE_NO_PAD.encode(key.y()?);
+
+                Ok(TeePubKey::EC {
+                    crv: Curve::P256.as_ref().to_string(),
+                    alg: KeyWrapAlgorithm::EcdhEsA256Kw.as_ref().to_string(),
+                    x,
+                    y,
+                })
+            }
+        }
+    }
+
+    #[inline]
+    pub fn unwrap_cek(&self, header: &ProtectedHeader, wrapped_cek: Vec<u8>) -> Result<Vec<u8>> {
+        #[allow(deprecated)]
+        if &header.alg[..] == PaddingMode::PKCS1v15.as_ref() {
+            warn!("Use deprecated Rsa PKCSv1.5 algorithm!");
+            let TeeKey::Rsa(key) = &self.key else {
+                bail!("Unmatched key. Must be RSA key");
+            };
+
+            let cek = key.decrypt(PaddingMode::PKCS1v15, wrapped_cek)?;
+            Ok(cek)
+        } else if &header.alg[..] == PaddingMode::OAEP.as_ref() {
+            let TeeKey::Rsa(key) = &self.key else {
+                bail!("Unmatched key. Must be RSA key");
+            };
+
+            let cek = key.decrypt(PaddingMode::OAEP, wrapped_cek)?;
+            Ok(cek)
+        } else if &header.alg[..] == KeyWrapAlgorithm::EcdhEsA256Kw.as_ref() {
+            let epk = header
+                .other_fields
+                .get("epk")
+                .ok_or(anyhow!("Invalid JWE ProtectedHeader. Without `epk`"))?;
+            let crv = epk
+                .get("crv")
+                .ok_or(anyhow!("Invalid JWE ProtectedHeader. Without `crv`"))?
+                .as_str()
+                .ok_or(anyhow!(
+                    "Invalid JWE ProtectedHeader. `crv` is not a string"
+                ))?;
+
+            let x = epk
+                .get("x")
+                .ok_or(anyhow!("Invalid JWE ProtectedHeader. Without `x`"))?
+                .as_str()
+                .ok_or(anyhow!("Invalid JWE ProtectedHeader. `x` is not a string"))?;
+
+            let x = URL_SAFE_NO_PAD.decode(x)?;
+
+            let y = epk
+                .get("y")
+                .ok_or(anyhow!("Invalid JWE ProtectedHeader. Without `y`"))?
+                .as_str()
+                .ok_or(anyhow!("Invalid JWE ProtectedHeader. `y` is not a string"))?;
+
+            let y = URL_SAFE_NO_PAD.decode(y)?;
+
+            let TeeKey::Ec(key) = &self.key else {
+                bail!("Unmatched key. Must be EC key");
+            };
+
+            if crv != key.curve().as_ref() {
+                bail!("Unmatched curve: {}", crv);
+            }
+
+            let cek = key.unwrap_key(wrapped_cek, x, y, KeyWrapAlgorithm::EcdhEsA256Kw)?;
+            Ok(cek)
+        } else {
+            bail!("Unsupported algorithm: {}", header.alg)
+        }
+    }
+
+    #[inline]
+    pub fn from_pem(pem: &str) -> Result<Self> {
+        if let Ok(keypair) = RSAKeyPair::from_pkcs1_pem(pem) {
+            return Ok(Self {
+                key: TeeKey::Rsa(Box::new(keypair)),
+            });
+        }
+
+        let keypair = EcKeyPair::from_pkcs8_pem(pem)
+            .context("private key is not RSA (PKCS#1) nor EC P256 (PKCS#8)")?;
+        Ok(Self {
+            key: TeeKey::Ec(Box::new(keypair)),
         })
     }
 
     #[inline]
-    pub fn decrypt(&self, mode: PaddingMode, cipher_text: Vec<u8>) -> Result<Vec<u8>> {
-        self.keypair.decrypt(mode, cipher_text)
-    }
-
-    #[inline]
-    pub fn from_pkcs1_pem(pem: &str) -> Result<Self> {
-        let keypair = RSAKeyPair::from_pkcs1_pem(pem)?;
-        Ok(Self { keypair })
-    }
-
-    #[inline]
-    pub fn to_pkcs1_pem(&self) -> Result<Zeroizing<String>> {
-        self.keypair.to_pkcs1_pem()
+    pub fn to_pem(&self) -> Result<Zeroizing<String>> {
+        match &self.key {
+            TeeKey::Rsa(keypair) => keypair.to_pkcs1_pem(),
+            TeeKey::Ec(keypair) => keypair.to_pkcs8_pem(),
+        }
     }
 
     pub fn decrypt_response(&self, response: Response) -> Result<Vec<u8>> {
-        // deserialize the jose header and check that the key type matches
-        let protected: ProtectedHeader = serde_json::from_str(&response.protected)?;
-        let padding_mode = PaddingMode::try_from(&protected.alg[..])
-            .context("Unsupported padding mode for wrapped key")?;
-
         // unwrap the wrapped key
-        let wrapped_symkey: Vec<u8> = URL_SAFE_NO_PAD.decode(&response.encrypted_key)?;
-        let symkey = self.decrypt(padding_mode, wrapped_symkey)?;
+        let cek = self.unwrap_cek(&response.protected, response.encrypted_key)?;
 
-        let iv = URL_SAFE_NO_PAD.decode(&response.iv)?;
-        let ciphertext = URL_SAFE_NO_PAD.decode(&response.ciphertext)?;
-
-        let plaintext = crypto::decrypt(Zeroizing::new(symkey), ciphertext, iv, protected.enc)?;
+        let aad = response.protected.generate_aad()?;
+        let plaintext = crypto::decrypt_aead(
+            Zeroizing::new(cek),
+            response.ciphertext,
+            response.iv,
+            aad,
+            response.tag,
+            crypto::WrapType::Aes256Gcm,
+        )?;
 
         Ok(plaintext)
     }
-}
-
-#[derive(Deserialize)]
-struct ProtectedHeader {
-    /// enryption algorithm for encrypted key
-    alg: String,
-    /// encryption algorithm for payload
-    enc: WrapType,
 }

--- a/attestation-agent/kbs_protocol/src/token_provider/aa/mod.rs
+++ b/attestation-agent/kbs_protocol/src/token_provider/aa/mod.rs
@@ -59,7 +59,7 @@ impl TokenProvider for AATokenProvider {
         })?;
         let token = Token::new(message.token)
             .map_err(|e| Error::AATokenProvider(format!("deserialize token failed: {e:?}")))?;
-        let tee_keypair = TeeKeyPair::from_pkcs1_pem(&message.tee_keypair).map_err(|e| {
+        let tee_keypair = TeeKeyPair::from_pem(&message.tee_keypair).map_err(|e| {
             Error::AATokenProvider(format!("deserialize tee keypair failed: {e:?}"))
         })?;
         Ok((token, tee_keypair))


### PR DESCRIPTION
~Per RFC7516, the AEAD's auth tag should be included inside the JWE body. We fix this to align with trustee side~

https://github.com/confidential-containers/trustee/pull/597

~~Let's wait after https://github.com/confidential-containers/trustee/pull/597 gets merged.~~

This patch does a bunch of fixes per RFC7516.
1. AEAD Auth Tag is now expcilitly included inside the `tag` part.
2. Add TEE key pair support for `RSA OAEP` and `ECDH-ES+A256KW`(by default)
3. Mark `RSA PKCS#1 v1.5` padding scheme as deprecated as it is not recommended.