### PR TITLE
tdx-attester: log error on empty TSM report

### DIFF
--- a/attestation-agent/attester/src/tdx/mod.rs
+++ b/attestation-agent/attester/src/tdx/mod.rs
@@ -87,6 +87,7 @@ impl Attester for TdxAttester {
             },
             |tsm| {
                 tsm.attestation_report(TsmReportData::Tdx(report_data.clone()))
+                    .inspect(|outblob| {if outblob.is_empty() {log::error!("TSM provider returned an empty quote without an error")}})
                     .context("TDX Attester: quote generation using TSM reports failed")
             },
         )?;


### PR DESCRIPTION
Fixes: #823 

tdx_guest TSM provider covers a wide range of errors which trigger an errno on outblob read but can also return empty reports without error.

One such scenario seems to be when Qemu isn't connecting to TDX QGS properly (likely due to misconfiguration) but returns back with an empty buffer.

Notify users about this scenario and log an error on empty TSM report but don't turn it into a new error because there isn't any.

Note: when used with `evidence_getter`, a logger must be enabled to get the logs visible.