### PR TITLE
CI | Fix Kbs Client Error due to KBS configuration for EAR

### DIFF
--- a/attestation-agent/kbs_protocol/src/client/rcar_client.rs
+++ b/attestation-agent/kbs_protocol/src/client/rcar_client.rs
@@ -447,9 +447,11 @@ mod test {
             Err(e) => {
                 // Skip the test if the kbs server returned ProtocolVersion error. Any other
                 // error is treated as a failure.
-                assert!(e
-                    .to_string()
-                    .contains("KBS Client Protocol Version Mismatch"));
+                assert!(
+                    e.to_string()
+                        .contains("KBS Client Protocol Version Mismatch"),
+                    "Actual error: {e:#?}"
+                );
                 println!("NOTE: the test is skipped due to KBS protocol incompatibility.");
                 return ();
             }

--- a/attestation-agent/kbs_protocol/test/kbs-config.toml
+++ b/attestation-agent/kbs_protocol/test/kbs-config.toml
@@ -11,15 +11,14 @@ policy_path = "/opa/confidential-containers/kbs/policy.rego"
 [attestation_service]
 type = "coco_as_builtin"
 work_dir = "/opt/confidential-containers/attestation-service"
-policy_engine = "opa"
-attestation_token_broker = "Simple"
 
-    [attestation_service.attestation_token_config]
-    duration_min = 5
+[attestation_service.attestation_token_config]
+type = "Ear"
+duration_min = 5
 
-    [attestation_service.rvps_config]
-    type = "BuiltIn"
-    store_type = "LocalFs"
+[attestation_service.rvps_config]
+type = "BuiltIn"
+store_type = "LocalFs"
 
 [admin]
 insecure_api = true

--- a/attestation-agent/kbs_protocol/test/policy.rego
+++ b/attestation-agent/kbs_protocol/test/policy.rego
@@ -3,5 +3,5 @@ package policy
 default allow = false
 
 allow {
-	input["tee"] == "sample"
+	input["submods"]["cpu"]["ear.veraison.annotated-evidence"]["sample"]
 }


### PR DESCRIPTION
Due to the EAR PR, the configuration file format has been changed a little. This patch updates the KBS configuration file to include the latest EAR checking logic.

