### PR TITLE
image-rs: fix duplicated image layer detective logic

### DIFF
--- a/image-rs/src/pull.rs
+++ b/image-rs/src/pull.rs
@@ -162,6 +162,10 @@ impl<'a> PullClient<'a> {
         };
 
         let decryptor = Decryptor::from_media_type(&layer.media_type);
+
+        // There are two types of layers:
+        // 1. Compressed layer = Compress(Layer Data)
+        // 2. Encrypted+Compressed layer = Compress(Encrypt(Layer Data))
         if decryptor.is_encrypted() {
             let decrypt_key = tokio::task::spawn_blocking({
                 let decryptor = decryptor.clone();
@@ -210,6 +214,8 @@ impl<'a> PullClient<'a> {
         Ok(layer_meta)
     }
 
+    /// Decompress and unpack layer data. The returned value is the
+    /// digest of the uncompressed layer.
     async fn async_decompress_unpack_layer(
         &self,
         input_reader: (impl tokio::io::AsyncRead + Unpin + Send),


### PR DESCRIPTION
Before this commit, when we pull images who have two encrypted layers whose corresponding plaintext layers are same. For example `quay.io/fidencio/prueba:encrypted`, there will be an error like

```
index out of bounds: the len is 25 but the index is 25
```

This is caused by the deduplication logic inside image pull logic. On one hand, it will delete duplicated layers recorded inside image manifest, who reflectes the encrypted layers/blobs. On the other hand, it will delete duplicated layers recorded inside the config.json, who reflects the plaintext of the layers.

The image encryption logic will generate a random symmetric key for each layer. Thus even the same plaintext layer would be encrypted into different blobs/layers. Thus after deduplication, we might have more layers for image manifest.

This patch changes the deduplicating logic, by only check the layer digests inside image manifest, s.t. even if there are two same plaintext layers, we will pull and decrypt both of them. It's ok to do some optimization later if a fully analyzation is taken.

Fies #840

cc @fidencio @mkulke @arronwy 