### PR TITLE
AA/attester: move CCEL read logic to eventlog_rs crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -379,6 +379,7 @@ dependencies = [
  "clap 4.2.7",
  "codicon",
  "csv-rs",
+ "eventlog-rs",
  "hex",
  "hyper 0.14.28",
  "hyper-tls 0.5.0",
@@ -2046,6 +2047,19 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a19187fea3ac7e84da7dacf48de0c45d63c6a76f9490dae389aead16c243fce3"
+dependencies = [
+ "atty",
+ "humantime",
+ "log",
+ "regex",
+ "termcolor",
+]
+
+[[package]]
+name = "env_logger"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a12e6657c4c97ebab115a42dcee77225f7f482cdd841cf7088c657a42e9e00e7"
@@ -2105,6 +2119,21 @@ checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
 dependencies = [
  "cc",
  "libc",
+]
+
+[[package]]
+name = "eventlog-rs"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "606e113813a3db3f1f42b273d4fb89ca8ef1e2bd5b97befd08b260ae5708be8d"
+dependencies = [
+ "anyhow",
+ "byteorder",
+ "env_logger 0.8.4",
+ "hex",
+ "lazy_static",
+ "log",
+ "sha2 0.10.8",
 ]
 
 [[package]]
@@ -3547,7 +3576,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c2a198fb6b0eada2a8df47933734e6d35d350665a33a3593d7164fa52c75c19"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]

--- a/attestation-agent/attester/Cargo.toml
+++ b/attestation-agent/attester/Cargo.toml
@@ -12,6 +12,7 @@ az-snp-vtpm = { version = "0.7.1", default-features = false, features = ["attest
 az-tdx-vtpm = { version = "0.7.0", default-features = false, features = ["attester"], optional = true }
 base64.workspace = true
 clap = { workspace = true, features = ["derive"], optional = true }
+eventlog-rs = { version = "0.1.6", optional = true }
 hex.workspace = true
 kbs-types.workspace = true
 log.workspace = true
@@ -59,7 +60,7 @@ all-attesters = [
 # quotes. It's an unconditional dependency for tdx-attester since that is the only way to
 # generate TDX quotes with upstream kernels.
 tsm-report = ["tempfile"]
-tdx-attester = ["scroll", "tsm-report", "tdx-attest-rs"]
+tdx-attester = ["scroll", "tsm-report", "tdx-attest-rs", "eventlog-rs"]
 sgx-attester = ["occlum_dcap"]
 az-snp-vtpm-attester = ["az-snp-vtpm"]
 az-tdx-vtpm-attester = ["az-snp-vtpm-attester", "az-tdx-vtpm"]

--- a/attestation-agent/attester/src/tdx/mod.rs
+++ b/attestation-agent/attester/src/tdx/mod.rs
@@ -22,7 +22,6 @@ mod report;
 mod rtmr;
 
 const TDX_REPORT_DATA_SIZE: usize = 64;
-const CCEL_PATH: &str = "/sys/firmware/acpi/tables/data/CCEL";
 
 pub fn detect_platform() -> bool {
     TsmReportPath::new(TsmReportProvider::Tdx).is_ok() || Path::new("/dev/tdx_guest").exists()
@@ -129,7 +128,7 @@ impl Attester for TdxAttester {
         let engine = base64::engine::general_purpose::STANDARD;
         let quote = engine.encode(quote_bytes);
 
-        let cc_eventlog = match std::fs::read(CCEL_PATH) {
+        let cc_eventlog = match eventlog_rs::read::read_ccel() {
             Result::Ok(el) => Some(engine.encode(el)),
             Result::Err(e) => {
                 log::warn!("Read CC Eventlog failed: {:?}", e);


### PR DESCRIPTION
We move CCEL reading logic to `eventlog_rs` crate to keep the logic clean in gc.