### PR TITLE
image-rs: removed unused lifetime annotation

### DIFF
--- a/image-rs/src/image.rs
+++ b/image-rs/src/image.rs
@@ -336,7 +336,7 @@ impl ImageClient {
     }
 
     #[cfg(feature = "nydus")]
-    async fn do_pull_image_with_nydus<'a>(
+    async fn do_pull_image_with_nydus(
         &mut self,
         client: &mut PullClient<'_>,
         image_data: &mut ImageMeta,


### PR DESCRIPTION
A Rust 1.84.0 toolchain will complain about unused lifetime annnotations.