### PR TITLE
image-rs: fix broken link

### DIFF
--- a/image-rs/tests/README.md
+++ b/image-rs/tests/README.md
@@ -33,7 +33,7 @@ Implemented in `signature_verification.rs`.
 
 Image Signature Verification includes the following four
 tests illustrated in 
-<https://github.com/confidential-containers/image-rs/issues/43>,
+<https://github.com/confidential-containers/guest-components/issues/43>,
 s.t.
 
 | |signed image|unsigned image|


### PR DESCRIPTION
I can't remember if we ever had a separate image-rs repo. Either way, our link checker has recently started complaining about this, and indeed the link doesn't exist.