### PR TITLE
Licenses and trustee-attester fixes

### DIFF
--- a/attestation-agent/attestation-agent/Cargo.toml
+++ b/attestation-agent/attestation-agent/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 authors = ["The Attestation Agent Authors"]
 publish = false
 edition = "2021"
+license = "Apache-2.0"
 
 [[bin]]
 name = "grpc-aa"

--- a/attestation-agent/attester/Cargo.toml
+++ b/attestation-agent/attester/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 authors = ["The Attestation Agent Authors"]
 publish = false
 edition = "2021"
+license = "Apache-2.0"
 
 [dependencies]
 anyhow.workspace = true

--- a/attestation-agent/coco_keyprovider/Cargo.toml
+++ b/attestation-agent/coco_keyprovider/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 authors = ["The Attestation Agent Authors"]
 publish = false
 edition = "2021"
+license = "Apache-2.0"
 
 [dependencies]
 aes-gcm.workspace = true

--- a/attestation-agent/deps/crypto/Cargo.toml
+++ b/attestation-agent/deps/crypto/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 authors = ["The Attestation Agent Authors"]
 publish = false
 edition = "2021"
+license = "Apache-2.0"
 
 [dependencies]
 aes-gcm = { workspace = true, optional = true }

--- a/attestation-agent/deps/resource_uri/Cargo.toml
+++ b/attestation-agent/deps/resource_uri/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 authors = ["The Attestation Agent Authors"]
 publish = false
 edition = "2021"
+license = "Apache-2.0"
 
 [dev-dependencies]
 rstest.workspace = true

--- a/attestation-agent/deps/sev/Cargo.toml
+++ b/attestation-agent/deps/sev/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 authors = ["The Attestation Agent Authors"]
 publish = false
 edition = "2021"
+license = "Apache-2.0"
 
 [dependencies]
 anyhow.workspace = true

--- a/attestation-agent/kbc/Cargo.toml
+++ b/attestation-agent/kbc/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 authors = ["The Attestation Agent Authors"]
 publish = false
 edition = "2021"
+license = "Apache-2.0"
 
 [dependencies]
 anyhow.workspace = true

--- a/attestation-agent/kbs_protocol/Cargo.toml
+++ b/attestation-agent/kbs_protocol/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 authors = ["The Attestation Agent Authors"]
 publish = false
 edition = "2021"
+license = "Apache-2.0"
 
 [dependencies]
 anyhow.workspace = true

--- a/attestation-agent/kbs_protocol/src/bin/trustee-attester/main.rs
+++ b/attestation-agent/kbs_protocol/src/bin/trustee-attester/main.rs
@@ -80,6 +80,7 @@ async fn main() -> Result<()> {
                 true => path,
             };
             let resource = ResourceUri::new("", &resource_path)?;
+            let (_token, _key) = client.get_token().await?; // attest first
             let resource_bytes = client.get_resource(resource).await?;
 
             println!("{}", STANDARD.encode(resource_bytes));

--- a/attestation-agent/kbs_protocol/src/bin/trustee-attester/trustee-attester.1
+++ b/attestation-agent/kbs_protocol/src/bin/trustee-attester/trustee-attester.1
@@ -1,0 +1,52 @@
+.TH trustee-attester 1
+.LO 1
+
+.SH NAME
+trustee-attester \- attest and fetch secrets from Trustee
+
+.SH SYNOPSIS
+.B trustee-attester
+.RB    OPTIONS
+.RB    get-resource  \-\-path  <RESOURCE_PATH>
+
+.SH DESCRIPTION
+trustee-attester is a simple client to easily attest and fetch secrets
+(a.k.a confidential resources) from Trustee.
+
+.IR get-resource
+Do attestation and get a secret from Trustee.
+RESOURCE_PATH is a of format <repo>/<type>/<name>
+
+It is assumed that the secret was uploaded to Trustee, with the
+exact same RESOURCE_PATH, before trustee-attester runs.
+
+For more information look at
+https://github.com/confidential-containers/guest-components/blob/main/attestation-agent/docs/KBS_URI.md
+
+.SH OPTIONS
+.RB    \-\-url  <URL-of-Trustee>   [\-\-cert-file  <path-to-certificate>]
+
+.RB    \-\-url  <URL-of-Trustee>
+Format of <URL-of-Trustee> is <protocol>://<host>:<port>
+where <protocol> is
+.B http
+or
+.B https
+
+.RB    \-\-cert-file  <path-to-certificate>
+Optional. When <protocol> is https, add a certificate to verify the Trustee server.
+
+.SH EXAMPLES
+trustee-attester --url http://10.0.0.4:50000 get-resource --path default/secrets/secret1
+
+trustee-attester --url https://10.0.0.4:50000 --cert-file /etc/trustee-attester/server_cert.pem
+get-resource --path myrepo/keys/mykey1
+
+.SH NOTES
+.B trustee-attester
+is a part of https://github.com/confidential-containers/guest-components.
+
+User must have privileges to request an attestation-report from the hardware.
+
+.B Trustee
+can be found here https://github.com/confidential-containers/trustee

--- a/confidential-data-hub/hub/Cargo.toml
+++ b/confidential-data-hub/hub/Cargo.toml
@@ -3,6 +3,7 @@ name = "confidential-data-hub"
 version = "0.1.0"
 authors = ["The Confidential Container Authors"]
 edition = "2021"
+license = "Apache-2.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/image-rs/libs/test-utils/Cargo.toml
+++ b/image-rs/libs/test-utils/Cargo.toml
@@ -2,6 +2,7 @@
 name = "test-utils"
 version = "0.1.0"
 edition = "2021"
+license = "Apache-2.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
Packaging: Add package.license to Cargo.toml files
trustee-attester: Add a manual page
trustee-attester: attest before get-resource