### PR TITLE
ci: Enable ci tests on arm64

### DIFF
--- a/.github/workflows/aa_basic.yml
+++ b/.github/workflows/aa_basic.yml
@@ -48,6 +48,12 @@ jobs:
           - instance: ubuntu-24.04-arm
             make_args: "ATTESTER=cca-attester TEE_PLATFORM=cca"
             cargo_test_opts: "--no-default-features --features openssl,rust-crypto,passport,cca-attester,kbs,coco_as,ttrpc,grpc"
+            # TODO: remove rust: 1.82.0 and exclude when the following issue is resolved
+            # https://github.com/rust-lang/rust/issues/135867
+            rust: 1.82.0
+        exclude:
+          - instance: ubuntu-24.04-arm
+            rust: stable
     runs-on: ${{ matrix.instance }}
     steps:
       - name: Code checkout

--- a/.github/workflows/aa_basic.yml
+++ b/.github/workflows/aa_basic.yml
@@ -37,6 +37,7 @@ jobs:
         instance:
           - ubuntu-24.04
           - s390x
+          - ubuntu-24.04-arm
         include:
           - instance: ubuntu-24.04
             make_args: ""
@@ -44,6 +45,9 @@ jobs:
           - instance: s390x
             make_args: "ATTESTER=se-attester TEE_PLATFORM=se"
             cargo_test_opts: "--no-default-features --features openssl,passport,se-attester,kbs,coco_as"
+          - instance: ubuntu-24.04-arm
+            make_args: "ATTESTER=cca-attester TEE_PLATFORM=cca"
+            cargo_test_opts: "--no-default-features --features openssl,rust-crypto,passport,cca-attester,kbs,coco_as,ttrpc,grpc"
     runs-on: ${{ matrix.instance }}
     steps:
       - name: Code checkout

--- a/.github/workflows/aa_cc_kbc.yml
+++ b/.github/workflows/aa_cc_kbc.yml
@@ -48,6 +48,12 @@ jobs:
             attester: az-tdx-vtpm-attester
           - instance: ubuntu-24.04-arm
             attester: cca-attester
+            # TODO: remove rust: 1.82.0 and exclude when the following issue is resolved
+            # https://github.com/rust-lang/rust/issues/135867
+            rust: 1.82.0
+        exclude:
+          - instance: ubuntu-24.04-arm
+            rust: stable
     runs-on: ${{ matrix.instance }}
     steps:
       - name: Code checkout
@@ -61,7 +67,7 @@ jobs:
           profile: minimal
           toolchain: ${{ matrix.rust }}
           override: true
-          components: rustfmt
+          components: rustfmt, clippy
 
       - uses: ./.github/actions/install-intel-dcap
         with:

--- a/.github/workflows/aa_cc_kbc.yml
+++ b/.github/workflows/aa_cc_kbc.yml
@@ -29,17 +29,26 @@ jobs:
     defaults:
       run:
         working-directory: ./attestation-agent
-    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:
         rust:
           - stable
-        attester:
-          - snp-attester
-          - tdx-attester
-          - az-snp-vtpm-attester
-          - az-tdx-vtpm-attester
+        instance:
+          - ubuntu-24.04
+          - ubuntu-24.04-arm
+        include:
+          - instance: ubuntu-24.04
+            attester: snp-attester
+          - instance: ubuntu-24.04
+            attester: tdx-attester
+          - instance: ubuntu-24.04
+            attester: az-snp-vtpm-attester
+          - instance: ubuntu-24.04
+            attester: az-tdx-vtpm-attester
+          - instance: ubuntu-24.04-arm
+            attester: cca-attester
+    runs-on: ${{ matrix.instance }}
     steps:
       - name: Code checkout
         uses: actions/checkout@v4
@@ -57,11 +66,13 @@ jobs:
       - uses: ./.github/actions/install-intel-dcap
         with:
           ubuntu-version: noble
+        if: matrix.instance == 'ubuntu-24.04'
 
       - name: Install TPM dependencies
         run: |
           sudo apt-get update
           sudo apt-get install -y libtss2-dev
+        if: matrix.instance == 'ubuntu-24.04'
 
       - name: Install protoc
         run: |

--- a/.github/workflows/aa_crypto.yml
+++ b/.github/workflows/aa_crypto.yml
@@ -34,6 +34,16 @@ jobs:
         suites:
           - rust-crypto
           - openssl
+        rust:
+          - stable
+          # TODO: remove include and exclude when the following issue is resolved
+          # https://github.com/rust-lang/rust/issues/135867
+          - 1.82.0
+        exclude:
+          - instance: ubuntu-24.04
+            rust: 1.82.0
+          - instance: ubuntu-24.04-arm
+            rust: stable
     runs-on: ${{ matrix.instance }}
 
     steps:
@@ -42,13 +52,13 @@ jobs:
         with:
           fetch-depth: 1
 
-      - name: Install Rust toolchain (stable)
+      - name: Install Rust toolchain (${{ matrix.rust }})
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: stable
+          toolchain: ${{ matrix.rust }}
           override: true
-          components: rustfmt
+          components: rustfmt, clippy
 
       - name: Run rust fmt check
         uses: actions-rs/cargo@v1

--- a/.github/workflows/aa_crypto.yml
+++ b/.github/workflows/aa_crypto.yml
@@ -25,13 +25,16 @@ jobs:
     defaults:
       run:
         working-directory: ./attestation-agent
-    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:
+        instance:
+          - ubuntu-24.04
+          - ubuntu-24.04-arm
         suites:
           - rust-crypto
           - openssl
+    runs-on: ${{ matrix.instance }}
 
     steps:
       - name: Code checkout

--- a/.github/workflows/aa_release.yml
+++ b/.github/workflows/aa_release.yml
@@ -13,6 +13,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
@@ -25,6 +31,6 @@ jobs:
         with:
           context: .
           file: ./attestation-agent/docker/Dockerfile.keyprovider
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ghcr.io/confidential-containers/staged-images/coco-keyprovider:${{ github.sha }}, ghcr.io/confidential-containers/staged-images/coco-keyprovider:latest

--- a/.github/workflows/aa_sample_keyprovider.yml
+++ b/.github/workflows/aa_sample_keyprovider.yml
@@ -29,6 +29,14 @@ jobs:
         instance:
           - ubuntu-24.04
           - ubuntu-24.04-arm
+        # TODO: remove include and exclude when the following issue is resolved
+        # https://github.com/rust-lang/rust/issues/135867
+        include:
+          - instance: ubuntu-24.04-arm
+            rust: 1.82.0
+        exclude:
+          - instance: ubuntu-24.04-arm
+            rust: stable
     runs-on: ${{ matrix.instance }}
 
     steps:

--- a/.github/workflows/aa_sample_keyprovider.yml
+++ b/.github/workflows/aa_sample_keyprovider.yml
@@ -21,12 +21,15 @@ jobs:
   coco_keyprovider_ci:
     if: github.event_name != 'push'
     name: Check
-    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:
         rust:
           - stable
+        instance:
+          - ubuntu-24.04
+          - ubuntu-24.04-arm
+    runs-on: ${{ matrix.instance }}
 
     steps:
       - name: Code checkout

--- a/.github/workflows/api-server-rest-basic.yml
+++ b/.github/workflows/api-server-rest-basic.yml
@@ -38,6 +38,14 @@ jobs:
           - ubuntu-24.04-arm
         rust:
           - stable
+        # TODO: remove include and exclude when the following issue is resolved
+        # https://github.com/rust-lang/rust/issues/135867
+        include:
+          - instance: ubuntu-24.04-arm
+            rust: 1.82.0
+        exclude:
+          - instance: ubuntu-24.04-arm
+            rust: stable
     runs-on: ${{ matrix.instance }}
     steps:
       - name: Code checkout

--- a/.github/workflows/api-server-rest-basic.yml
+++ b/.github/workflows/api-server-rest-basic.yml
@@ -35,6 +35,7 @@ jobs:
         instance:
           - ubuntu-24.04
           - s390x
+          - ubuntu-24.04-arm
         rust:
           - stable
     runs-on: ${{ matrix.instance }}
@@ -63,7 +64,7 @@ jobs:
       - name: Musl build with default features
         run: |
           make LIBC=musl
-        if: matrix.instance == 'ubuntu-24.04'
+        if: ${{ startsWith(matrix.instance, 'ubuntu-24.04') }}
 
       - name: Run cargo test
         uses: actions-rs/cargo@v1

--- a/.github/workflows/cdh_basic.yml
+++ b/.github/workflows/cdh_basic.yml
@@ -38,6 +38,14 @@ jobs:
           - ubuntu-24.04-arm
         rust:
           - stable
+        # TODO: remove include and exclude when the following issue is resolved
+        # https://github.com/rust-lang/rust/issues/135867
+        include:
+          - instance: ubuntu-24.04-arm
+            rust: 1.82.0
+        exclude:
+          - instance: ubuntu-24.04-arm
+            rust: stable
     runs-on: ${{ matrix.instance }}
     steps:
       - name: Code checkout

--- a/.github/workflows/cdh_basic.yml
+++ b/.github/workflows/cdh_basic.yml
@@ -35,6 +35,7 @@ jobs:
         instance:
           - ubuntu-24.04
           - s390x
+          - ubuntu-24.04-arm
         rust:
           - stable
     runs-on: ${{ matrix.instance }}
@@ -63,7 +64,7 @@ jobs:
       - name: Musl build
         run: |
           make LIBC=musl
-        if: matrix.instance == 'ubuntu-24.04'
+        if: ${{ startsWith(matrix.instance, 'ubuntu-24.04') }}
 
       - name: Run cargo test
         run: |

--- a/.github/workflows/image_rs_build.yml
+++ b/.github/workflows/image_rs_build.yml
@@ -38,6 +38,16 @@ jobs:
           - ubuntu-24.04
           - s390x
           - ubuntu-24.04-arm
+        # TODO: remove include and exclude when the following issue is resolved
+        # https://github.com/rust-lang/rust/issues/135867
+        include:
+          - instance: ubuntu-24.04-arm
+            rust: 1.82.0
+        exclude:
+          - instance: ubuntu-24.04-arm
+            rust: stable
+          - instance: ubuntu-24.04-arm
+            rust: 1.83.0
     runs-on: ${{ matrix.instance }}
     steps:
       - name: Code checkout

--- a/.github/workflows/image_rs_build.yml
+++ b/.github/workflows/image_rs_build.yml
@@ -37,6 +37,7 @@ jobs:
         instance:
           - ubuntu-24.04
           - s390x
+          - ubuntu-24.04-arm
     runs-on: ${{ matrix.instance }}
     steps:
       - name: Code checkout
@@ -142,4 +143,4 @@ jobs:
       - name: Run cargo test - kata-cc (native-tls version) with keywrap-ttrpc (default) + keywrap-jwe + nydus
         run: |
           sudo -E PATH=$PATH -s cargo test -p image-rs --no-default-features --features=kata-cc-native-tls,keywrap-jwe,nydus
-        if: matrix.instance == 'ubuntu-24.04'
+        if: ${{ startsWith(matrix.instance, 'ubuntu-24.04') }}

--- a/.github/workflows/ocicrypt_rs_build.yml
+++ b/.github/workflows/ocicrypt_rs_build.yml
@@ -34,6 +34,16 @@ jobs:
         rust:
           - 1.83.0
           - stable
+        # TODO: remove include and exclude when the following issue is resolved
+        # https://github.com/rust-lang/rust/issues/135867
+        include:
+          - instance: ubuntu-24.04-arm
+            rust: 1.82.0
+        exclude:
+          - instance: ubuntu-24.04-arm
+            rust: stable
+          - instance: ubuntu-24.04-arm
+            rust: 1.83.0
     runs-on: ${{ matrix.instance }}
 
     steps:

--- a/.github/workflows/ocicrypt_rs_build.yml
+++ b/.github/workflows/ocicrypt_rs_build.yml
@@ -25,13 +25,16 @@ jobs:
   ci:
     if: github.event_name != 'push'
     name: Check
-    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:
+        instance:
+          - ubuntu-24.04
+          - ubuntu-24.04-arm
         rust:
           - 1.83.0
           - stable
+    runs-on: ${{ matrix.instance }}
 
     steps:
       - name: Code checkout

--- a/.github/workflows/trustee-attester.yml
+++ b/.github/workflows/trustee-attester.yml
@@ -36,6 +36,12 @@ jobs:
             cargo_test_opts: "-p kbs_protocol --bin trustee-attester --no-default-features --features background_check,passport,openssl,se-attester,bin"
           - instance: ubuntu-24.04-arm
             cargo_test_opts: "-p kbs_protocol --bin trustee-attester --no-default-features --features background_check,passport,openssl,cca-attester,bin"
+            # TODO: remove rust: 1.82.0 and exclude when the following issue is resolved
+            # https://github.com/rust-lang/rust/issues/135867
+            rust: 1.82.0
+        exclude:
+          - instance: ubuntu-24.04-arm
+            rust: stable
     runs-on: ${{ matrix.instance }}
     steps:
       - name: Code checkout

--- a/.github/workflows/trustee-attester.yml
+++ b/.github/workflows/trustee-attester.yml
@@ -28,11 +28,14 @@ jobs:
         instance:
           - ubuntu-24.04
           - s390x
+          - ubuntu-24.04-arm
         include:
           - instance: ubuntu-24.04
             cargo_test_opts: "-p kbs_protocol --bin trustee-attester --no-default-features --features background_check,passport,openssl,all-attesters,bin"
           - instance: s390x
             cargo_test_opts: "-p kbs_protocol --bin trustee-attester --no-default-features --features background_check,passport,openssl,se-attester,bin"
+          - instance: ubuntu-24.04-arm
+            cargo_test_opts: "-p kbs_protocol --bin trustee-attester --no-default-features --features background_check,passport,openssl,cca-attester,bin"
     runs-on: ${{ matrix.instance }}
     steps:
       - name: Code checkout

--- a/attestation-agent/Makefile
+++ b/attestation-agent/Makefile
@@ -108,8 +108,8 @@ else
     features := $(features),rust-crypto
 endif
 
-ifeq ($(ARCH), s390x)
-    LINT_OPTION = lint-s390x
+ifeq ($(ARCH), $(filter $(ARCH), s390x aarch64))
+    LINT_OPTION = lint-$(ARCH)
 else
     LINT_OPTION = lint-default
 endif
@@ -127,6 +127,9 @@ lint-default:
 
 lint-s390x:
 	cd attestation-agent && cargo clippy --no-default-features --features openssl,kbs,coco_as,bin,grpc,ttrpc
+
+lint-aarch64:
+	cd attestation-agent && cargo clippy --no-default-features --features openssl,rust-crypto,cca-attester,kbs,coco_as,bin,grpc,ttrpc
 
 install: 
 	install -D -m0755 $(TARGET) $(DESTDIR)/$(BIN_NAME)

--- a/attestation-agent/docker/Dockerfile.keyprovider
+++ b/attestation-agent/docker/Dockerfile.keyprovider
@@ -1,7 +1,7 @@
 # Copyright (c) 2023 by Alibaba.
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-FROM rust:1.75-slim-bookworm as builder
+FROM rust:1.84-slim-bookworm as builder
 
 LABEL org.opencontainers.image.source="https://github.com/confidential-containers/guest-components/blob/main/attestation-agent/docker/Dockerfile.keyprovider"
 


### PR DESCRIPTION
This changes enables CI tests on arm64 runner.

Ther guest-components's CI is as following: (${\color{red}red}$ parts are added by this change, links are test results on forked repo.)
* aa_basic.yml (on amd64, s390x, ${\color{red}arm64}$)
  * https://github.com/seungukshin/guest-components/actions/runs/12910598245/job/36000990431
* aa_cc_kbc.yml (on amd64, ${\color{red}arm64}$)
  * https://github.com/seungukshin/guest-components/actions/runs/12910903728/job/36002045320
* aa_crypto.yml (on amd64, ${\color{red}arm64}$)
  * https://github.com/seungukshin/guest-components/actions/runs/12928771208
* aa_occlum_sgx.yml (on amd64)
* aa_release.yml (on amd64, but generate amd64, ${\color{red}arm64}$ image using docker-buildx)
  * https://github.com/seungukshin/guest-components/actions/runs/12928098948/job/36054642982
* aa_sample_keyprovider.yml (on amd64, ${\color{red}arm64}$)
  * https://github.com/seungukshin/guest-components/actions/runs/12928903563/job/36057187914
* aa_sev_kbc.yml (on amd64)
* api-server-rest-basic.yml (on amd64, s390x, ${\color{red}arm64}$)
  * https://github.com/seungukshin/guest-components/actions/runs/12929118555/job/36057839641
* cdh_basic.yml (on amd64, s390x, ${\color{red}arm64}$)
  * https://github.com/seungukshin/guest-components/actions/runs/12929229686/job/36058180157
* dco.yml (on amd64)
* image_rs_build.yml (on amd64, s390x, ${\color{red}arm64}$)
  * https://github.com/seungukshin/guest-components/actions/runs/12930750435
* links.yml (on amd64)
* ocicrypt_rs_build.yml (on amd64, ${\color{red}arm64}$)
  * https://github.com/seungukshin/guest-components/actions/runs/12929520660
* publish-artifacts.yml (on amd64, s390x, but generate amd64, s390x, arm64 image using cross-compile)
* trustee-attester.yml (on amd64, s390x, ${\color{red}arm64}$)
  * https://github.com/seungukshin/guest-components/actions/runs/12930773078/job/36063085501
* vendor_release.yml (on amd64)