### PR TITLE
image-rs: replace krata-tar-rs to astral-tokio-tar

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -278,6 +278,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "astral-tokio-tar"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65152cbda42e8ab5ecff69e8811e8333d69188c7d5c41e3eedb8d127e3f23b27"
+dependencies = [
+ "filetime",
+ "futures-core",
+ "libc",
+ "portable-atomic",
+ "rustc-hash 2.1.1",
+ "tokio",
+ "tokio-stream",
+ "xattr",
+]
+
+[[package]]
 name = "async-compression"
 version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -640,7 +656,7 @@ dependencies = [
  "bitflags 2.6.0",
  "cexpr",
  "clang-sys",
- "itertools 0.10.5",
+ "itertools 0.11.0",
  "lazy_static",
  "lazycell",
  "proc-macro2",
@@ -3004,6 +3020,7 @@ name = "image-rs"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "astral-tokio-tar",
  "async-compression",
  "async-trait",
  "base64 0.22.1",
@@ -3017,7 +3034,6 @@ dependencies = [
  "futures-util",
  "hex",
  "kbc",
- "krata-tokio-tar",
  "log",
  "loopdev",
  "nix 0.29.0",
@@ -3402,22 +3418,6 @@ dependencies = [
  "ttrpc-codegen",
  "url",
  "zeroize",
-]
-
-[[package]]
-name = "krata-tokio-tar"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8bd5fee9b96acb5fc36b401896d601e6fdcce52b0e651ce24a3b21fb524e79f"
-dependencies = [
- "filetime",
- "futures-core",
- "libc",
- "portable-atomic",
- "redox_syscall 0.3.5",
- "tokio",
- "tokio-stream",
- "xattr",
 ]
 
 [[package]]
@@ -4829,7 +4829,7 @@ checksum = "f8650aabb6c35b860610e9cff5dc1af886c9e25073b7b1712a68972af4281302"
 dependencies = [
  "bytes",
  "heck 0.5.0",
- "itertools 0.10.5",
+ "itertools 0.11.0",
  "log",
  "multimap",
  "once_cell",
@@ -4862,7 +4862,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools 0.11.0",
  "proc-macro2",
  "quote",
  "syn 2.0.87",
@@ -4979,7 +4979,7 @@ dependencies = [
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
- "rustc-hash 2.0.0",
+ "rustc-hash 2.1.1",
  "rustls",
  "socket2 0.5.5",
  "thiserror 1.0.69",
@@ -4996,7 +4996,7 @@ dependencies = [
  "bytes",
  "rand 0.8.5",
  "ring",
- "rustc-hash 2.0.0",
+ "rustc-hash 2.1.1",
  "rustls",
  "slab",
  "thiserror 1.0.69",
@@ -5123,15 +5123,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d92195228612ac8eed47adbc2ed0f04e513a4ccb98175b6f2bd04d963b533655"
 dependencies = [
  "rand_core 0.6.4",
-]
-
-[[package]]
-name = "redox_syscall"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
-dependencies = [
- "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -5437,9 +5428,9 @@ checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc-hash"
-version = "2.0.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "583034fd73374156e66797ed8e5b0d5690409c9226b22d87cb7f19821c05d152"
+checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
 name = "rustc_version"

--- a/image-rs/Cargo.toml
+++ b/image-rs/Cargo.toml
@@ -53,7 +53,7 @@ sha2.workspace = true
 sigstore = { git = "https://github.com/sigstore/sigstore-rs.git", rev = "037b7be86a68bc63e1d2ee7f16ea8f843ddcc7d8", default-features = false, optional = true }
 strum.workspace = true
 strum_macros = "0.27"
-krata-tokio-tar = "0.4.2"
+astral-tokio-tar = "0.5.1"
 tokio.workspace = true
 tokio-util = "0.7.13"
 tonic = { workspace = true, optional = true }
@@ -88,7 +88,7 @@ default = [
     "signature-cosign-rustls",
     "keywrap-grpc",
     "oci-client-rustls",
-    "signature-simple-xrss"
+    "signature-simple-xrss",
 ]
 
 # This will be based on `ring` dependency

--- a/image-rs/src/unpack.rs
+++ b/image-rs/src/unpack.rs
@@ -170,11 +170,7 @@ pub async fn unpack<R: AsyncRead + Unpin>(input: R, destination: &Path) -> Resul
             let times = [atime, atime];
 
             dirs.insert(path.clone(), times);
-        } else if kind.is_symlink() {
-            let mtime = FileTime::from_unix_time(mtime, 0);
-            filetime::set_symlink_file_times(file_path, mtime, mtime)
-                .context(format!("failed to set mtime for sym link `{file_path}`"))?;
-        } else if !kind.is_hard_link() {
+        } else if !kind.is_symlink() && !kind.is_hard_link() {
             // for other files except link we use fchown
             let f = fs::OpenOptions::new()
                 .write(true)


### PR DESCRIPTION
astral-tokio-tar is a fork version of krata-tar-rs, and it introduces more bug fixes and features than krata-tar-rs, including the long link bug #689.

Also, the mtime preserving is added to astral-tokio-tar itself, thus we do not to do this explicitly.

Close #689

cc @arronwy @ChengyuZhu6 @burgerdev