### PR TITLE
[Build] Stop build.rs from triggering due to protoc output for hub

### DIFF
--- a/attestation-agent/kbs_protocol/build.rs
+++ b/attestation-agent/kbs_protocol/build.rs
@@ -27,6 +27,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             Ok(())
         }
 
+        println!("cargo::rerun-if-changed=../protos/attestation-agent.proto");
+
         ttrpc_codegen::Codegen::new()
             .out_dir("src/ttrpc_protos")
             .include("../protos")

--- a/confidential-data-hub/hub/build.rs
+++ b/confidential-data-hub/hub/build.rs
@@ -14,7 +14,10 @@ fn main() {
     tonic_build::configure()
         .build_server(true)
         .out_dir("./src/kms/plugins/kbs/sev")
-        .compile_protos(&["./src/kms/plugins/kbs/sev/protos/getsecret.proto"], &[""])
+        .compile_protos(
+            &["./src/kms/plugins/kbs/sev/protos/getsecret.proto"],
+            &["./src/kms/plugins/kbs/sev/protos"],
+        )
         .expect("Generate sev protocol code failed.");
 
     #[cfg(feature = "grpc")]

--- a/image-rs/build.rs
+++ b/image-rs/build.rs
@@ -8,16 +8,19 @@ fn main() {
     tonic_build::compile_protos("./protos/getresource.proto").expect("tonic build");
 
     #[cfg(feature = "ttrpc-codegen")]
-    ttrpc_codegen::Codegen::new()
-        .out_dir("./src/resource/kbs/ttrpc_proto")
-        .input("./protos/getresource.proto")
-        .include("./protos")
-        .rust_protobuf()
-        .customize(ttrpc_codegen::Customize {
-            async_all: true,
-            ..Default::default()
-        })
-        .rust_protobuf_customize(ttrpc_codegen::ProtobufCustomize::default().gen_mod_rs(false))
-        .run()
-        .expect("ttrpc build");
+    {
+        println!("cargo::rerun-if-changed=./protos/getresource.proto");
+        ttrpc_codegen::Codegen::new()
+            .out_dir("./src/resource/kbs/ttrpc_proto")
+            .input("./protos/getresource.proto")
+            .include("./protos")
+            .rust_protobuf()
+            .customize(ttrpc_codegen::Customize {
+                async_all: true,
+                ..Default::default()
+            })
+            .rust_protobuf_customize(ttrpc_codegen::ProtobufCustomize::default().gen_mod_rs(false))
+            .run()
+            .expect("ttrpc build");
+    }
 }


### PR DESCRIPTION
Currently if we clone the repo and issue `make` from `confidential-data-hub`, the `build` target fires, which runs this:
```cd hub && $(RUST_FLAGS) cargo build $(release) --no-default-features --features "$(features)" $(binary) $(LIBC_FLAG)```

During normal development, repeatedly running this command will take ~10s. This is because the build.rs scripts are designed to produce .rs files from .proto files, which causes cargo to see dirty/stale .rs source and thus rebuild. This PR only triggers those build.rs steps when the proto files change. This should reduce that normal development flow (i.e. `make` from `confidential-data-hub/`) to the expected 0.5s.