### PR TITLE
image-rs: enable rustls-native-certs when using rustls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3024,7 +3024,7 @@ dependencies = [
  "nix 0.29.0",
  "nydus-api",
  "nydus-service",
- "oci-client 0.14.0",
+ "oci-client",
  "oci-spec",
  "ocicrypt-rs",
  "prost 0.13.5",
@@ -4131,32 +4131,6 @@ dependencies = [
  "cfg-if",
  "libc",
  "sgx_types",
-]
-
-[[package]]
-name = "oci-client"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53e050f8bab3f561aa5ab537e1a6ed24006d58b4ee93cd6bb2c0cb822726f306"
-dependencies = [
- "bytes",
- "chrono",
- "futures-util",
- "http 1.1.0",
- "http-auth",
- "jwt",
- "lazy_static",
- "oci-spec",
- "olpc-cjson",
- "regex",
- "reqwest 0.12.9",
- "serde",
- "serde_json",
- "sha2 0.10.8",
- "thiserror 1.0.69",
- "tokio",
- "tracing",
- "unicase",
 ]
 
 [[package]]
@@ -6046,8 +6020,8 @@ dependencies = [
 
 [[package]]
 name = "sigstore"
-version = "0.10.0"
-source = "git+https://github.com/sigstore/sigstore-rs.git?rev=037b7be86a68bc63e1d2ee7f16ea8f843ddcc7d8#037b7be86a68bc63e1d2ee7f16ea8f843ddcc7d8"
+version = "0.11.0"
+source = "git+https://github.com/sigstore/sigstore-rs.git?rev=c39c519#c39c519dd99be23f18e6143dd233b46bf2096e4d"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -6065,7 +6039,7 @@ dependencies = [
  "hex",
  "json-syntax",
  "lazy_static",
- "oci-client 0.13.0",
+ "oci-client",
  "olpc-cjson",
  "p256",
  "p384",
@@ -6083,7 +6057,7 @@ dependencies = [
  "serde_repr",
  "sha2 0.10.8",
  "signature",
- "thiserror 1.0.69",
+ "thiserror 2.0.11",
  "tls_codec",
  "tokio",
  "tokio-util",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2733,6 +2733,7 @@ dependencies = [
  "hyper 1.3.1",
  "hyper-util",
  "rustls",
+ "rustls-native-certs 0.7.3",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls",
@@ -5263,6 +5264,7 @@ dependencies = [
  "pin-project-lite",
  "quinn",
  "rustls",
+ "rustls-native-certs 0.8.0",
  "rustls-pemfile 2.1.2",
  "rustls-pki-types",
  "serde",
@@ -5475,6 +5477,32 @@ dependencies = [
  "rustls-webpki",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5bfb394eeed242e909609f56089eecfe5fda225042e8b171791b9c95f5931e5"
+dependencies = [
+ "openssl-probe",
+ "rustls-pemfile 2.1.2",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcaf18a4f2be7326cd874a5fa579fae794320a0f388d365dca7e480e55f83f8a"
+dependencies = [
+ "openssl-probe",
+ "rustls-pemfile 2.1.2",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
 ]
 
 [[package]]

--- a/image-rs/Cargo.toml
+++ b/image-rs/Cargo.toml
@@ -177,7 +177,10 @@ signature-cosign = ["signature", "futures"]
 signature-cosign-rustls = ["signature-cosign", "sigstore/cosign-rustls-tls"]
 signature-cosign-native = ["signature-cosign", "sigstore/cosign-native-tls"]
 
-oci-client-rustls = ["oci-client/rustls-tls"]
+oci-client-rustls = [
+    "oci-client/rustls-tls",
+    "oci-client/rustls-tls-native-roots",
+]
 oci-client-native = ["oci-client/native-tls"]
 
 signature-simple-xrss = ["signature-simple", "dep:reqwest"]

--- a/image-rs/Cargo.toml
+++ b/image-rs/Cargo.toml
@@ -50,7 +50,7 @@ serde = { workspace = true, features = ["serde_derive", "rc"] }
 serde_json.workspace = true
 serde_yaml = { version = "0.9", optional = true }
 sha2.workspace = true
-sigstore = { git = "https://github.com/sigstore/sigstore-rs.git", rev = "037b7be86a68bc63e1d2ee7f16ea8f843ddcc7d8", default-features = false, optional = true }
+sigstore = { git = "https://github.com/sigstore/sigstore-rs.git", rev = "c39c519", default-features = false, optional = true }
 strum.workspace = true
 strum_macros = "0.27"
 krata-tokio-tar = "0.4.2"
@@ -174,7 +174,11 @@ keywrap-jwe = ["ocicrypt-rs/keywrap-jwe"]
 
 signature = ["hex"]
 signature-cosign = ["signature", "futures"]
-signature-cosign-rustls = ["signature-cosign", "sigstore/cosign-rustls-tls"]
+signature-cosign-rustls = [
+    "signature-cosign",
+    "sigstore/cosign-rustls-tls",
+    "sigstore/rustls-tls-native-roots",
+]
 signature-cosign-native = ["signature-cosign", "sigstore/cosign-native-tls"]
 
 oci-client-rustls = [


### PR DESCRIPTION
`oci-client/rustls-tls-native-roots` feature will allow oci-client to read local CA certs including self-signed certs in the rootfs when using rustls suites.

Before this patch, if we pull an image with `kata-cc-rustls-tls` feature from self-signed registry whose CA is updated with `update-ca-certificates`, there will be an error

```
failed to pull manifest error sending request for url (https://127.0.0.1:5000/v2/alpine/manifests/latest)
```

With this patch it will succeed.