### PR TITLE
resource-uri: handle two-part resource paths

### DIFF
--- a/attestation-agent/deps/resource_uri/src/lib.rs
+++ b/attestation-agent/deps/resource_uri/src/lib.rs
@@ -57,17 +57,21 @@ impl TryFrom<url::Url> for ResourceUri {
 
         let path = &value.path()[1..];
         let values: Vec<&str> = path.split('/').collect();
-        if values.len() == 3 {
-            Ok(Self {
-                kbs_addr: addr,
-                repository: values[0].into(),
-                r#type: values[1].into(),
-                tag: values[2].into(),
-                query: value.query().map(|s| s.to_string()),
-            })
+        let (repository, r#type, tag) = if values.len() == 3 {
+            (values[0].into(), values[1].into(), values[2].into())
+        } else if values.len() == 2 {
+            println!("two-part resource path, filling in \"default\" for repository");
+            ("default".into(), values[0].into(), values[1].into())
         } else {
-            Err(RESOURCE_ID_ERROR_INFO)
-        }
+            return Err(RESOURCE_ID_ERROR_INFO);
+        };
+        Ok(Self {
+            kbs_addr: addr,
+            repository,
+            r#type,
+            tag,
+            query: value.query().map(|s| s.to_string()),
+        })
     }
 }
 


### PR DESCRIPTION
Two-part resource paths have so far resulted in an error.  This however seems incorrect since the repository part of a resource path is specified as optional in the kbs-protocol definition(*).

This change could conceivably break a caller that relies on ResourceUri to bail out if a resource path only has two parts.  Arguably such a caller would itself be faulty though, given the kbs-protocol definition.

(*) https://github.com/confidential-containers/trustee/blob/main/kbs/docs/kbs_attestation_protocol.md#secret-resource