### PR TITLE
cdh: allow Trustee to bump Aliyun KMS plugin

### DIFF
--- a/confidential-data-hub/hub/Cargo.toml
+++ b/confidential-data-hub/hub/Cargo.toml
@@ -38,10 +38,10 @@ async-trait.workspace = true
 attestation-agent = { path = "../../attestation-agent/attestation-agent", default-features = false }
 base64.workspace = true
 bincode = { workspace = true, optional = true }
-cfg-if = { workspace = true, optional = true }
+cfg-if.workspace = true
 chrono = { workspace = true, optional = true }
 clap = { workspace = true, features = ["derive"], optional = true }
-config = { workspace = true, optional = true }
+config.workspace = true
 const_format.workspace = true
 crypto.path = "../../attestation-agent/deps/crypto"
 ehsm_client = { git = "https://github.com/intel/ehsm", rev = "3454cac66b968a593c3edc43410c0b52416bbd3e", optional = true }
@@ -129,7 +129,7 @@ sev = ["bincode", "dep:sev", "prost", "tonic", "uuid"]
 ehsm = ["ehsm_client"]
 
 # Binary RPC type
-bin = ["anyhow", "cfg-if", "clap", "config", "env_logger", "serde"]
+bin = ["anyhow", "clap", "env_logger", "serde"]
 ttrpc = ["dep:ttrpc", "protobuf", "ttrpc-codegen", "tokio/signal"]
 grpc = ["prost", "tonic", "tokio/signal"]
 

--- a/confidential-data-hub/hub/Cargo.toml
+++ b/confidential-data-hub/hub/Cargo.toml
@@ -105,12 +105,14 @@ default = ["aliyun", "kbs", "bin", "ttrpc", "grpc", "cli"]
 
 # support aliyun stacks (KMS, ..)
 aliyun = [
+    "anyhow",
     "chrono",
     "hex",
     "p12",
     "prost",
     "reqwest/rustls-tls",
     "sha2",
+    "serde",
     "tempfile",
     "tonic",
     "url",


### PR DESCRIPTION
Not an ideal fix but allows trustee to keep both of its guest-components dependencies pointing to the same version.

More details: https://github.com/confidential-containers/guest-components/pull/816#issuecomment-2537669124