### PR TITLE
ci: allow CDH ci to be triggered by image-rs changes

### DIFF
--- a/.github/workflows/cdh_basic.yml
+++ b/.github/workflows/cdh_basic.yml
@@ -5,12 +5,14 @@ on:
     branches:
       - "main"
     paths:
+      - 'image-rs/**'
       - 'confidential-data-hub/**'
       - '.github/workflows/cdh_basic.yml'
       - 'Cargo.toml'
       - 'Cargo.lock'
   pull_request:
     paths:
+      - 'image-rs/**'
       - 'confidential-data-hub/**'
       - '.github/workflows/cdh_basic.yml'
       - 'Cargo.toml'


### PR DESCRIPTION
image-rs now is a dependency of CDH, thus any change upon image-rs should be test on CDH too.

related to #918 