### PR TITLE
CI: delete musl build for CDH

### DIFF
--- a/.github/workflows/cdh_basic.yml
+++ b/.github/workflows/cdh_basic.yml
@@ -71,11 +71,6 @@ jobs:
           mkdir -p ${HOME}/.local/bin
           make RESOURCE_PROVIDER=kbs,sev && make install PREFIX=${HOME}/.local
 
-      - name: Musl build
-        run: |
-          make LIBC=musl
-        if: ${{ startsWith(matrix.instance, 'ubuntu-24.04') }}
-
       - name: Run cargo test
         run: |
           sudo -E PATH=$PATH -s cargo test --features kbs,aliyun,sev,bin -p confidential-data-hub


### PR DESCRIPTION
Due to https://github.com/confidential-containers/guest-components/commit/29711496a38bad2cb9597d8954b306435f95a3e4 musl build will be triggered when the platform is not s390x and powerpc during the `Build and install` step. Thus we do not need this new round to do a duplicated musl build test.