### PR TITLE
resource-uri: make repository part of resource path mandatory in docs

### DIFF
--- a/attestation-agent/docs/KBS_URI.md
+++ b/attestation-agent/docs/KBS_URI.md
@@ -16,7 +16,7 @@ where:
 
 - `kbs://`: This is the fixed, custom KBS resource scheme. It indicates that this URI for a [CoCo KBS](https://github.com/confidential-containers/kbs/tree/main/kbs) resource.
 - `<kbs_host>:<kbs_port>`: This the KBS host address and port. It is either an IP address or a domain name, and an *optional* TCP/UDP port. Also can be treated as a `confidential resource registry`.
-- `<repository>/<type>/<tag>`: This is the resource path. Typically, `<repository>` would be a user name, `<type>` would be the type of the resource, and `<tag>` would help distinguish between different resource instances of the same type. The default value of `<repository>` is `default`.
+- `<repository>/<type>/<tag>`: This is the resource path. Typically, `<repository>` would be a user name, `<type>` would be the type of the resource, and `<tag>` would help distinguish between different resource instances of the same type.
 
 For example: `kbs://example.cckbs.org:8081/alice/decryption-key/1`
 


### PR DESCRIPTION
This is to align KBS URI documentation with trustee PR #720(*) which makes the repository part of resource path mandatory.  Note that no code change seems necessary here since the actual 'ResourceUri' implementation has in fact already treated the repository part as mandatory, bailing out if it was missing.

(*) https://github.com/confidential-containers/trustee/pull/720