### PR TITLE
ocicrypt-rs: fix doc comment format

### DIFF
--- a/ocicrypt-rs/src/helpers.rs
+++ b/ocicrypt-rs/src/helpers.rs
@@ -188,14 +188,14 @@ fn process_private_keyfiles(keyfiles_and_pwds: &[String]) -> Result<[Vec<Vec<u8>
 /// Create the CryptoConfig object that contains the necessary information to perform decryption.
 ///
 /// # Arguments
-/// * `keys` - decryption key info in following format:\
-///           - \<filename> \
-///           - \<filename>:file=\<passwordfile> \
-///           - \<filename>:pass=\<password> \
-///           - \<filename>:fd=\<filedescriptor> \
-///           - \<filename>:\<password> \
-///           - provider:<cmd/gprc/native>
-/// * `dec_recipients` - contains x509 cert for PKCS7 decryption.
+/// - `keys` - decryption key info in following format:\
+///   - \<filename> \
+///   - \<filename>:file=\<passwordfile> \
+///   - \<filename>:pass=\<password> \
+///   - \<filename>:fd=\<filedescriptor> \
+///   - \<filename>:\<password> \
+///   - provider:<cmd/gprc/native>
+/// - `dec_recipients` - contains x509 cert for PKCS7 decryption.
 pub fn create_decrypt_config(
     keys: Vec<String>,
     dec_recipients: Vec<String>,
@@ -242,13 +242,13 @@ pub fn create_decrypt_config(
 /// list of key paths of private keys to perform encryption.
 ///
 /// # Arguments
-/// * `recipients` - encryption key info in format protocol:value.\
-///           - jwe:\<keyfile> \
-///           - pkcs7:\<keyfile> \
-///           - pkcs11:\<keyfile> \
-///           - pgp: \<address> \
-///           - provider:<cmd/grpc/native>
-/// * `keys` - private keys potential needs for encryption.
+/// - `recipients` encryption key info in format protocol:value.\
+///   - jwe:\<keyfile> \
+///   - pkcs7:\<keyfile> \
+///   - pkcs11:\<keyfile> \
+///   - pgp: \<address> \
+///   - provider:<cmd/grpc/native>
+/// - `keys` private keys potential needs for encryption.
 pub fn create_encrypt_config(recipients: Vec<String>, keys: Vec<String>) -> Result<CryptoConfig> {
     let mut ec = EncryptConfig::default();
     let mut cc = CryptoConfig::default();


### PR DESCRIPTION
Some of our dependabot PRs are blocked by the linter complaining about the format of this content. Let's see if this fixes it.