### PR TITLE
toolchain: add rust toolchain file

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "1.80.0"


### PR DESCRIPTION
rust-toolchain will record the current cargo and rust toolchain version to build the project.

See https://rust-lang.github.io/rustup/overrides.html#the-toolchain-file for more details.

cc @larrydewey 