### PR TITLE
AA: set default URL field for coco_as and kbs token field

### DIFF
--- a/attestation-agent/attestation-agent/src/config/mod.rs
+++ b/attestation-agent/attestation-agent/src/config/mod.rs
@@ -95,6 +95,8 @@ impl TryFrom<&str> for Config {
             .set_default("eventlog_config.eventlog_algorithm", DEFAULT_EVENTLOG_HASH)?
             .set_default("eventlog_config.init_pcr", DEFAULT_PCR_INDEX)?
             .set_default("eventlog_config.enable_eventlog", "false")?
+            .set_default("token_configs.coco_as.url", "")?
+            .set_default("token_configs.kbs.url", "")?
             .build()?;
 
         let cfg = c.try_deserialize()?;


### PR DESCRIPTION
When we do not explicitly set the fields in AA's config file like

```
[token_configs.coco_as]
url = "http://127.0.0.1:8000"

...

[token_configs.kbs]
url = "https://127.0.0.1:8080"
```

The launch of AA will fail saying that the launch config is not valid. This is not expected in scenarios no attestation token is needed for AA, and users only rely on AA's get_evidence APIs. Some other scenarios are those where the specified Attestation Token will never be accessed.

In such scenarios the url fields do not matters, thus we set default values. Note that the url fields are used lazily when the get_token API is called, so it is safe to set an empty value.