### PR TITLE
Update SNP Attester

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -426,7 +426,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
- "sev 4.0.0",
+ "sev 6.0.0",
  "sha2 0.10.9",
  "strum 0.27.1",
  "tdx-attest-rs",
@@ -6169,6 +6169,30 @@ dependencies = [
  "libc",
  "openssl",
  "rdrand",
+ "serde",
+ "serde-big-array",
+ "serde_bytes",
+ "static_assertions",
+ "uuid",
+]
+
+[[package]]
+name = "sev"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20ac277517d8fffdf3c41096323ed705b3a7c75e397129c072fb448339839d0f"
+dependencies = [
+ "base64 0.22.1",
+ "bincode",
+ "bitfield 0.15.0",
+ "bitflags 1.3.2",
+ "byteorder",
+ "codicon",
+ "dirs",
+ "hex",
+ "iocuddle",
+ "lazy_static",
+ "libc",
  "serde",
  "serde-big-array",
  "serde_bytes",

--- a/attestation-agent/attester/Cargo.toml
+++ b/attestation-agent/attester/Cargo.toml
@@ -24,7 +24,7 @@ scroll = { version = "0.12.0", default-features = false, features = ["derive", "
 serde.workspace = true
 serde_json.workspace = true
 serde_with.workspace = true
-sev = { version = "4.0.0", default-features = false, features = ["snp"], optional = true }
+sev = { version = "6.0.0", default-features = false, features = ["snp"], optional = true }
 sha2.workspace = true
 strum.workspace = true
 tdx-attest-rs = { git = "https://github.com/intel/SGXDataCenterAttestationPrimitives", tag = "DCAP_1.22", optional = true }

--- a/attestation-agent/attester/src/snp/hostdata.rs
+++ b/attestation-agent/attester/src/snp/hostdata.rs
@@ -4,6 +4,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+use sev::firmware::guest::{AttestationReport, Firmware};
 use thiserror::Error;
 
 #[derive(Error, Debug)]
@@ -16,9 +17,9 @@ pub enum GetHostDataError {
 }
 
 pub fn get_snp_host_data() -> Result<[u8; 32], GetHostDataError> {
-    let mut firmware = sev::firmware::guest::Firmware::open()?;
+    let mut firmware = Firmware::open()?;
     let report_data: [u8; 64] = [0; 64];
-    let report = firmware.get_report(None, Some(report_data), Some(0))?;
-
-    Ok(report.host_data)
+    let report_bytes = firmware.get_report(None, Some(report_data), Some(0))?;
+    let report = AttestationReport::from_bytes(&report_bytes)?;
+    Ok(*report.host_data)
 }

--- a/attestation-agent/attester/src/snp/mod.rs
+++ b/attestation-agent/attester/src/snp/mod.rs
@@ -46,7 +46,8 @@ impl Attester for SnpAttester {
             .context("Failed to get attestation report")?;
 
         let evidence = SnpEvidence {
-            attestation_report: report,
+            attestation_report: AttestationReport::from_bytes(&report)
+                .context("Failed to parse attestation report")?,
             cert_chain: certs,
         };
 


### PR DESCRIPTION
Updated the SNP Attester to use version 6.0.0 of the VIRTEE SEV crate. Minor code adjustments were made to accommodate the library's new report-handling logic, but the overall functionality remains unchanged.

This will also add compatibility to the changes introduced in https://github.com/confidential-containers/trustee/pull/785, so both will need to be part of compatible releases.