### PR TITLE
Multi-Device Attestation (Take 2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -686,7 +686,7 @@ dependencies = [
  "bitflags 2.9.0",
  "cexpr",
  "clang-sys",
- "itertools 0.10.5",
+ "itertools 0.12.1",
  "log",
  "prettyplease",
  "proc-macro2",
@@ -3405,8 +3405,9 @@ dependencies = [
 
 [[package]]
 name = "kbs-types"
-version = "0.10.0"
-source = "git+https://github.com/fitzthum/kbs-types?branch=multi-device-composite#4eee602253c80e5eea1679aeded5927bb8f315db"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2be9fa1f64b3c8da5043cdc634007c6f7444b3ef1f3668f66b34180bdb398ec7"
 dependencies = [
  "base64 0.22.1",
  "serde",
@@ -7457,7 +7458,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -392,6 +392,7 @@ dependencies = [
  "cfg-if",
  "clap",
  "codicon",
+ "crypto",
  "csv-rs",
  "hex",
  "hyper 0.14.32",
@@ -3405,8 +3406,7 @@ dependencies = [
 [[package]]
 name = "kbs-types"
 version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db954f164e19a63a1eb7c04c46511167d68a5eb5025d4a435c1ba297f00dbf4"
+source = "git+https://github.com/fitzthum/kbs-types?branch=multi-device-composite#4eee602253c80e5eea1679aeded5927bb8f315db"
 dependencies = [
  "base64 0.22.1",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,8 +38,7 @@ hmac = "0.12.1"
 jwt-simple = { version = "0.12", default-features = false, features = [
     "pure-rust",
 ] }
-#kbs-types = "0.10.0"
-kbs-types = { git = "https://github.com/fitzthum/kbs-types", branch = "multi-device-composite" }
+kbs-types = "0.12.0"
 log = "0.4.27"
 nix = "0.30"
 openssl = "0.10"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,8 @@ hmac = "0.12.1"
 jwt-simple = { version = "0.12", default-features = false, features = [
     "pure-rust",
 ] }
-kbs-types = "0.10.0"
+#kbs-types = "0.10.0"
+kbs-types = { git = "https://github.com/fitzthum/kbs-types", branch = "multi-device-composite" }
 log = "0.4.27"
 nix = "0.30"
 openssl = "0.10"

--- a/attestation-agent/attestation-agent/src/bin/ttrpc_dep/server.rs
+++ b/attestation-agent/attestation-agent/src/bin/ttrpc_dep/server.rs
@@ -6,11 +6,15 @@
 use ::ttrpc::proto::Code;
 use async_trait::async_trait;
 use attestation_agent::{AttestationAPIs, AttestationAgent};
+use crypto::HashAlgorithm;
+use kbs_types::TeePubKey;
 use log::{debug, error};
+use std::str::FromStr;
 
 use crate::ttrpc_dep::ttrpc_protocol::{
     attestation_agent::{
-        ExtendRuntimeMeasurementRequest, ExtendRuntimeMeasurementResponse, GetEvidenceRequest,
+        ExtendRuntimeMeasurementRequest, ExtendRuntimeMeasurementResponse,
+        GetAdditionalEvidenceRequest, GetCompositeEvidenceRequest, GetEvidenceRequest,
         GetEvidenceResponse, GetTeeTypeRequest, GetTeeTypeResponse, GetTokenRequest,
         GetTokenResponse,
     },
@@ -63,6 +67,82 @@ impl AttestationAgentService for AA {
             .await
             .map_err(|e| {
                 error!("AA (ttrpc): get evidence failed:\n {e:?}");
+                let mut error_status = ::ttrpc::proto::Status::new();
+                error_status.set_code(Code::INTERNAL);
+                error_status
+                    .set_message(format!("[ERROR:{AGENT_NAME}] AA-KBC get evidence failed"));
+                ::ttrpc::Error::RpcStatus(error_status)
+            })?;
+
+        debug!("AA (ttrpc): Get evidence successfully!");
+
+        let mut reply = GetEvidenceResponse::new();
+        reply.Evidence = evidence;
+
+        ::ttrpc::Result::Ok(reply)
+    }
+
+    async fn get_additional_evidence(
+        &self,
+        _ctx: &::ttrpc::r#async::TtrpcContext,
+        req: GetAdditionalEvidenceRequest,
+    ) -> ::ttrpc::Result<GetEvidenceResponse> {
+        debug!("AA (ttrpc): get evidence ...");
+
+        let evidence = self
+            .inner
+            .get_additional_evidence(&req.RuntimeData)
+            .await
+            .map_err(|e| {
+                error!("AA (ttrpc): get evidence failed:\n {e:?}");
+                let mut error_status = ::ttrpc::proto::Status::new();
+                error_status.set_code(Code::INTERNAL);
+                error_status
+                    .set_message(format!("[ERROR:{AGENT_NAME}] AA-KBC get evidence failed"));
+                ::ttrpc::Error::RpcStatus(error_status)
+            })?;
+
+        debug!("AA (ttrpc): Get evidence successfully!");
+
+        let mut reply = GetEvidenceResponse::new();
+        reply.Evidence = evidence;
+
+        ::ttrpc::Result::Ok(reply)
+    }
+
+    async fn get_composite_evidence(
+        &self,
+        _ctx: &::ttrpc::r#async::TtrpcContext,
+        req: GetCompositeEvidenceRequest,
+    ) -> ::ttrpc::Result<GetEvidenceResponse> {
+        debug!("AA (ttrpc): get composite evidence ...");
+
+        let tee_pubkey: TeePubKey = serde_json::from_str(&req.TeePubKey).map_err(|e| {
+            error!("AA (ttrpc): get composite evidence failed:\n {e:?}");
+            let mut error_status = ::ttrpc::proto::Status::new();
+            error_status.set_code(Code::INTERNAL);
+            error_status.set_message(format!(
+                "[ERROR:{AGENT_NAME}] Failed to deserialize TeePubKey"
+            ));
+            ::ttrpc::Error::RpcStatus(error_status)
+        })?;
+
+        let hash_algorithm = HashAlgorithm::from_str(&req.HashAlgorithm).map_err(|e| {
+            error!("AA (ttrpc): get composite evidence failed:\n {e:?}");
+            let mut error_status = ::ttrpc::proto::Status::new();
+            error_status.set_code(Code::INTERNAL);
+            error_status.set_message(format!(
+                "[ERROR:{AGENT_NAME}] Failed to deserialize hash algorithm"
+            ));
+            ::ttrpc::Error::RpcStatus(error_status)
+        })?;
+
+        let evidence = self
+            .inner
+            .get_composite_evidence(tee_pubkey, req.Nonce, hash_algorithm)
+            .await
+            .map_err(|e| {
+                error!("AA (ttrpc): get composite evidence failed:\n {e:?}");
                 let mut error_status = ::ttrpc::proto::Status::new();
                 error_status.set_code(Code::INTERNAL);
                 error_status

--- a/attestation-agent/attestation-agent/src/bin/ttrpc_dep/ttrpc_protocol/attestation_agent.rs
+++ b/attestation-agent/attestation-agent/src/bin/ttrpc_dep/ttrpc_protocol/attestation_agent.rs
@@ -146,6 +146,286 @@ impl ::protobuf::reflect::ProtobufValue for GetEvidenceRequest {
     type RuntimeType = ::protobuf::reflect::rt::RuntimeTypeMessage<Self>;
 }
 
+// @@protoc_insertion_point(message:attestation_agent.GetAdditionalEvidenceRequest)
+#[derive(PartialEq,Clone,Default,Debug)]
+pub struct GetAdditionalEvidenceRequest {
+    // message fields
+    // @@protoc_insertion_point(field:attestation_agent.GetAdditionalEvidenceRequest.RuntimeData)
+    pub RuntimeData: ::std::vec::Vec<u8>,
+    // special fields
+    // @@protoc_insertion_point(special_field:attestation_agent.GetAdditionalEvidenceRequest.special_fields)
+    pub special_fields: ::protobuf::SpecialFields,
+}
+
+impl<'a> ::std::default::Default for &'a GetAdditionalEvidenceRequest {
+    fn default() -> &'a GetAdditionalEvidenceRequest {
+        <GetAdditionalEvidenceRequest as ::protobuf::Message>::default_instance()
+    }
+}
+
+impl GetAdditionalEvidenceRequest {
+    pub fn new() -> GetAdditionalEvidenceRequest {
+        ::std::default::Default::default()
+    }
+
+    fn generated_message_descriptor_data() -> ::protobuf::reflect::GeneratedMessageDescriptorData {
+        let mut fields = ::std::vec::Vec::with_capacity(1);
+        let mut oneofs = ::std::vec::Vec::with_capacity(0);
+        fields.push(::protobuf::reflect::rt::v2::make_simpler_field_accessor::<_, _>(
+            "RuntimeData",
+            |m: &GetAdditionalEvidenceRequest| { &m.RuntimeData },
+            |m: &mut GetAdditionalEvidenceRequest| { &mut m.RuntimeData },
+        ));
+        ::protobuf::reflect::GeneratedMessageDescriptorData::new_2::<GetAdditionalEvidenceRequest>(
+            "GetAdditionalEvidenceRequest",
+            fields,
+            oneofs,
+        )
+    }
+}
+
+impl ::protobuf::Message for GetAdditionalEvidenceRequest {
+    const NAME: &'static str = "GetAdditionalEvidenceRequest";
+
+    fn is_initialized(&self) -> bool {
+        true
+    }
+
+    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream<'_>) -> ::protobuf::Result<()> {
+        while let Some(tag) = is.read_raw_tag_or_eof()? {
+            match tag {
+                10 => {
+                    self.RuntimeData = is.read_bytes()?;
+                },
+                tag => {
+                    ::protobuf::rt::read_unknown_or_skip_group(tag, is, self.special_fields.mut_unknown_fields())?;
+                },
+            };
+        }
+        ::std::result::Result::Ok(())
+    }
+
+    // Compute sizes of nested messages
+    #[allow(unused_variables)]
+    fn compute_size(&self) -> u64 {
+        let mut my_size = 0;
+        if !self.RuntimeData.is_empty() {
+            my_size += ::protobuf::rt::bytes_size(1, &self.RuntimeData);
+        }
+        my_size += ::protobuf::rt::unknown_fields_size(self.special_fields.unknown_fields());
+        self.special_fields.cached_size().set(my_size as u32);
+        my_size
+    }
+
+    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream<'_>) -> ::protobuf::Result<()> {
+        if !self.RuntimeData.is_empty() {
+            os.write_bytes(1, &self.RuntimeData)?;
+        }
+        os.write_unknown_fields(self.special_fields.unknown_fields())?;
+        ::std::result::Result::Ok(())
+    }
+
+    fn special_fields(&self) -> &::protobuf::SpecialFields {
+        &self.special_fields
+    }
+
+    fn mut_special_fields(&mut self) -> &mut ::protobuf::SpecialFields {
+        &mut self.special_fields
+    }
+
+    fn new() -> GetAdditionalEvidenceRequest {
+        GetAdditionalEvidenceRequest::new()
+    }
+
+    fn clear(&mut self) {
+        self.RuntimeData.clear();
+        self.special_fields.clear();
+    }
+
+    fn default_instance() -> &'static GetAdditionalEvidenceRequest {
+        static instance: GetAdditionalEvidenceRequest = GetAdditionalEvidenceRequest {
+            RuntimeData: ::std::vec::Vec::new(),
+            special_fields: ::protobuf::SpecialFields::new(),
+        };
+        &instance
+    }
+}
+
+impl ::protobuf::MessageFull for GetAdditionalEvidenceRequest {
+    fn descriptor() -> ::protobuf::reflect::MessageDescriptor {
+        static descriptor: ::protobuf::rt::Lazy<::protobuf::reflect::MessageDescriptor> = ::protobuf::rt::Lazy::new();
+        descriptor.get(|| file_descriptor().message_by_package_relative_name("GetAdditionalEvidenceRequest").unwrap()).clone()
+    }
+}
+
+impl ::std::fmt::Display for GetAdditionalEvidenceRequest {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+        ::protobuf::text_format::fmt(self, f)
+    }
+}
+
+impl ::protobuf::reflect::ProtobufValue for GetAdditionalEvidenceRequest {
+    type RuntimeType = ::protobuf::reflect::rt::RuntimeTypeMessage<Self>;
+}
+
+// @@protoc_insertion_point(message:attestation_agent.GetCompositeEvidenceRequest)
+#[derive(PartialEq,Clone,Default,Debug)]
+pub struct GetCompositeEvidenceRequest {
+    // message fields
+    // @@protoc_insertion_point(field:attestation_agent.GetCompositeEvidenceRequest.TeePubKey)
+    pub TeePubKey: ::std::string::String,
+    // @@protoc_insertion_point(field:attestation_agent.GetCompositeEvidenceRequest.Nonce)
+    pub Nonce: ::std::string::String,
+    // @@protoc_insertion_point(field:attestation_agent.GetCompositeEvidenceRequest.HashAlgorithm)
+    pub HashAlgorithm: ::std::string::String,
+    // special fields
+    // @@protoc_insertion_point(special_field:attestation_agent.GetCompositeEvidenceRequest.special_fields)
+    pub special_fields: ::protobuf::SpecialFields,
+}
+
+impl<'a> ::std::default::Default for &'a GetCompositeEvidenceRequest {
+    fn default() -> &'a GetCompositeEvidenceRequest {
+        <GetCompositeEvidenceRequest as ::protobuf::Message>::default_instance()
+    }
+}
+
+impl GetCompositeEvidenceRequest {
+    pub fn new() -> GetCompositeEvidenceRequest {
+        ::std::default::Default::default()
+    }
+
+    fn generated_message_descriptor_data() -> ::protobuf::reflect::GeneratedMessageDescriptorData {
+        let mut fields = ::std::vec::Vec::with_capacity(3);
+        let mut oneofs = ::std::vec::Vec::with_capacity(0);
+        fields.push(::protobuf::reflect::rt::v2::make_simpler_field_accessor::<_, _>(
+            "TeePubKey",
+            |m: &GetCompositeEvidenceRequest| { &m.TeePubKey },
+            |m: &mut GetCompositeEvidenceRequest| { &mut m.TeePubKey },
+        ));
+        fields.push(::protobuf::reflect::rt::v2::make_simpler_field_accessor::<_, _>(
+            "Nonce",
+            |m: &GetCompositeEvidenceRequest| { &m.Nonce },
+            |m: &mut GetCompositeEvidenceRequest| { &mut m.Nonce },
+        ));
+        fields.push(::protobuf::reflect::rt::v2::make_simpler_field_accessor::<_, _>(
+            "HashAlgorithm",
+            |m: &GetCompositeEvidenceRequest| { &m.HashAlgorithm },
+            |m: &mut GetCompositeEvidenceRequest| { &mut m.HashAlgorithm },
+        ));
+        ::protobuf::reflect::GeneratedMessageDescriptorData::new_2::<GetCompositeEvidenceRequest>(
+            "GetCompositeEvidenceRequest",
+            fields,
+            oneofs,
+        )
+    }
+}
+
+impl ::protobuf::Message for GetCompositeEvidenceRequest {
+    const NAME: &'static str = "GetCompositeEvidenceRequest";
+
+    fn is_initialized(&self) -> bool {
+        true
+    }
+
+    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream<'_>) -> ::protobuf::Result<()> {
+        while let Some(tag) = is.read_raw_tag_or_eof()? {
+            match tag {
+                10 => {
+                    self.TeePubKey = is.read_string()?;
+                },
+                18 => {
+                    self.Nonce = is.read_string()?;
+                },
+                26 => {
+                    self.HashAlgorithm = is.read_string()?;
+                },
+                tag => {
+                    ::protobuf::rt::read_unknown_or_skip_group(tag, is, self.special_fields.mut_unknown_fields())?;
+                },
+            };
+        }
+        ::std::result::Result::Ok(())
+    }
+
+    // Compute sizes of nested messages
+    #[allow(unused_variables)]
+    fn compute_size(&self) -> u64 {
+        let mut my_size = 0;
+        if !self.TeePubKey.is_empty() {
+            my_size += ::protobuf::rt::string_size(1, &self.TeePubKey);
+        }
+        if !self.Nonce.is_empty() {
+            my_size += ::protobuf::rt::string_size(2, &self.Nonce);
+        }
+        if !self.HashAlgorithm.is_empty() {
+            my_size += ::protobuf::rt::string_size(3, &self.HashAlgorithm);
+        }
+        my_size += ::protobuf::rt::unknown_fields_size(self.special_fields.unknown_fields());
+        self.special_fields.cached_size().set(my_size as u32);
+        my_size
+    }
+
+    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream<'_>) -> ::protobuf::Result<()> {
+        if !self.TeePubKey.is_empty() {
+            os.write_string(1, &self.TeePubKey)?;
+        }
+        if !self.Nonce.is_empty() {
+            os.write_string(2, &self.Nonce)?;
+        }
+        if !self.HashAlgorithm.is_empty() {
+            os.write_string(3, &self.HashAlgorithm)?;
+        }
+        os.write_unknown_fields(self.special_fields.unknown_fields())?;
+        ::std::result::Result::Ok(())
+    }
+
+    fn special_fields(&self) -> &::protobuf::SpecialFields {
+        &self.special_fields
+    }
+
+    fn mut_special_fields(&mut self) -> &mut ::protobuf::SpecialFields {
+        &mut self.special_fields
+    }
+
+    fn new() -> GetCompositeEvidenceRequest {
+        GetCompositeEvidenceRequest::new()
+    }
+
+    fn clear(&mut self) {
+        self.TeePubKey.clear();
+        self.Nonce.clear();
+        self.HashAlgorithm.clear();
+        self.special_fields.clear();
+    }
+
+    fn default_instance() -> &'static GetCompositeEvidenceRequest {
+        static instance: GetCompositeEvidenceRequest = GetCompositeEvidenceRequest {
+            TeePubKey: ::std::string::String::new(),
+            Nonce: ::std::string::String::new(),
+            HashAlgorithm: ::std::string::String::new(),
+            special_fields: ::protobuf::SpecialFields::new(),
+        };
+        &instance
+    }
+}
+
+impl ::protobuf::MessageFull for GetCompositeEvidenceRequest {
+    fn descriptor() -> ::protobuf::reflect::MessageDescriptor {
+        static descriptor: ::protobuf::rt::Lazy<::protobuf::reflect::MessageDescriptor> = ::protobuf::rt::Lazy::new();
+        descriptor.get(|| file_descriptor().message_by_package_relative_name("GetCompositeEvidenceRequest").unwrap()).clone()
+    }
+}
+
+impl ::std::fmt::Display for GetCompositeEvidenceRequest {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+        ::protobuf::text_format::fmt(self, f)
+    }
+}
+
+impl ::protobuf::reflect::ProtobufValue for GetCompositeEvidenceRequest {
+    type RuntimeType = ::protobuf::reflect::rt::RuntimeTypeMessage<Self>;
+}
+
 // @@protoc_insertion_point(message:attestation_agent.GetEvidenceResponse)
 #[derive(PartialEq,Clone,Default,Debug)]
 pub struct GetEvidenceResponse {
@@ -1384,28 +1664,36 @@ impl ::protobuf::reflect::ProtobufValue for GetTeeTypeResponse {
 static file_descriptor_proto_data: &'static [u8] = b"\
     \n\x17attestation-agent.proto\x12\x11attestation_agent\"6\n\x12GetEviden\
     ceRequest\x12\x20\n\x0bRuntimeData\x18\x01\x20\x01(\x0cR\x0bRuntimeData\
-    \"1\n\x13GetEvidenceResponse\x12\x1a\n\x08Evidence\x18\x01\x20\x01(\x0cR\
-    \x08Evidence\"/\n\x0fGetTokenRequest\x12\x1c\n\tTokenType\x18\x01\x20\
-    \x01(\tR\tTokenType\"(\n\x10GetTokenResponse\x12\x14\n\x05Token\x18\x01\
-    \x20\x01(\x0cR\x05Token\"\xae\x01\n\x1fExtendRuntimeMeasurementRequest\
-    \x12\x16\n\x06Domain\x18\x01\x20\x01(\tR\x06Domain\x12\x1c\n\tOperation\
-    \x18\x02\x20\x01(\tR\tOperation\x12\x18\n\x07Content\x18\x03\x20\x01(\tR\
-    \x07Content\x12)\n\rRegisterIndex\x18\x04\x20\x01(\x04H\0R\rRegisterInde\
-    x\x88\x01\x01B\x10\n\x0e_RegisterIndex\"\"\n\x20ExtendRuntimeMeasurement\
-    Response\"K\n\x11InitDataPlaintext\x12\x18\n\x07Content\x18\x01\x20\x01(\
-    \x0cR\x07Content\x12\x1c\n\tAlgorithm\x18\x02\x20\x01(\tR\tAlgorithm\"-\
-    \n\x13BindInitDataRequest\x12\x16\n\x06Digest\x18\x01\x20\x01(\x0cR\x06D\
-    igest\"\x16\n\x14BindInitDataResponse\"\x13\n\x11GetTeeTypeRequest\"&\n\
-    \x12GetTeeTypeResponse\x12\x10\n\x03tee\x18\x01\x20\x01(\tR\x03tee2\x8e\
-    \x04\n\x17AttestationAgentService\x12\\\n\x0bGetEvidence\x12%.attestatio\
-    n_agent.GetEvidenceRequest\x1a&.attestation_agent.GetEvidenceResponse\
-    \x12S\n\x08GetToken\x12\".attestation_agent.GetTokenRequest\x1a#.attesta\
-    tion_agent.GetTokenResponse\x12\x83\x01\n\x18ExtendRuntimeMeasurement\
-    \x122.attestation_agent.ExtendRuntimeMeasurementRequest\x1a3.attestation\
-    _agent.ExtendRuntimeMeasurementResponse\x12_\n\x0cBindInitData\x12&.atte\
-    station_agent.BindInitDataRequest\x1a'.attestation_agent.BindInitDataRes\
-    ponse\x12Y\n\nGetTeeType\x12$.attestation_agent.GetTeeTypeRequest\x1a%.a\
-    ttestation_agent.GetTeeTypeResponseb\x06proto3\
+    \"@\n\x1cGetAdditionalEvidenceRequest\x12\x20\n\x0bRuntimeData\x18\x01\
+    \x20\x01(\x0cR\x0bRuntimeData\"w\n\x1bGetCompositeEvidenceRequest\x12\
+    \x1c\n\tTeePubKey\x18\x01\x20\x01(\tR\tTeePubKey\x12\x14\n\x05Nonce\x18\
+    \x02\x20\x01(\tR\x05Nonce\x12$\n\rHashAlgorithm\x18\x03\x20\x01(\tR\rHas\
+    hAlgorithm\"1\n\x13GetEvidenceResponse\x12\x1a\n\x08Evidence\x18\x01\x20\
+    \x01(\x0cR\x08Evidence\"/\n\x0fGetTokenRequest\x12\x1c\n\tTokenType\x18\
+    \x01\x20\x01(\tR\tTokenType\"(\n\x10GetTokenResponse\x12\x14\n\x05Token\
+    \x18\x01\x20\x01(\x0cR\x05Token\"\xae\x01\n\x1fExtendRuntimeMeasurementR\
+    equest\x12\x16\n\x06Domain\x18\x01\x20\x01(\tR\x06Domain\x12\x1c\n\tOper\
+    ation\x18\x02\x20\x01(\tR\tOperation\x12\x18\n\x07Content\x18\x03\x20\
+    \x01(\tR\x07Content\x12)\n\rRegisterIndex\x18\x04\x20\x01(\x04H\0R\rRegi\
+    sterIndex\x88\x01\x01B\x10\n\x0e_RegisterIndex\"\"\n\x20ExtendRuntimeMea\
+    surementResponse\"K\n\x11InitDataPlaintext\x12\x18\n\x07Content\x18\x01\
+    \x20\x01(\x0cR\x07Content\x12\x1c\n\tAlgorithm\x18\x02\x20\x01(\tR\tAlgo\
+    rithm\"-\n\x13BindInitDataRequest\x12\x16\n\x06Digest\x18\x01\x20\x01(\
+    \x0cR\x06Digest\"\x16\n\x14BindInitDataResponse\"\x13\n\x11GetTeeTypeReq\
+    uest\"&\n\x12GetTeeTypeResponse\x12\x10\n\x03tee\x18\x01\x20\x01(\tR\x03\
+    tee2\xf0\x05\n\x17AttestationAgentService\x12\\\n\x0bGetEvidence\x12%.at\
+    testation_agent.GetEvidenceRequest\x1a&.attestation_agent.GetEvidenceRes\
+    ponse\x12n\n\x14GetCompositeEvidence\x12..attestation_agent.GetComposite\
+    EvidenceRequest\x1a&.attestation_agent.GetEvidenceResponse\x12p\n\x15Get\
+    AdditionalEvidence\x12/.attestation_agent.GetAdditionalEvidenceRequest\
+    \x1a&.attestation_agent.GetEvidenceResponse\x12S\n\x08GetToken\x12\".att\
+    estation_agent.GetTokenRequest\x1a#.attestation_agent.GetTokenResponse\
+    \x12\x83\x01\n\x18ExtendRuntimeMeasurement\x122.attestation_agent.Extend\
+    RuntimeMeasurementRequest\x1a3.attestation_agent.ExtendRuntimeMeasuremen\
+    tResponse\x12_\n\x0cBindInitData\x12&.attestation_agent.BindInitDataRequ\
+    est\x1a'.attestation_agent.BindInitDataResponse\x12Y\n\nGetTeeType\x12$.\
+    attestation_agent.GetTeeTypeRequest\x1a%.attestation_agent.GetTeeTypeRes\
+    ponseb\x06proto3\
 ";
 
 /// `FileDescriptorProto` object which was a source for this generated file
@@ -1423,8 +1711,10 @@ pub fn file_descriptor() -> &'static ::protobuf::reflect::FileDescriptor {
     file_descriptor.get(|| {
         let generated_file_descriptor = generated_file_descriptor_lazy.get(|| {
             let mut deps = ::std::vec::Vec::with_capacity(0);
-            let mut messages = ::std::vec::Vec::with_capacity(11);
+            let mut messages = ::std::vec::Vec::with_capacity(13);
             messages.push(GetEvidenceRequest::generated_message_descriptor_data());
+            messages.push(GetAdditionalEvidenceRequest::generated_message_descriptor_data());
+            messages.push(GetCompositeEvidenceRequest::generated_message_descriptor_data());
             messages.push(GetEvidenceResponse::generated_message_descriptor_data());
             messages.push(GetTokenRequest::generated_message_descriptor_data());
             messages.push(GetTokenResponse::generated_message_descriptor_data());

--- a/attestation-agent/attestation-agent/src/bin/ttrpc_dep/ttrpc_protocol/attestation_agent_ttrpc.rs
+++ b/attestation-agent/attestation-agent/src/bin/ttrpc_dep/ttrpc_protocol/attestation_agent_ttrpc.rs
@@ -36,6 +36,16 @@ impl AttestationAgentServiceClient {
         ::ttrpc::async_client_request!(self, ctx, req, "attestation_agent.AttestationAgentService", "GetEvidence", cres);
     }
 
+    pub async fn get_composite_evidence(&self, ctx: ttrpc::context::Context, req: &super::attestation_agent::GetCompositeEvidenceRequest) -> ::ttrpc::Result<super::attestation_agent::GetEvidenceResponse> {
+        let mut cres = super::attestation_agent::GetEvidenceResponse::new();
+        ::ttrpc::async_client_request!(self, ctx, req, "attestation_agent.AttestationAgentService", "GetCompositeEvidence", cres);
+    }
+
+    pub async fn get_additional_evidence(&self, ctx: ttrpc::context::Context, req: &super::attestation_agent::GetAdditionalEvidenceRequest) -> ::ttrpc::Result<super::attestation_agent::GetEvidenceResponse> {
+        let mut cres = super::attestation_agent::GetEvidenceResponse::new();
+        ::ttrpc::async_client_request!(self, ctx, req, "attestation_agent.AttestationAgentService", "GetAdditionalEvidence", cres);
+    }
+
     pub async fn get_token(&self, ctx: ttrpc::context::Context, req: &super::attestation_agent::GetTokenRequest) -> ::ttrpc::Result<super::attestation_agent::GetTokenResponse> {
         let mut cres = super::attestation_agent::GetTokenResponse::new();
         ::ttrpc::async_client_request!(self, ctx, req, "attestation_agent.AttestationAgentService", "GetToken", cres);
@@ -65,6 +75,28 @@ struct GetEvidenceMethod {
 impl ::ttrpc::r#async::MethodHandler for GetEvidenceMethod {
     async fn handler(&self, ctx: ::ttrpc::r#async::TtrpcContext, req: ::ttrpc::Request) -> ::ttrpc::Result<::ttrpc::Response> {
         ::ttrpc::async_request_handler!(self, ctx, req, attestation_agent, GetEvidenceRequest, get_evidence);
+    }
+}
+
+struct GetCompositeEvidenceMethod {
+    service: Arc<dyn AttestationAgentService + Send + Sync>,
+}
+
+#[async_trait]
+impl ::ttrpc::r#async::MethodHandler for GetCompositeEvidenceMethod {
+    async fn handler(&self, ctx: ::ttrpc::r#async::TtrpcContext, req: ::ttrpc::Request) -> ::ttrpc::Result<::ttrpc::Response> {
+        ::ttrpc::async_request_handler!(self, ctx, req, attestation_agent, GetCompositeEvidenceRequest, get_composite_evidence);
+    }
+}
+
+struct GetAdditionalEvidenceMethod {
+    service: Arc<dyn AttestationAgentService + Send + Sync>,
+}
+
+#[async_trait]
+impl ::ttrpc::r#async::MethodHandler for GetAdditionalEvidenceMethod {
+    async fn handler(&self, ctx: ::ttrpc::r#async::TtrpcContext, req: ::ttrpc::Request) -> ::ttrpc::Result<::ttrpc::Response> {
+        ::ttrpc::async_request_handler!(self, ctx, req, attestation_agent, GetAdditionalEvidenceRequest, get_additional_evidence);
     }
 }
 
@@ -117,6 +149,12 @@ pub trait AttestationAgentService: Sync {
     async fn get_evidence(&self, _ctx: &::ttrpc::r#async::TtrpcContext, _: super::attestation_agent::GetEvidenceRequest) -> ::ttrpc::Result<super::attestation_agent::GetEvidenceResponse> {
         Err(::ttrpc::Error::RpcStatus(::ttrpc::get_status(::ttrpc::Code::NOT_FOUND, "/attestation_agent.AttestationAgentService/GetEvidence is not supported".to_string())))
     }
+    async fn get_composite_evidence(&self, _ctx: &::ttrpc::r#async::TtrpcContext, _: super::attestation_agent::GetCompositeEvidenceRequest) -> ::ttrpc::Result<super::attestation_agent::GetEvidenceResponse> {
+        Err(::ttrpc::Error::RpcStatus(::ttrpc::get_status(::ttrpc::Code::NOT_FOUND, "/attestation_agent.AttestationAgentService/GetCompositeEvidence is not supported".to_string())))
+    }
+    async fn get_additional_evidence(&self, _ctx: &::ttrpc::r#async::TtrpcContext, _: super::attestation_agent::GetAdditionalEvidenceRequest) -> ::ttrpc::Result<super::attestation_agent::GetEvidenceResponse> {
+        Err(::ttrpc::Error::RpcStatus(::ttrpc::get_status(::ttrpc::Code::NOT_FOUND, "/attestation_agent.AttestationAgentService/GetAdditionalEvidence is not supported".to_string())))
+    }
     async fn get_token(&self, _ctx: &::ttrpc::r#async::TtrpcContext, _: super::attestation_agent::GetTokenRequest) -> ::ttrpc::Result<super::attestation_agent::GetTokenResponse> {
         Err(::ttrpc::Error::RpcStatus(::ttrpc::get_status(::ttrpc::Code::NOT_FOUND, "/attestation_agent.AttestationAgentService/GetToken is not supported".to_string())))
     }
@@ -138,6 +176,12 @@ pub fn create_attestation_agent_service(service: Arc<dyn AttestationAgentService
 
     methods.insert("GetEvidence".to_string(),
                     Box::new(GetEvidenceMethod{service: service.clone()}) as Box<dyn ::ttrpc::r#async::MethodHandler + Send + Sync>);
+
+    methods.insert("GetCompositeEvidence".to_string(),
+                    Box::new(GetCompositeEvidenceMethod{service: service.clone()}) as Box<dyn ::ttrpc::r#async::MethodHandler + Send + Sync>);
+
+    methods.insert("GetAdditionalEvidence".to_string(),
+                    Box::new(GetAdditionalEvidenceMethod{service: service.clone()}) as Box<dyn ::ttrpc::r#async::MethodHandler + Send + Sync>);
 
     methods.insert("GetToken".to_string(),
                     Box::new(GetTokenMethod{service: service.clone()}) as Box<dyn ::ttrpc::r#async::MethodHandler + Send + Sync>);

--- a/attestation-agent/attestation-agent/src/lib.rs
+++ b/attestation-agent/attestation-agent/src/lib.rs
@@ -171,7 +171,7 @@ impl AttestationAPIs for AttestationAgent {
             .attester
             .primary_evidence(runtime_data.to_vec())
             .await?;
-        Ok(evidence.into_bytes())
+        Ok(evidence.to_string().into_bytes())
     }
 
     /// Extend runtime measurement register. Parameters

--- a/attestation-agent/attester/Cargo.toml
+++ b/attestation-agent/attester/Cargo.toml
@@ -14,6 +14,7 @@ az-tdx-vtpm = { version = "0.7.0", default-features = false, features = ["attest
 base64.workspace = true
 clap = { workspace = true, features = ["derive"], optional = true }
 cfg-if.workspace = true
+crypto.path = "../deps/crypto"
 hex.workspace = true
 iocuddle = { version = "0.1.1", optional = true }
 kbs-types.workspace = true

--- a/attestation-agent/attester/src/az_snp_vtpm/mod.rs
+++ b/attestation-agent/attester/src/az_snp_vtpm/mod.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-use super::{Attester, InitDataResult};
+use super::{Attester, InitDataResult, TeeEvidence};
 use anyhow::{bail, Context, Result};
 use az_snp_vtpm::{imds, is_snp_cvm, vtpm};
 use log::{debug, info};
@@ -31,7 +31,7 @@ struct Evidence {
 
 #[async_trait::async_trait]
 impl Attester for AzSnpVtpmAttester {
-    async fn get_evidence(&self, report_data: Vec<u8>) -> anyhow::Result<String> {
+    async fn get_evidence(&self, report_data: Vec<u8>) -> anyhow::Result<TeeEvidence> {
         let report = vtpm::get_report()?;
         let quote = vtpm::get_quote(&report_data)?;
         let certs = imds::get_certs()?;
@@ -43,7 +43,7 @@ impl Attester for AzSnpVtpmAttester {
             vcek,
         };
 
-        Ok(serde_json::to_string(&evidence)?)
+        Ok(serde_json::to_value(&evidence)?)
     }
 
     async fn bind_init_data(&self, init_data_digest: &[u8]) -> anyhow::Result<InitDataResult> {

--- a/attestation-agent/attester/src/az_tdx_vtpm/mod.rs
+++ b/attestation-agent/attester/src/az_tdx_vtpm/mod.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-use super::{Attester, InitDataResult};
+use super::{Attester, InitDataResult, TeeEvidence};
 use crate::az_snp_vtpm::utils;
 use anyhow::*;
 use az_tdx_vtpm::vtpm::Quote as TpmQuote;
@@ -34,7 +34,7 @@ struct Evidence {
 
 #[async_trait::async_trait]
 impl Attester for AzTdxVtpmAttester {
-    async fn get_evidence(&self, report_data: Vec<u8>) -> Result<String> {
+    async fn get_evidence(&self, report_data: Vec<u8>) -> Result<TeeEvidence> {
         let hcl_report_bytes = vtpm::get_report_with_report_data(&report_data)?;
         let hcl_report = hcl::HclReport::new(hcl_report_bytes.clone())?;
         let td_report = hcl_report.try_into()?;
@@ -47,7 +47,7 @@ impl Attester for AzTdxVtpmAttester {
             hcl_report: hcl_report_bytes,
             td_quote: td_quote_bytes,
         };
-        Ok(serde_json::to_string(&evidence)?)
+        Ok(serde_json::to_value(&evidence)?)
     }
 
     async fn bind_init_data(&self, init_data_digest: &[u8]) -> anyhow::Result<InitDataResult> {

--- a/attestation-agent/attester/src/bin/evidence_getter.rs
+++ b/attestation-agent/attester/src/bin/evidence_getter.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-use attester::*;
+use attester::CompositeAttester;
 use clap::Parser;
 use std::io::Read;
 use tokio::fs;
@@ -29,9 +29,7 @@ async fn main() {
     let mut report_data = vec![0u8; 64];
 
     let cli = Cli::parse();
-
-    let tee = detect_tee_type();
-    let attester: BoxedAttester = tee.try_into().expect("create attester failed");
+    let attester = CompositeAttester::new().expect("Failed to initialize attester.");
 
     match cli {
         Cli::Stdio => std::io::stdin()
@@ -51,7 +49,7 @@ async fn main() {
     }
 
     let evidence = attester
-        .get_evidence(report_data)
+        .primary_evidence(report_data)
         .await
         .expect("get evidence failed");
     println!("{evidence}");

--- a/attestation-agent/attester/src/cca/mod.rs
+++ b/attestation-agent/attester/src/cca/mod.rs
@@ -4,7 +4,7 @@
 //
 
 use super::tsm_report::*;
-use super::Attester;
+use super::{Attester, TeeEvidence};
 use anyhow::*;
 use serde::{Deserialize, Serialize};
 
@@ -28,7 +28,7 @@ struct CcaEvidence {
 
 #[async_trait::async_trait]
 impl Attester for CcaAttester {
-    async fn get_evidence(&self, mut challenge: Vec<u8>) -> Result<String> {
+    async fn get_evidence(&self, mut challenge: Vec<u8>) -> Result<TeeEvidence> {
         if challenge.len() > CCA_CHALLENGE_SIZE {
             bail!("CCA Attester: Challenge size must be {CCA_CHALLENGE_SIZE} bytes or less.");
         }
@@ -37,8 +37,7 @@ impl Attester for CcaAttester {
         let tsm = TsmReportPath::new(TsmReportProvider::Cca)?;
         let token = tsm.attestation_report(TsmReportData::Cca(challenge))?;
         let evidence = CcaEvidence { token };
-        let ev =
-            serde_json::to_string(&evidence).context("Serialization of CCA evidence failed")?;
+        let ev = serde_json::to_value(&evidence).context("Serialization of CCA evidence failed")?;
         Ok(ev)
     }
 }

--- a/attestation-agent/attester/src/csv/mod.rs
+++ b/attestation-agent/attester/src/csv/mod.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-use super::Attester;
+use super::{Attester, TeeEvidence};
 use anyhow::{bail, Context, Ok, Result};
 use codicon::Decoder;
 use csv_rs::{
@@ -41,7 +41,7 @@ pub struct CsvAttester {}
 
 #[async_trait::async_trait]
 impl Attester for CsvAttester {
-    async fn get_evidence(&self, mut report_data: Vec<u8>) -> Result<String> {
+    async fn get_evidence(&self, mut report_data: Vec<u8>) -> Result<TeeEvidence> {
         if report_data.len() > 64 {
             bail!("CSV Attester: Report data must be no more than 64 bytes");
         }
@@ -63,7 +63,7 @@ impl Attester for CsvAttester {
             cert_chain: CertificateChain { hsk, cek, pek },
             serial_number: report_signer.sn.to_vec(),
         };
-        serde_json::to_string(&evidence).context("Serialize CSV evidence failed")
+        serde_json::to_value(&evidence).context("Serialize CSV evidence failed")
     }
 }
 

--- a/attestation-agent/attester/src/lib.rs
+++ b/attestation-agent/attester/src/lib.rs
@@ -41,7 +41,7 @@ pub mod tsm_report;
 #[cfg(feature = "se-attester")]
 pub mod se;
 
-pub type BoxedAttester = Box<dyn Attester + Send + Sync>;
+pub(crate) type BoxedAttester = Box<dyn Attester + Send + Sync>;
 
 impl TryFrom<Tee> for BoxedAttester {
     type Error = anyhow::Error;
@@ -78,7 +78,7 @@ pub enum InitDataResult {
 }
 
 #[async_trait::async_trait]
-pub trait Attester {
+pub(crate) trait Attester {
     /// Call the hardware driver to get the Hardware specific evidence.
     /// The parameter `report_data` will be used as the user input of the
     /// evidence to avoid reply attack.

--- a/attestation-agent/attester/src/lib.rs
+++ b/attestation-agent/attester/src/lib.rs
@@ -4,7 +4,12 @@
 //
 
 use anyhow::*;
-use kbs_types::Tee;
+use kbs_types::{Tee, TeePubKey};
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+use std::collections::HashMap;
+
+use crypto::HashAlgorithm;
 
 pub mod sample;
 pub mod utils;
@@ -156,4 +161,163 @@ pub fn detect_tee_type() -> Tee {
          Attestation will continue using the fallback sample attester."
     );
     Tee::Sample
+}
+
+/// Get any additional TEEs that might be connected to the guest,
+/// such as a confidential device.
+pub fn detect_attestable_devices() -> Vec<Tee> {
+    // TODO
+    vec![]
+}
+
+/// The CompositeAttester struct is an interface to all the attesters
+/// that represent a confidential guest.
+pub struct CompositeAttester {
+    primary_attester_type: Tee,
+    primary_attester: BoxedAttester,
+    additional_attesters: HashMap<Tee, BoxedAttester>,
+}
+
+/// CompositeEvidence is the combined evidence from all the TEEs
+/// that represent the guest.
+#[derive(Serialize, Deserialize)]
+pub struct CompositeEvidence {
+    primary_evidence: String,
+    // The additional evidence is a map of Tee -> evidence,
+    // but we convert it to a string to avoid any inconsistencies
+    // with serialization. The string in this struct is exactly
+    // what is used to calculate the runtime data.
+    additional_evidence: String,
+}
+
+impl CompositeAttester {
+    pub fn new() -> Result<Self> {
+        let primary_tee = detect_tee_type();
+        let additional_tees = detect_attestable_devices();
+
+        let mut additional_attesters = HashMap::new();
+        for tee in additional_tees {
+            additional_attesters.insert(tee, tee.try_into()?);
+        }
+
+        Ok(Self {
+            primary_attester_type: primary_tee,
+            primary_attester: primary_tee.try_into()?,
+            additional_attesters,
+        })
+    }
+
+    pub fn tee_type(&self) -> Tee {
+        self.primary_attester_type
+    }
+
+    /// Get evidence for the guest.
+    /// If the guest has devices/TEEs beyond the CPU,
+    /// composite evidence will be generated.
+    /// The evidence from the additional devices will be collected first
+    /// so that it can be bound to the evidence of the primary device
+    /// via the report/runtime data.
+    pub async fn evidence(
+        &self,
+        tee_pubkey: TeePubKey,
+        nonce: String,
+        hash_algorithm: HashAlgorithm,
+    ) -> Result<String> {
+        let additional_evidence = match self.additional_attesters.is_empty() {
+            true => "".to_string(),
+            false => {
+                // Calculate the runtime data for devices, which does not include the
+                // device evidence.
+                let device_runtime_data = json!({
+                    "tee-pubkey": tee_pubkey,
+                    "nonce": nonce,
+                });
+
+                let device_runtime_data = serde_json::to_string(&device_runtime_data)
+                    .context("serialize runtime data failed")?;
+                let device_runtime_data = hash_algorithm.digest(device_runtime_data.as_bytes());
+
+                let additional_evidence = self.additional_evidence(device_runtime_data).await?;
+                serde_json::to_string(&additional_evidence)?
+            }
+        };
+
+        // Calculate the runtime data for the primary attester, which includes
+        // the device evidence retrieved above.
+        let primary_runtime_data = match self.primary_attester_type {
+            // SE handles the report data differently. As such, it does not support
+            // multi-device attestation.
+            Tee::Se => {
+                if !self.additional_attesters.is_empty() {
+                    bail!("Cannot attest multiple devices on s390x platform.")
+                }
+                nonce.into_bytes()
+            }
+            _ => {
+                let primary_runtime_data = json!({
+                    "tee-pubkey": tee_pubkey,
+                    "nonce": nonce,
+                    "additional-evidence": additional_evidence,
+                });
+                let primary_runtime_data = serde_json::to_string(&primary_runtime_data)
+                    .context("serialize runtime data failed")?;
+                hash_algorithm.digest(primary_runtime_data.as_bytes())
+            }
+        };
+        let primary_evidence = self.primary_evidence(primary_runtime_data).await?;
+
+        let guest_evidence = CompositeEvidence {
+            primary_evidence,
+            additional_evidence,
+        };
+        Ok(serde_json::to_string(&guest_evidence)?)
+    }
+
+    /// Get the evidence from the primary attester.
+    /// The caller is responsible for handling the report data.
+    pub async fn primary_evidence(&self, report_data: Vec<u8>) -> Result<String> {
+        self.primary_attester.get_evidence(report_data).await
+    }
+
+    /// Get the evidence from any additional attesters.
+    /// The caller is responsible for handling the report data.
+    pub async fn additional_evidence(&self, report_data: Vec<u8>) -> Result<HashMap<Tee, String>> {
+        let mut evidence = HashMap::new();
+
+        for (tee, attester) in &self.additional_attesters {
+            evidence.insert(*tee, attester.get_evidence(report_data.clone()).await?);
+        }
+
+        Ok(evidence)
+    }
+
+    /// Extend TEE specific dynamic measurement register
+    /// to enable dynamic measurement capabilities for input data at runtime.
+    /// This will be carried out via the primary attester only.
+    pub async fn extend_runtime_measurement(
+        &self,
+        event_digest: Vec<u8>,
+        register_index: u64,
+    ) -> Result<()> {
+        self.primary_attester
+            .extend_runtime_measurement(event_digest, register_index)
+            .await
+    }
+
+    /// Bind init data to the hardware evidence of the primary attester
+    /// either by checking that it matches an existing field or by extending
+    /// a PCR.
+    pub async fn bind_init_data(&self, init_data_digest: &[u8]) -> Result<InitDataResult> {
+        self.primary_attester.bind_init_data(init_data_digest).await
+    }
+
+    /// Get the current PCR value for some index.
+    /// This will be fulfilled via the primary attester.
+    /// It will raise an error if the primary attester
+    /// does not support runtime measurement.
+    pub async fn get_runtime_measurement(&self, pcr_index: u64) -> Result<Vec<u8>> {
+        self.primary_attester
+            .get_runtime_measurement(pcr_index)
+            .await
+    }
 }

--- a/attestation-agent/attester/src/lib.rs
+++ b/attestation-agent/attester/src/lib.rs
@@ -191,12 +191,12 @@ pub struct CompositeAttester {
 /// that represent the guest.
 #[derive(Serialize, Deserialize)]
 pub struct CompositeEvidence {
-    primary_evidence: TeeEvidence,
+    pub primary_evidence: TeeEvidence,
     // The additional evidence is a map of Tee -> evidence,
     // but we convert it to a string to avoid any inconsistencies
     // with serialization. The string in this struct is exactly
     // what is used to calculate the runtime data.
-    additional_evidence: String,
+    pub additional_evidence: String,
 }
 
 impl CompositeAttester {

--- a/attestation-agent/attester/src/lib.rs
+++ b/attestation-agent/attester/src/lib.rs
@@ -226,7 +226,7 @@ impl CompositeAttester {
     /// The evidence from the additional devices will be collected first
     /// so that it can be bound to the evidence of the primary device
     /// via the report/runtime data.
-    pub async fn evidence(
+    pub async fn composite_evidence(
         &self,
         tee_pubkey: TeePubKey,
         nonce: String,

--- a/attestation-agent/attester/src/sample/mod.rs
+++ b/attestation-agent/attester/src/sample/mod.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-use super::Attester;
+use super::{Attester, TeeEvidence};
 use anyhow::*;
 use base64::Engine;
 use serde::{Deserialize, Serialize};
@@ -25,12 +25,12 @@ pub struct SampleAttester {}
 
 #[async_trait::async_trait]
 impl Attester for SampleAttester {
-    async fn get_evidence(&self, report_data: Vec<u8>) -> Result<String> {
+    async fn get_evidence(&self, report_data: Vec<u8>) -> Result<TeeEvidence> {
         let evidence = SampleQuote {
             svn: "1".to_string(),
             report_data: base64::engine::general_purpose::STANDARD.encode(report_data),
         };
 
-        serde_json::to_string(&evidence).context("Serialize sample evidence failed")
+        serde_json::to_value(&evidence).context("Serialize sample evidence failed")
     }
 }

--- a/attestation-agent/attester/src/sample/mod.rs
+++ b/attestation-agent/attester/src/sample/mod.rs
@@ -6,6 +6,7 @@
 use super::{Attester, TeeEvidence};
 use anyhow::*;
 use base64::Engine;
+use log::warn;
 use serde::{Deserialize, Serialize};
 
 // Sample attester is always supported
@@ -32,5 +33,18 @@ impl Attester for SampleAttester {
         };
 
         serde_json::to_value(&evidence).context("Serialize sample evidence failed")
+    }
+
+    async fn extend_runtime_measurement(
+        &self,
+        _event_digest: Vec<u8>,
+        _register_index: u64,
+    ) -> Result<()> {
+        warn!("The Sample Attester does not extend any runtime measurement.");
+        Ok(())
+    }
+
+    async fn get_runtime_measurement(&self, _pcr_index: u64) -> Result<Vec<u8>> {
+        Ok(vec![])
     }
 }

--- a/attestation-agent/attester/src/sample_device/mod.rs
+++ b/attestation-agent/attester/src/sample_device/mod.rs
@@ -1,0 +1,37 @@
+// Copyright (c) 2025 IBM
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+use super::{Attester, TeeEvidence};
+use anyhow::*;
+use base64::Engine;
+use serde::{Deserialize, Serialize};
+use std::env;
+
+// The sample device attester can be enabled
+// vi an environment variable.
+pub fn detect_platform() -> bool {
+    env::var("ENABLE_SAMPLE_DEVICE").is_ok()
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+struct SampleDeviceEvidence {
+    svn: String,
+    report_data: String,
+}
+
+#[derive(Debug, Default)]
+pub struct SampleDeviceAttester {}
+
+#[async_trait::async_trait]
+impl Attester for SampleDeviceAttester {
+    async fn get_evidence(&self, report_data: Vec<u8>) -> Result<TeeEvidence> {
+        let evidence = SampleDeviceEvidence {
+            svn: "2".to_string(),
+            report_data: base64::engine::general_purpose::STANDARD.encode(report_data),
+        };
+
+        serde_json::to_value(&evidence).context("Failed to serialize sample evidence.")
+    }
+}

--- a/attestation-agent/attester/src/se/mod.rs
+++ b/attestation-agent/attester/src/se/mod.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-use super::Attester;
+use super::{Attester, TeeEvidence};
 use anyhow::*;
 use log::debug;
 use pv::{
@@ -63,7 +63,7 @@ pub struct SeAttester {}
 
 #[async_trait::async_trait]
 impl Attester for SeAttester {
-    async fn get_evidence(&self, req: Vec<u8>) -> Result<String> {
+    async fn get_evidence(&self, req: Vec<u8>) -> Result<TeeEvidence> {
         // req is serialized SeAttestationRequest String bytes
         let request: SeAttestationRequest = serde_json::from_slice(&req)?;
         let SeAttestationRequest {
@@ -101,6 +101,6 @@ impl Attester for SeAttester {
         };
 
         debug!("response json: {response:#?}");
-        Ok(serde_json::to_string(&response)?)
+        Ok(serde_json::to_value(&response)?)
     }
 }

--- a/attestation-agent/attester/src/sgx_dcap/mod.rs
+++ b/attestation-agent/attester/src/sgx_dcap/mod.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-use super::Attester;
+use super::{Attester, TeeEvidence};
 use anyhow::{bail, Context, Result};
 use base64::Engine;
 use occlum_dcap::{sgx_report_data_t, DcapQuote};
@@ -47,7 +47,7 @@ pub struct SgxDcapAttester {}
 
 #[async_trait::async_trait]
 impl Attester for SgxDcapAttester {
-    async fn get_evidence(&self, mut report_data: Vec<u8>) -> Result<String> {
+    async fn get_evidence(&self, mut report_data: Vec<u8>) -> Result<TeeEvidence> {
         if report_data.len() > 64 {
             bail!("SGX Attester: Report data should be SHA384 base64 String");
         }
@@ -81,7 +81,7 @@ impl Attester for SgxDcapAttester {
             quote: base64::engine::general_purpose::STANDARD.encode(quote),
         };
 
-        serde_json::to_string(&evidence).context("Serialize SGX DCAP Attester evidence failed")
+        serde_json::to_value(&evidence).context("Serialize SGX DCAP Attester evidence failed")
     }
 }
 

--- a/attestation-agent/attester/src/snp/mod.rs
+++ b/attestation-agent/attester/src/snp/mod.rs
@@ -6,7 +6,7 @@
 use crate::utils::pad;
 use crate::InitDataResult;
 
-use super::Attester;
+use super::{Attester, TeeEvidence};
 use anyhow::*;
 use serde::{Deserialize, Serialize};
 use sev::firmware::guest::AttestationReport;
@@ -31,7 +31,7 @@ pub struct SnpAttester {}
 
 #[async_trait::async_trait]
 impl Attester for SnpAttester {
-    async fn get_evidence(&self, mut report_data: Vec<u8>) -> Result<String> {
+    async fn get_evidence(&self, mut report_data: Vec<u8>) -> Result<TeeEvidence> {
         if report_data.len() > 64 {
             bail!("SNP Attester: Report data must be no more than 64 bytes");
         }
@@ -51,7 +51,7 @@ impl Attester for SnpAttester {
             cert_chain: certs,
         };
 
-        serde_json::to_string(&evidence).context("Serialize SNP evidence failed")
+        serde_json::to_value(&evidence).context("Serialize SNP evidence failed")
     }
 
     async fn bind_init_data(&self, init_data_digest: &[u8]) -> Result<InitDataResult> {

--- a/attestation-agent/attester/src/tdx/mod.rs
+++ b/attestation-agent/attester/src/tdx/mod.rs
@@ -4,7 +4,7 @@
 //
 
 use super::tsm_report::*;
-use super::Attester;
+use super::{Attester, TeeEvidence};
 use crate::utils::pad;
 use crate::InitDataResult;
 use anyhow::*;
@@ -127,7 +127,7 @@ impl TdxAttester {
 
 #[async_trait::async_trait]
 impl Attester for TdxAttester {
-    async fn get_evidence(&self, mut report_data: Vec<u8>) -> Result<String> {
+    async fn get_evidence(&self, mut report_data: Vec<u8>) -> Result<TeeEvidence> {
         if report_data.len() > TDX_REPORT_DATA_SIZE {
             bail!("TDX Attester: Report data must be no more than {TDX_REPORT_DATA_SIZE} bytes");
         }
@@ -170,7 +170,7 @@ impl Attester for TdxAttester {
             aa_eventlog,
         };
 
-        serde_json::to_string(&evidence).context("Serialize TDX evidence failed")
+        serde_json::to_value(&evidence).context("Serialize TDX evidence failed")
     }
 
     async fn extend_runtime_measurement(

--- a/attestation-agent/kbs_protocol/src/builder.rs
+++ b/attestation-agent/kbs_protocol/src/builder.rs
@@ -101,7 +101,7 @@ impl<T> KbsClientBuilder<T> {
         };
 
         let client = KbsClient {
-            _tee: ClientTee::Unitialized,
+            _tee: ClientTee::Uninitialized,
             tee_key,
             token,
             provider: self.provider,

--- a/attestation-agent/kbs_protocol/src/client/mod.rs
+++ b/attestation-agent/kbs_protocol/src/client/mod.rs
@@ -24,8 +24,8 @@ use kbs_types::Tee;
 use crate::{keypair::TeeKeyPair, token_provider::Token};
 
 pub(crate) enum ClientTee {
-    Unitialized,
-    _Initializated(Tee),
+    Uninitialized,
+    _Initialized(Tee),
 }
 
 /// This Client is used to connect to the remote KBS.

--- a/attestation-agent/kbs_protocol/src/client/mod.rs
+++ b/attestation-agent/kbs_protocol/src/client/mod.rs
@@ -48,7 +48,7 @@ pub struct KbsClient<T> {
     pub(crate) token: Option<Token>,
 }
 
-pub const KBS_PROTOCOL_VERSION: &str = "0.2.0";
+pub const KBS_PROTOCOL_VERSION: &str = "0.3.0";
 
 pub const KBS_GET_RESOURCE_MAX_ATTEMPT: u64 = 3;
 

--- a/attestation-agent/kbs_protocol/src/client/rcar_client.rs
+++ b/attestation-agent/kbs_protocol/src/client/rcar_client.rs
@@ -144,12 +144,12 @@ impl KbsClient<Box<dyn EvidenceProvider>> {
         let auth_endpoint = format!("{}/{KBS_PREFIX}/auth", self.kbs_host_url);
 
         let tee = match &self._tee {
-            ClientTee::Unitialized => {
+            ClientTee::Uninitialized => {
                 let tee = self.provider.get_tee_type().await?;
-                self._tee = ClientTee::_Initializated(tee);
+                self._tee = ClientTee::_Initialized(tee);
                 tee
             }
-            ClientTee::_Initializated(tee) => *tee,
+            ClientTee::_Initialized(tee) => *tee,
         };
 
         let request = build_request(tee).await;

--- a/attestation-agent/kbs_protocol/src/evidence_provider/aa_ttrpc.rs
+++ b/attestation-agent/kbs_protocol/src/evidence_provider/aa_ttrpc.rs
@@ -11,7 +11,7 @@ use ttrpc::context;
 
 use crate::{
     ttrpc_protos::{
-        attestation_agent::{GetEvidenceRequest, GetTeeTypeRequest},
+        attestation_agent::{GetCompositeEvidenceRequest, GetTeeTypeRequest},
         attestation_agent_ttrpc::AttestationAgentServiceClient,
     },
     Error, Result,
@@ -50,7 +50,7 @@ impl EvidenceProvider for AAEvidenceProvider {
         let pubkey_string = serde_json::to_string(&tee_pubkey).map_err(|e| {
             Error::AAEvidenceProvider(format!("Failed to serialize Tee Pub Key: {e}"))
         })?;
-        let req = GetEvidenceRequest {
+        let req = GetCompositeEvidenceRequest {
             TeePubKey: pubkey_string,
             Nonce: nonce,
             HashAlgorithm: hash_algorithm.to_string(),
@@ -58,7 +58,7 @@ impl EvidenceProvider for AAEvidenceProvider {
         };
         let res = self
             .client
-            .get_evidence(
+            .get_composite_evidence(
                 context::with_timeout(AA_TTRPC_TIMEOUT_SECONDS * 1000 * 1000 * 1000),
                 &req,
             )

--- a/attestation-agent/kbs_protocol/src/evidence_provider/mock.rs
+++ b/attestation-agent/kbs_protocol/src/evidence_provider/mock.rs
@@ -4,7 +4,8 @@
 //
 
 use async_trait::async_trait;
-use kbs_types::Tee;
+use crypto::HashAlgorithm;
+use kbs_types::{Tee, TeePubKey};
 
 use super::EvidenceProvider;
 
@@ -15,7 +16,12 @@ pub struct MockedEvidenceProvider {}
 
 #[async_trait]
 impl EvidenceProvider for MockedEvidenceProvider {
-    async fn get_evidence(&self, _runtime_data: Vec<u8>) -> Result<String> {
+    async fn get_evidence(
+        &self,
+        _tee_pubkey: TeePubKey,
+        _nonce: String,
+        _hash_algorithm: HashAlgorithm,
+    ) -> Result<String> {
         Ok("test evidence".into())
     }
 

--- a/attestation-agent/kbs_protocol/src/evidence_provider/mod.rs
+++ b/attestation-agent/kbs_protocol/src/evidence_provider/mod.rs
@@ -16,12 +16,18 @@ pub use aa_ttrpc::*;
 
 use crate::Result;
 use async_trait::async_trait;
-use kbs_types::Tee;
+use crypto::HashAlgorithm;
+use kbs_types::{Tee, TeePubKey};
 
 #[async_trait]
 pub trait EvidenceProvider: Send + Sync {
     /// Get evidence with as runtime data (report data, challege)
-    async fn get_evidence(&self, runtime_data: Vec<u8>) -> Result<String>;
+    async fn get_evidence(
+        &self,
+        tee_pubkey: TeePubKey,
+        nonce: String,
+        hash_algorithm: HashAlgorithm,
+    ) -> Result<String>;
 
     /// Get the underlying Tee type
     async fn get_tee_type(&self) -> Result<Tee>;

--- a/attestation-agent/kbs_protocol/src/evidence_provider/native.rs
+++ b/attestation-agent/kbs_protocol/src/evidence_provider/native.rs
@@ -31,7 +31,7 @@ impl EvidenceProvider for NativeEvidenceProvider {
         hash_algorithm: HashAlgorithm,
     ) -> Result<String> {
         self.0
-            .evidence(tee_pubkey, nonce, hash_algorithm)
+            .composite_evidence(tee_pubkey, nonce, hash_algorithm)
             .await
             .map_err(|e| Error::GetEvidence(e.to_string()))
     }

--- a/attestation-agent/kbs_protocol/src/ttrpc_protos/attestation_agent.rs
+++ b/attestation-agent/kbs_protocol/src/ttrpc_protos/attestation_agent.rs
@@ -28,8 +28,12 @@ const _PROTOBUF_VERSION_CHECK: () = ::protobuf::VERSION_3_7_1;
 #[derive(PartialEq,Clone,Default,Debug)]
 pub struct GetEvidenceRequest {
     // message fields
-    // @@protoc_insertion_point(field:attestation_agent.GetEvidenceRequest.RuntimeData)
-    pub RuntimeData: ::std::vec::Vec<u8>,
+    // @@protoc_insertion_point(field:attestation_agent.GetEvidenceRequest.TeePubKey)
+    pub TeePubKey: ::std::string::String,
+    // @@protoc_insertion_point(field:attestation_agent.GetEvidenceRequest.Nonce)
+    pub Nonce: ::std::string::String,
+    // @@protoc_insertion_point(field:attestation_agent.GetEvidenceRequest.HashAlgorithm)
+    pub HashAlgorithm: ::std::string::String,
     // special fields
     // @@protoc_insertion_point(special_field:attestation_agent.GetEvidenceRequest.special_fields)
     pub special_fields: ::protobuf::SpecialFields,
@@ -47,12 +51,22 @@ impl GetEvidenceRequest {
     }
 
     fn generated_message_descriptor_data() -> ::protobuf::reflect::GeneratedMessageDescriptorData {
-        let mut fields = ::std::vec::Vec::with_capacity(1);
+        let mut fields = ::std::vec::Vec::with_capacity(3);
         let mut oneofs = ::std::vec::Vec::with_capacity(0);
         fields.push(::protobuf::reflect::rt::v2::make_simpler_field_accessor::<_, _>(
-            "RuntimeData",
-            |m: &GetEvidenceRequest| { &m.RuntimeData },
-            |m: &mut GetEvidenceRequest| { &mut m.RuntimeData },
+            "TeePubKey",
+            |m: &GetEvidenceRequest| { &m.TeePubKey },
+            |m: &mut GetEvidenceRequest| { &mut m.TeePubKey },
+        ));
+        fields.push(::protobuf::reflect::rt::v2::make_simpler_field_accessor::<_, _>(
+            "Nonce",
+            |m: &GetEvidenceRequest| { &m.Nonce },
+            |m: &mut GetEvidenceRequest| { &mut m.Nonce },
+        ));
+        fields.push(::protobuf::reflect::rt::v2::make_simpler_field_accessor::<_, _>(
+            "HashAlgorithm",
+            |m: &GetEvidenceRequest| { &m.HashAlgorithm },
+            |m: &mut GetEvidenceRequest| { &mut m.HashAlgorithm },
         ));
         ::protobuf::reflect::GeneratedMessageDescriptorData::new_2::<GetEvidenceRequest>(
             "GetEvidenceRequest",
@@ -73,7 +87,13 @@ impl ::protobuf::Message for GetEvidenceRequest {
         while let Some(tag) = is.read_raw_tag_or_eof()? {
             match tag {
                 10 => {
-                    self.RuntimeData = is.read_bytes()?;
+                    self.TeePubKey = is.read_string()?;
+                },
+                18 => {
+                    self.Nonce = is.read_string()?;
+                },
+                26 => {
+                    self.HashAlgorithm = is.read_string()?;
                 },
                 tag => {
                     ::protobuf::rt::read_unknown_or_skip_group(tag, is, self.special_fields.mut_unknown_fields())?;
@@ -87,8 +107,14 @@ impl ::protobuf::Message for GetEvidenceRequest {
     #[allow(unused_variables)]
     fn compute_size(&self) -> u64 {
         let mut my_size = 0;
-        if !self.RuntimeData.is_empty() {
-            my_size += ::protobuf::rt::bytes_size(1, &self.RuntimeData);
+        if !self.TeePubKey.is_empty() {
+            my_size += ::protobuf::rt::string_size(1, &self.TeePubKey);
+        }
+        if !self.Nonce.is_empty() {
+            my_size += ::protobuf::rt::string_size(2, &self.Nonce);
+        }
+        if !self.HashAlgorithm.is_empty() {
+            my_size += ::protobuf::rt::string_size(3, &self.HashAlgorithm);
         }
         my_size += ::protobuf::rt::unknown_fields_size(self.special_fields.unknown_fields());
         self.special_fields.cached_size().set(my_size as u32);
@@ -96,8 +122,14 @@ impl ::protobuf::Message for GetEvidenceRequest {
     }
 
     fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream<'_>) -> ::protobuf::Result<()> {
-        if !self.RuntimeData.is_empty() {
-            os.write_bytes(1, &self.RuntimeData)?;
+        if !self.TeePubKey.is_empty() {
+            os.write_string(1, &self.TeePubKey)?;
+        }
+        if !self.Nonce.is_empty() {
+            os.write_string(2, &self.Nonce)?;
+        }
+        if !self.HashAlgorithm.is_empty() {
+            os.write_string(3, &self.HashAlgorithm)?;
         }
         os.write_unknown_fields(self.special_fields.unknown_fields())?;
         ::std::result::Result::Ok(())
@@ -116,13 +148,17 @@ impl ::protobuf::Message for GetEvidenceRequest {
     }
 
     fn clear(&mut self) {
-        self.RuntimeData.clear();
+        self.TeePubKey.clear();
+        self.Nonce.clear();
+        self.HashAlgorithm.clear();
         self.special_fields.clear();
     }
 
     fn default_instance() -> &'static GetEvidenceRequest {
         static instance: GetEvidenceRequest = GetEvidenceRequest {
-            RuntimeData: ::std::vec::Vec::new(),
+            TeePubKey: ::std::string::String::new(),
+            Nonce: ::std::string::String::new(),
+            HashAlgorithm: ::std::string::String::new(),
             special_fields: ::protobuf::SpecialFields::new(),
         };
         &instance
@@ -1382,30 +1418,31 @@ impl ::protobuf::reflect::ProtobufValue for GetTeeTypeResponse {
 }
 
 static file_descriptor_proto_data: &'static [u8] = b"\
-    \n\x17attestation-agent.proto\x12\x11attestation_agent\"6\n\x12GetEviden\
-    ceRequest\x12\x20\n\x0bRuntimeData\x18\x01\x20\x01(\x0cR\x0bRuntimeData\
-    \"1\n\x13GetEvidenceResponse\x12\x1a\n\x08Evidence\x18\x01\x20\x01(\x0cR\
-    \x08Evidence\"/\n\x0fGetTokenRequest\x12\x1c\n\tTokenType\x18\x01\x20\
-    \x01(\tR\tTokenType\"(\n\x10GetTokenResponse\x12\x14\n\x05Token\x18\x01\
-    \x20\x01(\x0cR\x05Token\"\xae\x01\n\x1fExtendRuntimeMeasurementRequest\
-    \x12\x16\n\x06Domain\x18\x01\x20\x01(\tR\x06Domain\x12\x1c\n\tOperation\
-    \x18\x02\x20\x01(\tR\tOperation\x12\x18\n\x07Content\x18\x03\x20\x01(\tR\
-    \x07Content\x12)\n\rRegisterIndex\x18\x04\x20\x01(\x04H\0R\rRegisterInde\
-    x\x88\x01\x01B\x10\n\x0e_RegisterIndex\"\"\n\x20ExtendRuntimeMeasurement\
-    Response\"K\n\x11InitDataPlaintext\x12\x18\n\x07Content\x18\x01\x20\x01(\
-    \x0cR\x07Content\x12\x1c\n\tAlgorithm\x18\x02\x20\x01(\tR\tAlgorithm\"-\
-    \n\x13BindInitDataRequest\x12\x16\n\x06Digest\x18\x01\x20\x01(\x0cR\x06D\
-    igest\"\x16\n\x14BindInitDataResponse\"\x13\n\x11GetTeeTypeRequest\"&\n\
-    \x12GetTeeTypeResponse\x12\x10\n\x03tee\x18\x01\x20\x01(\tR\x03tee2\x8e\
-    \x04\n\x17AttestationAgentService\x12\\\n\x0bGetEvidence\x12%.attestatio\
-    n_agent.GetEvidenceRequest\x1a&.attestation_agent.GetEvidenceResponse\
-    \x12S\n\x08GetToken\x12\".attestation_agent.GetTokenRequest\x1a#.attesta\
-    tion_agent.GetTokenResponse\x12\x83\x01\n\x18ExtendRuntimeMeasurement\
-    \x122.attestation_agent.ExtendRuntimeMeasurementRequest\x1a3.attestation\
-    _agent.ExtendRuntimeMeasurementResponse\x12_\n\x0cBindInitData\x12&.atte\
-    station_agent.BindInitDataRequest\x1a'.attestation_agent.BindInitDataRes\
-    ponse\x12Y\n\nGetTeeType\x12$.attestation_agent.GetTeeTypeRequest\x1a%.a\
-    ttestation_agent.GetTeeTypeResponseb\x06proto3\
+    \n\x17attestation-agent.proto\x12\x11attestation_agent\"n\n\x12GetEviden\
+    ceRequest\x12\x1c\n\tTeePubKey\x18\x01\x20\x01(\tR\tTeePubKey\x12\x14\n\
+    \x05Nonce\x18\x02\x20\x01(\tR\x05Nonce\x12$\n\rHashAlgorithm\x18\x03\x20\
+    \x01(\tR\rHashAlgorithm\"1\n\x13GetEvidenceResponse\x12\x1a\n\x08Evidenc\
+    e\x18\x01\x20\x01(\x0cR\x08Evidence\"/\n\x0fGetTokenRequest\x12\x1c\n\tT\
+    okenType\x18\x01\x20\x01(\tR\tTokenType\"(\n\x10GetTokenResponse\x12\x14\
+    \n\x05Token\x18\x01\x20\x01(\x0cR\x05Token\"\xae\x01\n\x1fExtendRuntimeM\
+    easurementRequest\x12\x16\n\x06Domain\x18\x01\x20\x01(\tR\x06Domain\x12\
+    \x1c\n\tOperation\x18\x02\x20\x01(\tR\tOperation\x12\x18\n\x07Content\
+    \x18\x03\x20\x01(\tR\x07Content\x12)\n\rRegisterIndex\x18\x04\x20\x01(\
+    \x04H\0R\rRegisterIndex\x88\x01\x01B\x10\n\x0e_RegisterIndex\"\"\n\x20Ex\
+    tendRuntimeMeasurementResponse\"K\n\x11InitDataPlaintext\x12\x18\n\x07Co\
+    ntent\x18\x01\x20\x01(\x0cR\x07Content\x12\x1c\n\tAlgorithm\x18\x02\x20\
+    \x01(\tR\tAlgorithm\"-\n\x13BindInitDataRequest\x12\x16\n\x06Digest\x18\
+    \x01\x20\x01(\x0cR\x06Digest\"\x16\n\x14BindInitDataResponse\"\x13\n\x11\
+    GetTeeTypeRequest\"&\n\x12GetTeeTypeResponse\x12\x10\n\x03tee\x18\x01\
+    \x20\x01(\tR\x03tee2\x8e\x04\n\x17AttestationAgentService\x12\\\n\x0bGet\
+    Evidence\x12%.attestation_agent.GetEvidenceRequest\x1a&.attestation_agen\
+    t.GetEvidenceResponse\x12S\n\x08GetToken\x12\".attestation_agent.GetToke\
+    nRequest\x1a#.attestation_agent.GetTokenResponse\x12\x83\x01\n\x18Extend\
+    RuntimeMeasurement\x122.attestation_agent.ExtendRuntimeMeasurementReques\
+    t\x1a3.attestation_agent.ExtendRuntimeMeasurementResponse\x12_\n\x0cBind\
+    InitData\x12&.attestation_agent.BindInitDataRequest\x1a'.attestation_age\
+    nt.BindInitDataResponse\x12Y\n\nGetTeeType\x12$.attestation_agent.GetTee\
+    TypeRequest\x1a%.attestation_agent.GetTeeTypeResponseb\x06proto3\
 ";
 
 /// `FileDescriptorProto` object which was a source for this generated file

--- a/attestation-agent/kbs_protocol/src/ttrpc_protos/attestation_agent.rs
+++ b/attestation-agent/kbs_protocol/src/ttrpc_protos/attestation_agent.rs
@@ -24,29 +24,29 @@
 /// of protobuf runtime.
 const _PROTOBUF_VERSION_CHECK: () = ::protobuf::VERSION_3_7_1;
 
-// @@protoc_insertion_point(message:attestation_agent.GetEvidenceRequest)
+// @@protoc_insertion_point(message:attestation_agent.GetCompositeEvidenceRequest)
 #[derive(PartialEq,Clone,Default,Debug)]
-pub struct GetEvidenceRequest {
+pub struct GetCompositeEvidenceRequest {
     // message fields
-    // @@protoc_insertion_point(field:attestation_agent.GetEvidenceRequest.TeePubKey)
+    // @@protoc_insertion_point(field:attestation_agent.GetCompositeEvidenceRequest.TeePubKey)
     pub TeePubKey: ::std::string::String,
-    // @@protoc_insertion_point(field:attestation_agent.GetEvidenceRequest.Nonce)
+    // @@protoc_insertion_point(field:attestation_agent.GetCompositeEvidenceRequest.Nonce)
     pub Nonce: ::std::string::String,
-    // @@protoc_insertion_point(field:attestation_agent.GetEvidenceRequest.HashAlgorithm)
+    // @@protoc_insertion_point(field:attestation_agent.GetCompositeEvidenceRequest.HashAlgorithm)
     pub HashAlgorithm: ::std::string::String,
     // special fields
-    // @@protoc_insertion_point(special_field:attestation_agent.GetEvidenceRequest.special_fields)
+    // @@protoc_insertion_point(special_field:attestation_agent.GetCompositeEvidenceRequest.special_fields)
     pub special_fields: ::protobuf::SpecialFields,
 }
 
-impl<'a> ::std::default::Default for &'a GetEvidenceRequest {
-    fn default() -> &'a GetEvidenceRequest {
-        <GetEvidenceRequest as ::protobuf::Message>::default_instance()
+impl<'a> ::std::default::Default for &'a GetCompositeEvidenceRequest {
+    fn default() -> &'a GetCompositeEvidenceRequest {
+        <GetCompositeEvidenceRequest as ::protobuf::Message>::default_instance()
     }
 }
 
-impl GetEvidenceRequest {
-    pub fn new() -> GetEvidenceRequest {
+impl GetCompositeEvidenceRequest {
+    pub fn new() -> GetCompositeEvidenceRequest {
         ::std::default::Default::default()
     }
 
@@ -55,29 +55,29 @@ impl GetEvidenceRequest {
         let mut oneofs = ::std::vec::Vec::with_capacity(0);
         fields.push(::protobuf::reflect::rt::v2::make_simpler_field_accessor::<_, _>(
             "TeePubKey",
-            |m: &GetEvidenceRequest| { &m.TeePubKey },
-            |m: &mut GetEvidenceRequest| { &mut m.TeePubKey },
+            |m: &GetCompositeEvidenceRequest| { &m.TeePubKey },
+            |m: &mut GetCompositeEvidenceRequest| { &mut m.TeePubKey },
         ));
         fields.push(::protobuf::reflect::rt::v2::make_simpler_field_accessor::<_, _>(
             "Nonce",
-            |m: &GetEvidenceRequest| { &m.Nonce },
-            |m: &mut GetEvidenceRequest| { &mut m.Nonce },
+            |m: &GetCompositeEvidenceRequest| { &m.Nonce },
+            |m: &mut GetCompositeEvidenceRequest| { &mut m.Nonce },
         ));
         fields.push(::protobuf::reflect::rt::v2::make_simpler_field_accessor::<_, _>(
             "HashAlgorithm",
-            |m: &GetEvidenceRequest| { &m.HashAlgorithm },
-            |m: &mut GetEvidenceRequest| { &mut m.HashAlgorithm },
+            |m: &GetCompositeEvidenceRequest| { &m.HashAlgorithm },
+            |m: &mut GetCompositeEvidenceRequest| { &mut m.HashAlgorithm },
         ));
-        ::protobuf::reflect::GeneratedMessageDescriptorData::new_2::<GetEvidenceRequest>(
-            "GetEvidenceRequest",
+        ::protobuf::reflect::GeneratedMessageDescriptorData::new_2::<GetCompositeEvidenceRequest>(
+            "GetCompositeEvidenceRequest",
             fields,
             oneofs,
         )
     }
 }
 
-impl ::protobuf::Message for GetEvidenceRequest {
-    const NAME: &'static str = "GetEvidenceRequest";
+impl ::protobuf::Message for GetCompositeEvidenceRequest {
+    const NAME: &'static str = "GetCompositeEvidenceRequest";
 
     fn is_initialized(&self) -> bool {
         true
@@ -143,8 +143,8 @@ impl ::protobuf::Message for GetEvidenceRequest {
         &mut self.special_fields
     }
 
-    fn new() -> GetEvidenceRequest {
-        GetEvidenceRequest::new()
+    fn new() -> GetCompositeEvidenceRequest {
+        GetCompositeEvidenceRequest::new()
     }
 
     fn clear(&mut self) {
@@ -154,11 +154,133 @@ impl ::protobuf::Message for GetEvidenceRequest {
         self.special_fields.clear();
     }
 
-    fn default_instance() -> &'static GetEvidenceRequest {
-        static instance: GetEvidenceRequest = GetEvidenceRequest {
+    fn default_instance() -> &'static GetCompositeEvidenceRequest {
+        static instance: GetCompositeEvidenceRequest = GetCompositeEvidenceRequest {
             TeePubKey: ::std::string::String::new(),
             Nonce: ::std::string::String::new(),
             HashAlgorithm: ::std::string::String::new(),
+            special_fields: ::protobuf::SpecialFields::new(),
+        };
+        &instance
+    }
+}
+
+impl ::protobuf::MessageFull for GetCompositeEvidenceRequest {
+    fn descriptor() -> ::protobuf::reflect::MessageDescriptor {
+        static descriptor: ::protobuf::rt::Lazy<::protobuf::reflect::MessageDescriptor> = ::protobuf::rt::Lazy::new();
+        descriptor.get(|| file_descriptor().message_by_package_relative_name("GetCompositeEvidenceRequest").unwrap()).clone()
+    }
+}
+
+impl ::std::fmt::Display for GetCompositeEvidenceRequest {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+        ::protobuf::text_format::fmt(self, f)
+    }
+}
+
+impl ::protobuf::reflect::ProtobufValue for GetCompositeEvidenceRequest {
+    type RuntimeType = ::protobuf::reflect::rt::RuntimeTypeMessage<Self>;
+}
+
+// @@protoc_insertion_point(message:attestation_agent.GetEvidenceRequest)
+#[derive(PartialEq,Clone,Default,Debug)]
+pub struct GetEvidenceRequest {
+    // message fields
+    // @@protoc_insertion_point(field:attestation_agent.GetEvidenceRequest.RuntimeData)
+    pub RuntimeData: ::std::vec::Vec<u8>,
+    // special fields
+    // @@protoc_insertion_point(special_field:attestation_agent.GetEvidenceRequest.special_fields)
+    pub special_fields: ::protobuf::SpecialFields,
+}
+
+impl<'a> ::std::default::Default for &'a GetEvidenceRequest {
+    fn default() -> &'a GetEvidenceRequest {
+        <GetEvidenceRequest as ::protobuf::Message>::default_instance()
+    }
+}
+
+impl GetEvidenceRequest {
+    pub fn new() -> GetEvidenceRequest {
+        ::std::default::Default::default()
+    }
+
+    fn generated_message_descriptor_data() -> ::protobuf::reflect::GeneratedMessageDescriptorData {
+        let mut fields = ::std::vec::Vec::with_capacity(1);
+        let mut oneofs = ::std::vec::Vec::with_capacity(0);
+        fields.push(::protobuf::reflect::rt::v2::make_simpler_field_accessor::<_, _>(
+            "RuntimeData",
+            |m: &GetEvidenceRequest| { &m.RuntimeData },
+            |m: &mut GetEvidenceRequest| { &mut m.RuntimeData },
+        ));
+        ::protobuf::reflect::GeneratedMessageDescriptorData::new_2::<GetEvidenceRequest>(
+            "GetEvidenceRequest",
+            fields,
+            oneofs,
+        )
+    }
+}
+
+impl ::protobuf::Message for GetEvidenceRequest {
+    const NAME: &'static str = "GetEvidenceRequest";
+
+    fn is_initialized(&self) -> bool {
+        true
+    }
+
+    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream<'_>) -> ::protobuf::Result<()> {
+        while let Some(tag) = is.read_raw_tag_or_eof()? {
+            match tag {
+                10 => {
+                    self.RuntimeData = is.read_bytes()?;
+                },
+                tag => {
+                    ::protobuf::rt::read_unknown_or_skip_group(tag, is, self.special_fields.mut_unknown_fields())?;
+                },
+            };
+        }
+        ::std::result::Result::Ok(())
+    }
+
+    // Compute sizes of nested messages
+    #[allow(unused_variables)]
+    fn compute_size(&self) -> u64 {
+        let mut my_size = 0;
+        if !self.RuntimeData.is_empty() {
+            my_size += ::protobuf::rt::bytes_size(1, &self.RuntimeData);
+        }
+        my_size += ::protobuf::rt::unknown_fields_size(self.special_fields.unknown_fields());
+        self.special_fields.cached_size().set(my_size as u32);
+        my_size
+    }
+
+    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream<'_>) -> ::protobuf::Result<()> {
+        if !self.RuntimeData.is_empty() {
+            os.write_bytes(1, &self.RuntimeData)?;
+        }
+        os.write_unknown_fields(self.special_fields.unknown_fields())?;
+        ::std::result::Result::Ok(())
+    }
+
+    fn special_fields(&self) -> &::protobuf::SpecialFields {
+        &self.special_fields
+    }
+
+    fn mut_special_fields(&mut self) -> &mut ::protobuf::SpecialFields {
+        &mut self.special_fields
+    }
+
+    fn new() -> GetEvidenceRequest {
+        GetEvidenceRequest::new()
+    }
+
+    fn clear(&mut self) {
+        self.RuntimeData.clear();
+        self.special_fields.clear();
+    }
+
+    fn default_instance() -> &'static GetEvidenceRequest {
+        static instance: GetEvidenceRequest = GetEvidenceRequest {
+            RuntimeData: ::std::vec::Vec::new(),
             special_fields: ::protobuf::SpecialFields::new(),
         };
         &instance
@@ -179,6 +301,286 @@ impl ::std::fmt::Display for GetEvidenceRequest {
 }
 
 impl ::protobuf::reflect::ProtobufValue for GetEvidenceRequest {
+    type RuntimeType = ::protobuf::reflect::rt::RuntimeTypeMessage<Self>;
+}
+
+// @@protoc_insertion_point(message:attestation_agent.GetAdditionalEvidenceRequest)
+#[derive(PartialEq,Clone,Default,Debug)]
+pub struct GetAdditionalEvidenceRequest {
+    // message fields
+    // @@protoc_insertion_point(field:attestation_agent.GetAdditionalEvidenceRequest.RuntimeData)
+    pub RuntimeData: ::std::vec::Vec<u8>,
+    // special fields
+    // @@protoc_insertion_point(special_field:attestation_agent.GetAdditionalEvidenceRequest.special_fields)
+    pub special_fields: ::protobuf::SpecialFields,
+}
+
+impl<'a> ::std::default::Default for &'a GetAdditionalEvidenceRequest {
+    fn default() -> &'a GetAdditionalEvidenceRequest {
+        <GetAdditionalEvidenceRequest as ::protobuf::Message>::default_instance()
+    }
+}
+
+impl GetAdditionalEvidenceRequest {
+    pub fn new() -> GetAdditionalEvidenceRequest {
+        ::std::default::Default::default()
+    }
+
+    fn generated_message_descriptor_data() -> ::protobuf::reflect::GeneratedMessageDescriptorData {
+        let mut fields = ::std::vec::Vec::with_capacity(1);
+        let mut oneofs = ::std::vec::Vec::with_capacity(0);
+        fields.push(::protobuf::reflect::rt::v2::make_simpler_field_accessor::<_, _>(
+            "RuntimeData",
+            |m: &GetAdditionalEvidenceRequest| { &m.RuntimeData },
+            |m: &mut GetAdditionalEvidenceRequest| { &mut m.RuntimeData },
+        ));
+        ::protobuf::reflect::GeneratedMessageDescriptorData::new_2::<GetAdditionalEvidenceRequest>(
+            "GetAdditionalEvidenceRequest",
+            fields,
+            oneofs,
+        )
+    }
+}
+
+impl ::protobuf::Message for GetAdditionalEvidenceRequest {
+    const NAME: &'static str = "GetAdditionalEvidenceRequest";
+
+    fn is_initialized(&self) -> bool {
+        true
+    }
+
+    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream<'_>) -> ::protobuf::Result<()> {
+        while let Some(tag) = is.read_raw_tag_or_eof()? {
+            match tag {
+                10 => {
+                    self.RuntimeData = is.read_bytes()?;
+                },
+                tag => {
+                    ::protobuf::rt::read_unknown_or_skip_group(tag, is, self.special_fields.mut_unknown_fields())?;
+                },
+            };
+        }
+        ::std::result::Result::Ok(())
+    }
+
+    // Compute sizes of nested messages
+    #[allow(unused_variables)]
+    fn compute_size(&self) -> u64 {
+        let mut my_size = 0;
+        if !self.RuntimeData.is_empty() {
+            my_size += ::protobuf::rt::bytes_size(1, &self.RuntimeData);
+        }
+        my_size += ::protobuf::rt::unknown_fields_size(self.special_fields.unknown_fields());
+        self.special_fields.cached_size().set(my_size as u32);
+        my_size
+    }
+
+    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream<'_>) -> ::protobuf::Result<()> {
+        if !self.RuntimeData.is_empty() {
+            os.write_bytes(1, &self.RuntimeData)?;
+        }
+        os.write_unknown_fields(self.special_fields.unknown_fields())?;
+        ::std::result::Result::Ok(())
+    }
+
+    fn special_fields(&self) -> &::protobuf::SpecialFields {
+        &self.special_fields
+    }
+
+    fn mut_special_fields(&mut self) -> &mut ::protobuf::SpecialFields {
+        &mut self.special_fields
+    }
+
+    fn new() -> GetAdditionalEvidenceRequest {
+        GetAdditionalEvidenceRequest::new()
+    }
+
+    fn clear(&mut self) {
+        self.RuntimeData.clear();
+        self.special_fields.clear();
+    }
+
+    fn default_instance() -> &'static GetAdditionalEvidenceRequest {
+        static instance: GetAdditionalEvidenceRequest = GetAdditionalEvidenceRequest {
+            RuntimeData: ::std::vec::Vec::new(),
+            special_fields: ::protobuf::SpecialFields::new(),
+        };
+        &instance
+    }
+}
+
+impl ::protobuf::MessageFull for GetAdditionalEvidenceRequest {
+    fn descriptor() -> ::protobuf::reflect::MessageDescriptor {
+        static descriptor: ::protobuf::rt::Lazy<::protobuf::reflect::MessageDescriptor> = ::protobuf::rt::Lazy::new();
+        descriptor.get(|| file_descriptor().message_by_package_relative_name("GetAdditionalEvidenceRequest").unwrap()).clone()
+    }
+}
+
+impl ::std::fmt::Display for GetAdditionalEvidenceRequest {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+        ::protobuf::text_format::fmt(self, f)
+    }
+}
+
+impl ::protobuf::reflect::ProtobufValue for GetAdditionalEvidenceRequest {
+    type RuntimeType = ::protobuf::reflect::rt::RuntimeTypeMessage<Self>;
+}
+
+// @@protoc_insertion_point(message:attestation_agent.GetPrimaryEvidenceRequest)
+#[derive(PartialEq,Clone,Default,Debug)]
+pub struct GetPrimaryEvidenceRequest {
+    // message fields
+    // @@protoc_insertion_point(field:attestation_agent.GetPrimaryEvidenceRequest.TeePubKey)
+    pub TeePubKey: ::std::string::String,
+    // @@protoc_insertion_point(field:attestation_agent.GetPrimaryEvidenceRequest.Nonce)
+    pub Nonce: ::std::string::String,
+    // @@protoc_insertion_point(field:attestation_agent.GetPrimaryEvidenceRequest.HashAlgorithm)
+    pub HashAlgorithm: ::std::string::String,
+    // special fields
+    // @@protoc_insertion_point(special_field:attestation_agent.GetPrimaryEvidenceRequest.special_fields)
+    pub special_fields: ::protobuf::SpecialFields,
+}
+
+impl<'a> ::std::default::Default for &'a GetPrimaryEvidenceRequest {
+    fn default() -> &'a GetPrimaryEvidenceRequest {
+        <GetPrimaryEvidenceRequest as ::protobuf::Message>::default_instance()
+    }
+}
+
+impl GetPrimaryEvidenceRequest {
+    pub fn new() -> GetPrimaryEvidenceRequest {
+        ::std::default::Default::default()
+    }
+
+    fn generated_message_descriptor_data() -> ::protobuf::reflect::GeneratedMessageDescriptorData {
+        let mut fields = ::std::vec::Vec::with_capacity(3);
+        let mut oneofs = ::std::vec::Vec::with_capacity(0);
+        fields.push(::protobuf::reflect::rt::v2::make_simpler_field_accessor::<_, _>(
+            "TeePubKey",
+            |m: &GetPrimaryEvidenceRequest| { &m.TeePubKey },
+            |m: &mut GetPrimaryEvidenceRequest| { &mut m.TeePubKey },
+        ));
+        fields.push(::protobuf::reflect::rt::v2::make_simpler_field_accessor::<_, _>(
+            "Nonce",
+            |m: &GetPrimaryEvidenceRequest| { &m.Nonce },
+            |m: &mut GetPrimaryEvidenceRequest| { &mut m.Nonce },
+        ));
+        fields.push(::protobuf::reflect::rt::v2::make_simpler_field_accessor::<_, _>(
+            "HashAlgorithm",
+            |m: &GetPrimaryEvidenceRequest| { &m.HashAlgorithm },
+            |m: &mut GetPrimaryEvidenceRequest| { &mut m.HashAlgorithm },
+        ));
+        ::protobuf::reflect::GeneratedMessageDescriptorData::new_2::<GetPrimaryEvidenceRequest>(
+            "GetPrimaryEvidenceRequest",
+            fields,
+            oneofs,
+        )
+    }
+}
+
+impl ::protobuf::Message for GetPrimaryEvidenceRequest {
+    const NAME: &'static str = "GetPrimaryEvidenceRequest";
+
+    fn is_initialized(&self) -> bool {
+        true
+    }
+
+    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream<'_>) -> ::protobuf::Result<()> {
+        while let Some(tag) = is.read_raw_tag_or_eof()? {
+            match tag {
+                10 => {
+                    self.TeePubKey = is.read_string()?;
+                },
+                18 => {
+                    self.Nonce = is.read_string()?;
+                },
+                26 => {
+                    self.HashAlgorithm = is.read_string()?;
+                },
+                tag => {
+                    ::protobuf::rt::read_unknown_or_skip_group(tag, is, self.special_fields.mut_unknown_fields())?;
+                },
+            };
+        }
+        ::std::result::Result::Ok(())
+    }
+
+    // Compute sizes of nested messages
+    #[allow(unused_variables)]
+    fn compute_size(&self) -> u64 {
+        let mut my_size = 0;
+        if !self.TeePubKey.is_empty() {
+            my_size += ::protobuf::rt::string_size(1, &self.TeePubKey);
+        }
+        if !self.Nonce.is_empty() {
+            my_size += ::protobuf::rt::string_size(2, &self.Nonce);
+        }
+        if !self.HashAlgorithm.is_empty() {
+            my_size += ::protobuf::rt::string_size(3, &self.HashAlgorithm);
+        }
+        my_size += ::protobuf::rt::unknown_fields_size(self.special_fields.unknown_fields());
+        self.special_fields.cached_size().set(my_size as u32);
+        my_size
+    }
+
+    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream<'_>) -> ::protobuf::Result<()> {
+        if !self.TeePubKey.is_empty() {
+            os.write_string(1, &self.TeePubKey)?;
+        }
+        if !self.Nonce.is_empty() {
+            os.write_string(2, &self.Nonce)?;
+        }
+        if !self.HashAlgorithm.is_empty() {
+            os.write_string(3, &self.HashAlgorithm)?;
+        }
+        os.write_unknown_fields(self.special_fields.unknown_fields())?;
+        ::std::result::Result::Ok(())
+    }
+
+    fn special_fields(&self) -> &::protobuf::SpecialFields {
+        &self.special_fields
+    }
+
+    fn mut_special_fields(&mut self) -> &mut ::protobuf::SpecialFields {
+        &mut self.special_fields
+    }
+
+    fn new() -> GetPrimaryEvidenceRequest {
+        GetPrimaryEvidenceRequest::new()
+    }
+
+    fn clear(&mut self) {
+        self.TeePubKey.clear();
+        self.Nonce.clear();
+        self.HashAlgorithm.clear();
+        self.special_fields.clear();
+    }
+
+    fn default_instance() -> &'static GetPrimaryEvidenceRequest {
+        static instance: GetPrimaryEvidenceRequest = GetPrimaryEvidenceRequest {
+            TeePubKey: ::std::string::String::new(),
+            Nonce: ::std::string::String::new(),
+            HashAlgorithm: ::std::string::String::new(),
+            special_fields: ::protobuf::SpecialFields::new(),
+        };
+        &instance
+    }
+}
+
+impl ::protobuf::MessageFull for GetPrimaryEvidenceRequest {
+    fn descriptor() -> ::protobuf::reflect::MessageDescriptor {
+        static descriptor: ::protobuf::rt::Lazy<::protobuf::reflect::MessageDescriptor> = ::protobuf::rt::Lazy::new();
+        descriptor.get(|| file_descriptor().message_by_package_relative_name("GetPrimaryEvidenceRequest").unwrap()).clone()
+    }
+}
+
+impl ::std::fmt::Display for GetPrimaryEvidenceRequest {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+        ::protobuf::text_format::fmt(self, f)
+    }
+}
+
+impl ::protobuf::reflect::ProtobufValue for GetPrimaryEvidenceRequest {
     type RuntimeType = ::protobuf::reflect::rt::RuntimeTypeMessage<Self>;
 }
 
@@ -1418,31 +1820,40 @@ impl ::protobuf::reflect::ProtobufValue for GetTeeTypeResponse {
 }
 
 static file_descriptor_proto_data: &'static [u8] = b"\
-    \n\x17attestation-agent.proto\x12\x11attestation_agent\"n\n\x12GetEviden\
-    ceRequest\x12\x1c\n\tTeePubKey\x18\x01\x20\x01(\tR\tTeePubKey\x12\x14\n\
-    \x05Nonce\x18\x02\x20\x01(\tR\x05Nonce\x12$\n\rHashAlgorithm\x18\x03\x20\
-    \x01(\tR\rHashAlgorithm\"1\n\x13GetEvidenceResponse\x12\x1a\n\x08Evidenc\
-    e\x18\x01\x20\x01(\x0cR\x08Evidence\"/\n\x0fGetTokenRequest\x12\x1c\n\tT\
-    okenType\x18\x01\x20\x01(\tR\tTokenType\"(\n\x10GetTokenResponse\x12\x14\
-    \n\x05Token\x18\x01\x20\x01(\x0cR\x05Token\"\xae\x01\n\x1fExtendRuntimeM\
-    easurementRequest\x12\x16\n\x06Domain\x18\x01\x20\x01(\tR\x06Domain\x12\
-    \x1c\n\tOperation\x18\x02\x20\x01(\tR\tOperation\x12\x18\n\x07Content\
-    \x18\x03\x20\x01(\tR\x07Content\x12)\n\rRegisterIndex\x18\x04\x20\x01(\
-    \x04H\0R\rRegisterIndex\x88\x01\x01B\x10\n\x0e_RegisterIndex\"\"\n\x20Ex\
-    tendRuntimeMeasurementResponse\"K\n\x11InitDataPlaintext\x12\x18\n\x07Co\
-    ntent\x18\x01\x20\x01(\x0cR\x07Content\x12\x1c\n\tAlgorithm\x18\x02\x20\
-    \x01(\tR\tAlgorithm\"-\n\x13BindInitDataRequest\x12\x16\n\x06Digest\x18\
-    \x01\x20\x01(\x0cR\x06Digest\"\x16\n\x14BindInitDataResponse\"\x13\n\x11\
-    GetTeeTypeRequest\"&\n\x12GetTeeTypeResponse\x12\x10\n\x03tee\x18\x01\
-    \x20\x01(\tR\x03tee2\x8e\x04\n\x17AttestationAgentService\x12\\\n\x0bGet\
-    Evidence\x12%.attestation_agent.GetEvidenceRequest\x1a&.attestation_agen\
-    t.GetEvidenceResponse\x12S\n\x08GetToken\x12\".attestation_agent.GetToke\
-    nRequest\x1a#.attestation_agent.GetTokenResponse\x12\x83\x01\n\x18Extend\
-    RuntimeMeasurement\x122.attestation_agent.ExtendRuntimeMeasurementReques\
-    t\x1a3.attestation_agent.ExtendRuntimeMeasurementResponse\x12_\n\x0cBind\
-    InitData\x12&.attestation_agent.BindInitDataRequest\x1a'.attestation_age\
-    nt.BindInitDataResponse\x12Y\n\nGetTeeType\x12$.attestation_agent.GetTee\
-    TypeRequest\x1a%.attestation_agent.GetTeeTypeResponseb\x06proto3\
+    \n\x17attestation-agent.proto\x12\x11attestation_agent\"w\n\x1bGetCompos\
+    iteEvidenceRequest\x12\x1c\n\tTeePubKey\x18\x01\x20\x01(\tR\tTeePubKey\
+    \x12\x14\n\x05Nonce\x18\x02\x20\x01(\tR\x05Nonce\x12$\n\rHashAlgorithm\
+    \x18\x03\x20\x01(\tR\rHashAlgorithm\"6\n\x12GetEvidenceRequest\x12\x20\n\
+    \x0bRuntimeData\x18\x01\x20\x01(\x0cR\x0bRuntimeData\"@\n\x1cGetAddition\
+    alEvidenceRequest\x12\x20\n\x0bRuntimeData\x18\x01\x20\x01(\x0cR\x0bRunt\
+    imeData\"u\n\x19GetPrimaryEvidenceRequest\x12\x1c\n\tTeePubKey\x18\x01\
+    \x20\x01(\tR\tTeePubKey\x12\x14\n\x05Nonce\x18\x02\x20\x01(\tR\x05Nonce\
+    \x12$\n\rHashAlgorithm\x18\x03\x20\x01(\tR\rHashAlgorithm\"1\n\x13GetEvi\
+    denceResponse\x12\x1a\n\x08Evidence\x18\x01\x20\x01(\x0cR\x08Evidence\"/\
+    \n\x0fGetTokenRequest\x12\x1c\n\tTokenType\x18\x01\x20\x01(\tR\tTokenTyp\
+    e\"(\n\x10GetTokenResponse\x12\x14\n\x05Token\x18\x01\x20\x01(\x0cR\x05T\
+    oken\"\xae\x01\n\x1fExtendRuntimeMeasurementRequest\x12\x16\n\x06Domain\
+    \x18\x01\x20\x01(\tR\x06Domain\x12\x1c\n\tOperation\x18\x02\x20\x01(\tR\
+    \tOperation\x12\x18\n\x07Content\x18\x03\x20\x01(\tR\x07Content\x12)\n\r\
+    RegisterIndex\x18\x04\x20\x01(\x04H\0R\rRegisterIndex\x88\x01\x01B\x10\n\
+    \x0e_RegisterIndex\"\"\n\x20ExtendRuntimeMeasurementResponse\"K\n\x11Ini\
+    tDataPlaintext\x12\x18\n\x07Content\x18\x01\x20\x01(\x0cR\x07Content\x12\
+    \x1c\n\tAlgorithm\x18\x02\x20\x01(\tR\tAlgorithm\"-\n\x13BindInitDataReq\
+    uest\x12\x16\n\x06Digest\x18\x01\x20\x01(\x0cR\x06Digest\"\x16\n\x14Bind\
+    InitDataResponse\"\x13\n\x11GetTeeTypeRequest\"&\n\x12GetTeeTypeResponse\
+    \x12\x10\n\x03tee\x18\x01\x20\x01(\tR\x03tee2\xf0\x05\n\x17AttestationAg\
+    entService\x12\\\n\x0bGetEvidence\x12%.attestation_agent.GetEvidenceRequ\
+    est\x1a&.attestation_agent.GetEvidenceResponse\x12n\n\x14GetCompositeEvi\
+    dence\x12..attestation_agent.GetCompositeEvidenceRequest\x1a&.attestatio\
+    n_agent.GetEvidenceResponse\x12p\n\x15GetAdditionalEvidence\x12/.attesta\
+    tion_agent.GetAdditionalEvidenceRequest\x1a&.attestation_agent.GetEviden\
+    ceResponse\x12S\n\x08GetToken\x12\".attestation_agent.GetTokenRequest\
+    \x1a#.attestation_agent.GetTokenResponse\x12\x83\x01\n\x18ExtendRuntimeM\
+    easurement\x122.attestation_agent.ExtendRuntimeMeasurementRequest\x1a3.a\
+    ttestation_agent.ExtendRuntimeMeasurementResponse\x12_\n\x0cBindInitData\
+    \x12&.attestation_agent.BindInitDataRequest\x1a'.attestation_agent.BindI\
+    nitDataResponse\x12Y\n\nGetTeeType\x12$.attestation_agent.GetTeeTypeRequ\
+    est\x1a%.attestation_agent.GetTeeTypeResponseb\x06proto3\
 ";
 
 /// `FileDescriptorProto` object which was a source for this generated file
@@ -1460,8 +1871,11 @@ pub fn file_descriptor() -> &'static ::protobuf::reflect::FileDescriptor {
     file_descriptor.get(|| {
         let generated_file_descriptor = generated_file_descriptor_lazy.get(|| {
             let mut deps = ::std::vec::Vec::with_capacity(0);
-            let mut messages = ::std::vec::Vec::with_capacity(11);
+            let mut messages = ::std::vec::Vec::with_capacity(14);
+            messages.push(GetCompositeEvidenceRequest::generated_message_descriptor_data());
             messages.push(GetEvidenceRequest::generated_message_descriptor_data());
+            messages.push(GetAdditionalEvidenceRequest::generated_message_descriptor_data());
+            messages.push(GetPrimaryEvidenceRequest::generated_message_descriptor_data());
             messages.push(GetEvidenceResponse::generated_message_descriptor_data());
             messages.push(GetTokenRequest::generated_message_descriptor_data());
             messages.push(GetTokenResponse::generated_message_descriptor_data());

--- a/attestation-agent/kbs_protocol/src/ttrpc_protos/attestation_agent_ttrpc.rs
+++ b/attestation-agent/kbs_protocol/src/ttrpc_protos/attestation_agent_ttrpc.rs
@@ -36,6 +36,16 @@ impl AttestationAgentServiceClient {
         ::ttrpc::async_client_request!(self, ctx, req, "attestation_agent.AttestationAgentService", "GetEvidence", cres);
     }
 
+    pub async fn get_composite_evidence(&self, ctx: ttrpc::context::Context, req: &super::attestation_agent::GetCompositeEvidenceRequest) -> ::ttrpc::Result<super::attestation_agent::GetEvidenceResponse> {
+        let mut cres = super::attestation_agent::GetEvidenceResponse::new();
+        ::ttrpc::async_client_request!(self, ctx, req, "attestation_agent.AttestationAgentService", "GetCompositeEvidence", cres);
+    }
+
+    pub async fn get_additional_evidence(&self, ctx: ttrpc::context::Context, req: &super::attestation_agent::GetAdditionalEvidenceRequest) -> ::ttrpc::Result<super::attestation_agent::GetEvidenceResponse> {
+        let mut cres = super::attestation_agent::GetEvidenceResponse::new();
+        ::ttrpc::async_client_request!(self, ctx, req, "attestation_agent.AttestationAgentService", "GetAdditionalEvidence", cres);
+    }
+
     pub async fn get_token(&self, ctx: ttrpc::context::Context, req: &super::attestation_agent::GetTokenRequest) -> ::ttrpc::Result<super::attestation_agent::GetTokenResponse> {
         let mut cres = super::attestation_agent::GetTokenResponse::new();
         ::ttrpc::async_client_request!(self, ctx, req, "attestation_agent.AttestationAgentService", "GetToken", cres);
@@ -65,6 +75,28 @@ struct GetEvidenceMethod {
 impl ::ttrpc::r#async::MethodHandler for GetEvidenceMethod {
     async fn handler(&self, ctx: ::ttrpc::r#async::TtrpcContext, req: ::ttrpc::Request) -> ::ttrpc::Result<::ttrpc::Response> {
         ::ttrpc::async_request_handler!(self, ctx, req, attestation_agent, GetEvidenceRequest, get_evidence);
+    }
+}
+
+struct GetCompositeEvidenceMethod {
+    service: Arc<dyn AttestationAgentService + Send + Sync>,
+}
+
+#[async_trait]
+impl ::ttrpc::r#async::MethodHandler for GetCompositeEvidenceMethod {
+    async fn handler(&self, ctx: ::ttrpc::r#async::TtrpcContext, req: ::ttrpc::Request) -> ::ttrpc::Result<::ttrpc::Response> {
+        ::ttrpc::async_request_handler!(self, ctx, req, attestation_agent, GetCompositeEvidenceRequest, get_composite_evidence);
+    }
+}
+
+struct GetAdditionalEvidenceMethod {
+    service: Arc<dyn AttestationAgentService + Send + Sync>,
+}
+
+#[async_trait]
+impl ::ttrpc::r#async::MethodHandler for GetAdditionalEvidenceMethod {
+    async fn handler(&self, ctx: ::ttrpc::r#async::TtrpcContext, req: ::ttrpc::Request) -> ::ttrpc::Result<::ttrpc::Response> {
+        ::ttrpc::async_request_handler!(self, ctx, req, attestation_agent, GetAdditionalEvidenceRequest, get_additional_evidence);
     }
 }
 
@@ -117,6 +149,12 @@ pub trait AttestationAgentService: Sync {
     async fn get_evidence(&self, _ctx: &::ttrpc::r#async::TtrpcContext, _: super::attestation_agent::GetEvidenceRequest) -> ::ttrpc::Result<super::attestation_agent::GetEvidenceResponse> {
         Err(::ttrpc::Error::RpcStatus(::ttrpc::get_status(::ttrpc::Code::NOT_FOUND, "/attestation_agent.AttestationAgentService/GetEvidence is not supported".to_string())))
     }
+    async fn get_composite_evidence(&self, _ctx: &::ttrpc::r#async::TtrpcContext, _: super::attestation_agent::GetCompositeEvidenceRequest) -> ::ttrpc::Result<super::attestation_agent::GetEvidenceResponse> {
+        Err(::ttrpc::Error::RpcStatus(::ttrpc::get_status(::ttrpc::Code::NOT_FOUND, "/attestation_agent.AttestationAgentService/GetCompositeEvidence is not supported".to_string())))
+    }
+    async fn get_additional_evidence(&self, _ctx: &::ttrpc::r#async::TtrpcContext, _: super::attestation_agent::GetAdditionalEvidenceRequest) -> ::ttrpc::Result<super::attestation_agent::GetEvidenceResponse> {
+        Err(::ttrpc::Error::RpcStatus(::ttrpc::get_status(::ttrpc::Code::NOT_FOUND, "/attestation_agent.AttestationAgentService/GetAdditionalEvidence is not supported".to_string())))
+    }
     async fn get_token(&self, _ctx: &::ttrpc::r#async::TtrpcContext, _: super::attestation_agent::GetTokenRequest) -> ::ttrpc::Result<super::attestation_agent::GetTokenResponse> {
         Err(::ttrpc::Error::RpcStatus(::ttrpc::get_status(::ttrpc::Code::NOT_FOUND, "/attestation_agent.AttestationAgentService/GetToken is not supported".to_string())))
     }
@@ -138,6 +176,12 @@ pub fn create_attestation_agent_service(service: Arc<dyn AttestationAgentService
 
     methods.insert("GetEvidence".to_string(),
                     Box::new(GetEvidenceMethod{service: service.clone()}) as Box<dyn ::ttrpc::r#async::MethodHandler + Send + Sync>);
+
+    methods.insert("GetCompositeEvidence".to_string(),
+                    Box::new(GetCompositeEvidenceMethod{service: service.clone()}) as Box<dyn ::ttrpc::r#async::MethodHandler + Send + Sync>);
+
+    methods.insert("GetAdditionalEvidence".to_string(),
+                    Box::new(GetAdditionalEvidenceMethod{service: service.clone()}) as Box<dyn ::ttrpc::r#async::MethodHandler + Send + Sync>);
 
     methods.insert("GetToken".to_string(),
                     Box::new(GetTokenMethod{service: service.clone()}) as Box<dyn ::ttrpc::r#async::MethodHandler + Send + Sync>);

--- a/attestation-agent/protos/attestation-agent.proto
+++ b/attestation-agent/protos/attestation-agent.proto
@@ -3,7 +3,9 @@ syntax = "proto3";
 package attestation_agent;
 
 message GetEvidenceRequest {
-    bytes RuntimeData = 1;
+    string TeePubKey = 1;
+    string Nonce = 2;
+    string HashAlgorithm = 3;
 }
 
 message GetEvidenceResponse {

--- a/attestation-agent/protos/attestation-agent.proto
+++ b/attestation-agent/protos/attestation-agent.proto
@@ -2,7 +2,16 @@ syntax = "proto3";
 
 package attestation_agent;
 
+// Get the primary evidence from the guest.
 message GetEvidenceRequest {
+    bytes RuntimeData = 1;
+}
+
+message GetAdditionalEvidenceRequest {
+    bytes RuntimeData = 1;
+}
+
+message GetCompositeEvidenceRequest {
     string TeePubKey = 1;
     string Nonce = 2;
     string HashAlgorithm = 3;
@@ -57,6 +66,8 @@ message GetTeeTypeResponse {
 
 service AttestationAgentService {
     rpc GetEvidence(GetEvidenceRequest) returns (GetEvidenceResponse) {};
+    rpc GetCompositeEvidence(GetCompositeEvidenceRequest) returns (GetEvidenceResponse) {};
+    rpc GetAdditionalEvidence(GetAdditionalEvidenceRequest) returns (GetEvidenceResponse) {};
     rpc GetToken(GetTokenRequest) returns (GetTokenResponse) {};
     rpc ExtendRuntimeMeasurement(ExtendRuntimeMeasurementRequest) returns (ExtendRuntimeMeasurementResponse) {};
     rpc BindInitData(BindInitDataRequest) returns (BindInitDataResponse) {};


### PR DESCRIPTION
This is a much better version of https://github.com/confidential-containers/guest-components/pull/957

(I am keeping the original branch in place in case anyone is developing on top of it. This PR is significantly different).

This PR isn't quite done, but it's ready for some feedback. I will fix the missing pieces next week.

I have adopted a composite evidence approach. This was not as complex as I had first pictured and I think the other approach was not secure. I wrote big commit messages. Check them out. 

Two interesting improvements over the first version:

1) Since we now have a primary attester, I don't pluralize the Tee field in the kbs protocol request. I realized that the first iteration didn't really need this either. It would only come in handy if we needed different nonces for difference devices, but that doesn't seem necessary. This allowed me to drop a lot of changes from the first iteration and it means that we don't actually need to modify the KBS protocol (although I do have a couple tweaks to `kbs-types`).

2) Since the previous iteration had a very simple representation of the guest evidence (i.e. a vector), I wasn't very rigorous about defining structs for it. In this version I have created a couple new abstractions to make this more clear. These abstractions also allow us to centralize most of the complexity of evidence generation, rather than implementing it in each of the callers. i think overall the changes are much clearer. 