### PR TITLE
CDH/image-rs | promote error information printing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3121,6 +3121,7 @@ dependencies = [
  "tempfile",
  "test-utils",
  "testcontainers",
+ "thiserror 2.0.12",
  "tokio",
  "tokio-util",
  "toml 0.8.22",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6183,8 +6183,9 @@ dependencies = [
 
 [[package]]
 name = "sigstore"
-version = "0.12.0"
-source = "git+https://github.com/sigstore/sigstore-rs.git?rev=5df33d6b7d0590a534948a2b9b415cd6e13bafdc#5df33d6b7d0590a534948a2b9b415cd6e13bafdc"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43427f0d642cfed11bd596608148ee4476dd75f938888aa13a9c4e176fe14225"
 dependencies = [
  "async-trait",
  "aws-lc-rs",

--- a/confidential-data-hub/README.md
+++ b/confidential-data-hub/README.md
@@ -3,7 +3,16 @@
 Confidential Data Hub (`CDH`) is a service running inside the guest to provide resource related
 APIs.
 
+### APIs
 
+The APIs are defined in the [proto file](./hub/protos/). 
+
+Note that CDH supports decryption of encrypted images. 
+To enable this you need to set environment `OCICRYPT_KEYPROVIDER_CONFIG`  to point to the [ocicrypt configuration file](./hub/src/image/ocicrypt_config.json) at startup, for example 
+
+```shell
+OCICRYPT_KEYPROVIDER_CONFIG=<path-to-ocicrypt_config.json> confidential-data-hub
+```
 
 ### Build
 

--- a/confidential-data-hub/example.config.json
+++ b/confidential-data-hub/example.config.json
@@ -20,8 +20,11 @@
         "sigstore_config_uri": "kbs:///default/sigstore-config/test",
         "image_security_policy_uri": "kbs:///default/security-policy/test",
         "authenticated_registry_credentials_uri": "kbs:///default/credential/test",
-        "image_pull_proxy": "http://127.0.0.1:5432",
-        "skip_proxy_ips": "192.168.0.1,localhost",
+        "image_pull_proxy": {
+            "https_proxy": "http://127.0.0.1:5432",
+            "http_proxy": "http://127.0.0.1:5432",
+            "no_proxy": "192.168.0.1,localhost"
+        },
         "extra_root_certificates": "-----BEGIN CERTIFICATE-----\nMIIFTDCCAvugAwIBAgIBADBGBgkqhkiG9w0BAQowOaAPMA0GCWCGSAFlAwQCAgUA\noRwwGgYJKoZIhvcNAQEIMA0GCWCGSAFlAwQCAgUAogMCATCjAwIBATB7MRQwEgYD\nVQQLDAtFbmdpbmVlcmluZzELMAkGA1UEBhMCVVMxFDASBgNVBAcMC1NhbnRhIENs\nYXJhMQswCQYDVQQIDAJDQTEfMB0GA1UECgwWQWR2YW5jZWQgTWljcm8gRGV2aWNl\nczESMBAGA1UEAwwJU0VWLU1pbGFuMB4XDTIzMDEyNDE3NTgyNloXDTMwMDEyNDE3\nNTgyNlowejEUMBIGA1UECwwLRW5naW5lZXJpbmcxCzAJBgNVBAYTAlVTMRQwEgYD\nVQQHDAtTYW50YSBDbGFyYTELMAkGA1UECAwCQ0ExHzAdBgNVBAoMFkFkdmFuY2Vk\nIE1pY3JvIERldmljZXMxETAPBgNVBAMMCFNFVi1WQ0VLMHYwEAYHKoZIzj0CAQYF\nK4EEACIDYgAExmG1ZbuoAQK93USRyZQcsyobfbaAEoKEELf/jK39cOVJt1t4s83W\nXM3rqIbS7qHUHQw/FGyOvdaEUs5+wwxpCWfDnmJMAQ+ctgZqgDEKh1NqlOuuKcKq\n2YAWE5cTH7sHo4IBFjCCARIwEAYJKwYBBAGceAEBBAMCAQAwFwYJKwYBBAGceAEC\nBAoWCE1pbGFuLUIwMBEGCisGAQQBnHgBAwEEAwIBAzARBgorBgEEAZx4AQMCBAMC\nAQAwEQYKKwYBBAGceAEDBAQDAgEAMBEGCisGAQQBnHgBAwUEAwIBADARBgorBgEE\nAZx4AQMGBAMCAQAwEQYKKwYBBAGceAEDBwQDAgEAMBEGCisGAQQBnHgBAwMEAwIB\nCDARBgorBgEEAZx4AQMIBAMCAXMwTQYJKwYBBAGceAEEBEDDhCejDUx6+dlvehW5\ncmmCWmTLdqI1L/1dGBFdia1HP46MC82aXZKGYSutSq37RCYgWjueT+qCMBE1oXDk\nd1JOMEYGCSqGSIb3DQEBCjA5oA8wDQYJYIZIAWUDBAICBQChHDAaBgkqhkiG9w0B\nAQgwDQYJYIZIAWUDBAICBQCiAwIBMKMDAgEBA4ICAQACgCai9x8DAWzX/2IelNWm\nituEBSiq9C9eDnBEckQYikAhPasfagnoWFAtKu/ZWTKHi+BMbhKwswBS8W0G1ywi\ncUWGlzigI4tdxxf1YBJyCoTSNssSbKmIh5jemBfrvIBo1yEd+e56ZJMdhN8e+xWU\nbvovUC2/7Dl76fzAaACLSorZUv5XPJwKXwEOHo7FIcREjoZn+fKjJTnmdXce0LD6\n9RHr+r+ceyE79gmK31bI9DYiJoL4LeGdXZ3gMOVDR1OnDos5lOBcV+quJ6JujpgH\nd9g3Sa7Du7pusD9Fdap98ocZslRfFjFi//2YdVM4MKbq6IwpYNB+2PCEKNC7SfbO\nNgZYJuPZnM/wViES/cP7MZNJ1KUKBI9yh6TmlSsZZOclGJvrOsBZimTXpATjdNMt\ncluKwqAUUzYQmU7bf2TMdOXyA9iH5wIpj1kWGE1VuFADTKILkTc6LzLzOWCofLxf\nonhTtSDtzIv/uel547GZqq+rVRvmIieEuEvDETwuookfV6qu3D/9KuSr9xiznmEg\nxynud/f525jppJMcD/ofbQxUZuGKvb3f3zy+aLxqidoX7gca2Xd9jyUy5Y/83+ZN\nbz4PZx81UJzXVI9ABEh8/xilATh1ZxOePTBJjN7lgr0lXtKYjV/43yyxgUYrXNZS\noLSG2dLCK9mjjraPjau34Q==\n-----END CERTIFICATE-----",
         "work_dir": "/run/image-rs"
     }

--- a/confidential-data-hub/example.config.toml
+++ b/confidential-data-hub/example.config.toml
@@ -117,21 +117,6 @@ image_security_policy_uri = "kbs:///default/security-policy/test"
 # By default this value is not set.
 authenticated_registry_credentials_uri = "kbs:///default/credential/test"
 
-# Proxy that will be used to pull image
-#
-# By default this value is not set.
-image_pull_proxy = "http://127.0.0.1:5432"
-
-# No proxy env that will be used to pull image.
-#
-# This will ensure that when we access the image registry with specified
-# IPs, the `image_pull_proxy` will not be used.
-#
-# If `image_pull_proxy` is not set, this field will do nothing.
-#
-# By default this value is not set.
-skip_proxy_ips = "192.168.0.1,localhost"
-
 # To support registries with self signed certs. This config item
 # is used to add extra trusted root certifications. The certificates
 # must be encoded by PEM.
@@ -177,3 +162,25 @@ oLSG2dLCK9mjjraPjau34Q==
 #
 # This value defaults to `/run/image-rs/`.
 work_dir = "/run/image-rs"
+
+[image.image_pull_proxy]
+
+# HTTPS proxy that will be used to pull image
+#
+# By default this value is not set.
+https_proxy = "http://127.0.0.1:5432"
+
+# HTTP proxy that will be used to pull image
+#
+# By default this value is not set.
+http_proxy = "http://127.0.0.1:5432"
+
+# No proxy env that will be used to pull image.
+#
+# This will ensure that when we access the image registry with specified
+# IPs, both `https_proxy` and `http_proxy` will not be used.
+#
+# If neither `https_proxy` nor `http_proxy` is not set, this field will do nothing.
+#
+# By default this value is not set.
+no_proxy = "192.168.0.1,localhost"

--- a/confidential-data-hub/hub/src/bin/grpc_server/mod.rs
+++ b/confidential-data-hub/hub/src/bin/grpc_server/mod.rs
@@ -53,7 +53,7 @@ impl SealedSecretService for Arc<Cdh> {
             .map_err(|e| {
                 let detailed_error = format_error!(e);
                 error!("[gRPC CDH] Call CDH to unseal secret failed:\n{detailed_error}");
-                Status::internal(format!("[ERROR] CDH unseal secret failed: {}", e))
+                Status::internal(format!("[CDH] [ERROR]: {e}"))
             })?;
 
         debug!("[gRPC CDH] Unseal secret successfully!");
@@ -80,7 +80,7 @@ impl GetResourceService for Arc<Cdh> {
             .map_err(|e| {
                 let detailed_error = format_error!(e);
                 error!("[gRPC CDH] Call CDH to get resource failed:\n{detailed_error}");
-                Status::internal(format!("[ERROR] CDH get resource failed: {}", e))
+                Status::internal(format!("[CDH] [ERROR]: {e}"))
             })?;
 
         debug!("[gRPC CDH] Get resource successfully!");
@@ -109,7 +109,7 @@ impl SecureMountService for Arc<Cdh> {
         let mount_path = self.inner.secure_mount(storage).await.map_err(|e| {
             let detailed_error = format_error!(e);
             error!("[gRPC CDH] Call CDH to secure mount failed:\n{detailed_error}");
-            Status::internal(format!("[ERROR] CDH secure mount failed: {}", e))
+            Status::internal(format!("[CDH] [ERROR]: {e}"))
         })?;
 
         debug!("[gRPC CDH] Secure mount successfully!");
@@ -136,7 +136,7 @@ impl ImagePullService for Arc<Cdh> {
             .map_err(|e| {
                 let detailed_error = format_error!(e);
                 error!("[gRPC CDH] Call CDH to pull image failed:\n{detailed_error}");
-                Status::internal(format!("[ERROR] CDH image pulling failed: {}", e))
+                Status::internal(format!("[CDH] [ERROR]: {e}"))
             })?;
 
         debug!("[gRPC CDH] Pull image successfully!");
@@ -185,7 +185,7 @@ impl KeyProviderService for Arc<Cdh> {
             .map_err(|e| {
                 let detailed_error = format_error!(e);
                 error!("[gRPC CDH] Call CDH to Unwrap Key failed:\n{detailed_error}");
-                Status::internal(format!("[ERROR] CDH Unwrap Key failed: {}", e))
+                Status::internal(format!("[CDH] [ERROR]: {e}"))
             })?;
 
         // Construct output structure and serialize it as the return value of gRPC

--- a/confidential-data-hub/hub/src/bin/ttrpc_server/mod.rs
+++ b/confidential-data-hub/hub/src/bin/ttrpc_server/mod.rs
@@ -55,7 +55,7 @@ impl SealedSecretService for Server {
             error!("[ttRPC CDH] UnsealSecret :\n{detailed_error}");
             let mut status = Status::new();
             status.set_code(Code::INTERNAL);
-            status.set_message("[CDH] [ERROR]: Unseal Secret failed".into());
+            status.set_message(format!("[CDH] [ERROR]: {e}"));
             Error::RpcStatus(status)
         })?;
 
@@ -79,7 +79,7 @@ impl GetResourceService for Server {
             error!("[ttRPC CDH] GetResource :\n{detailed_error}");
             let mut status = Status::new();
             status.set_code(Code::INTERNAL);
-            status.set_message("[CDH] [ERROR]: Get Resource failed".into());
+            status.set_message(format!("[CDH] [ERROR]: {e}"));
             Error::RpcStatus(status)
         })?;
 
@@ -121,7 +121,7 @@ impl KeyProviderService for Server {
             error!("[ttRPC CDH] UnWrapKey :\n{detailed_error}");
             let mut status = Status::new();
             status.set_code(Code::INTERNAL);
-            status.set_message("[CDH] [ERROR]: UnwrapKey failed".to_string());
+            status.set_message(format!("[CDH] [ERROR]: {e}"));
             Error::RpcStatus(status)
         })?;
 
@@ -167,7 +167,7 @@ impl SecureMountService for Server {
             error!("[ttRPC CDH] Secure Mount :\n{detailed_error}");
             let mut status = Status::new();
             status.set_code(Code::INTERNAL);
-            status.set_message("[CDH] [ERROR]: secure mount failed".to_string());
+            status.set_message(format!("[CDH] [ERROR]: {e}"));
             Error::RpcStatus(status)
         })?;
 
@@ -195,7 +195,7 @@ impl ImagePullService for Server {
                 error!("[ttRPC CDH] Pull Image :\n{detailed_error}");
                 let mut status = Status::new();
                 status.set_code(Code::INTERNAL);
-                status.set_message("[CDH] [ERROR]: pull image failed".to_string());
+                status.set_message(format!("[CDH] [ERROR]: {e}"));
                 Error::RpcStatus(status)
             })?;
 

--- a/confidential-data-hub/hub/src/config.rs
+++ b/confidential-data-hub/hub/src/config.rs
@@ -167,7 +167,7 @@ mod tests {
     use std::{env, io::Write};
 
     use anyhow::anyhow;
-    use image_rs::config::ImageConfig;
+    use image_rs::config::{ImageConfig, ProxyConfig};
     use rstest::rstest;
 
     use crate::{config::DEFAULT_CDH_SOCKET_ADDR, CdhConfig, KbsConfig};
@@ -188,7 +188,9 @@ sigstore_config_uri = "kbs:///default/sigstore-config/test"
 image_security_policy_uri = "kbs:///default/security-policy/test"
 authenticated_registry_credentials_uri = "kbs:///default/credential/test"
 extra_root_certificates = ["cert1", "cert2"]
-image_pull_proxy = "http://127.0.0.1:8080"
+
+[image.image_pull_proxy]
+https_proxy = "http://127.0.0.1:8080"
     "#,
         Some(CdhConfig {
             kbc: KbsConfig {
@@ -202,8 +204,11 @@ image_pull_proxy = "http://127.0.0.1:8080"
                 sigstore_config_uri: Some("kbs:///default/sigstore-config/test".to_string()),
                 image_security_policy_uri: Some("kbs:///default/security-policy/test".to_string()),
                 authenticated_registry_credentials_uri: Some("kbs:///default/credential/test".to_string()),
-                image_pull_proxy: Some("http://127.0.0.1:8080".into()),
-                skip_proxy_ips: None,
+                image_pull_proxy: Some(ProxyConfig {
+                    https_proxy: Some("http://127.0.0.1:8080".into()),
+                    http_proxy: None,
+                    no_proxy: None,
+                }),
                 extra_root_certificates: vec!["cert1".into(), "cert2".into()],
                 ..Default::default()
             },
@@ -240,7 +245,6 @@ name = "offline_fs_kbc"
                 image_security_policy_uri: None,
                 authenticated_registry_credentials_uri: None,
                 image_pull_proxy: None,
-                skip_proxy_ips: None,
                 ..Default::default()
         },
         socket: DEFAULT_CDH_SOCKET_ADDR.to_string(),
@@ -266,7 +270,6 @@ some_undefined_field = "unknown value"
                 image_security_policy_uri: None,
                 authenticated_registry_credentials_uri: None,
                 image_pull_proxy: None,
-                skip_proxy_ips: None,
                 ..Default::default()
         },
         socket: DEFAULT_CDH_SOCKET_ADDR.to_string(),

--- a/confidential-data-hub/hub/src/error.rs
+++ b/confidential-data-hub/hub/src/error.rs
@@ -16,27 +16,53 @@ pub enum Error {
         source: kms::Error,
     },
 
-    #[error("get resource failed")]
+    #[error("Get Resource failed")]
     GetResource {
         #[source]
         source: kms::Error,
     },
 
-    #[error("decrypt image (unwrap key) failed")]
+    #[error("Decrypt Image (UnwrapKey) failed")]
     ImageDecryption(#[from] image::Error),
 
     #[error("init Hub failed: {0}")]
     InitializationFailed(String),
 
-    #[error("unseal secret failed")]
+    #[error("Unseal Secret failed")]
     UnsealSecret(#[from] secret::SecretError),
 
-    #[error("secure mount failed")]
+    #[error("Secure Mount failed")]
     SecureMount(#[from] storage::Error),
 
-    #[error("image pull failed")]
-    ImagePull {
-        #[source]
-        source: anyhow::Error,
-    },
+    #[error("Image Pull error: {0}")]
+    ImagePull(#[from] image_rs::image::PullImageError),
+
+    #[error("Image Client error: {0}")]
+    ImageClient(#[from] image_rs::builder::BuilderError),
+}
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use anyhow::anyhow;
+    use image_rs::signature::SignatureError;
+    use rstest::rstest;
+
+    #[rstest]
+    #[case(Error::KbsClient { source: kms::Error::KbsClientError("details".into()) }, "kbs client initialization failed")]
+    #[case(Error::GetResource { source: kms::Error::KbsClientError("details".into()) }, "Get Resource failed")]
+    #[case(
+        Error::UnsealSecret(secret::SecretError::VersionError),
+        "Unseal Secret failed"
+    )]
+    #[case(
+        Error::SecureMount(storage::Error::StorageTypeNotRecognized(
+            strum::ParseError::VariantNotFound
+        )),
+        "Secure Mount failed"
+    )]
+    #[case(Error::ImagePull(image_rs::image::PullImageError::SignatureValidationFailed(SignatureError::DeniedByPolicy { source: anyhow!("some details")})), "Image Pull error: Image policy rejected: Denied by policy: some details")]
+    fn test_brief_message(#[case] error: Error, #[case] expected: &str) {
+        let brief_message = error.to_string();
+        assert_eq!(brief_message, expected);
+    }
 }

--- a/confidential-data-hub/hub/src/hub.rs
+++ b/confidential-data-hub/hub/src/hub.rs
@@ -90,8 +90,7 @@ impl DataHub for Hub {
             .lock()
             .await
             .pull_image(image_url, Path::new(bundle_path), &None, &None)
-            .await
-            .map_err(|e| Error::ImagePull { source: e })?;
+            .await?;
         Ok(manifest_digest)
     }
 }
@@ -99,12 +98,7 @@ impl DataHub for Hub {
 async fn initialize_image_client(config: ImageConfig) -> Result<Mutex<ImageClient>> {
     debug!("Image client lazy initializing...");
 
-    let image_client = Into::<ClientBuilder>::into(config)
-        .build()
-        .await
-        .map_err(|e| {
-            Error::InitializationFailed(format!("failed to initialize image pull client :{e:?}"))
-        })?;
+    let image_client = Into::<ClientBuilder>::into(config).build().await?;
 
     Ok(Mutex::new(image_client))
 }

--- a/confidential-data-hub/hub/src/image/ocicrypt_config.json
+++ b/confidential-data-hub/hub/src/image/ocicrypt_config.json
@@ -1,0 +1,7 @@
+{
+    "key-providers": {
+        "attestation-agent": {
+            "ttrpc": "unix:///run/confidential-containers/cdh.sock"
+        }
+    }
+}

--- a/image-rs/Cargo.toml
+++ b/image-rs/Cargo.toml
@@ -50,7 +50,7 @@ serde = { workspace = true, features = ["serde_derive", "rc"] }
 serde_json.workspace = true
 serde_yaml = { version = "0.9", optional = true }
 sha2.workspace = true
-sigstore = { git = "https://github.com/sigstore/sigstore-rs.git", rev = "5df33d6b7d0590a534948a2b9b415cd6e13bafdc", default-features = false, optional = true }
+sigstore = { version = "0.12.1", default-features = false, optional = true }
 strum.workspace = true
 strum_macros = "0.27"
 astral-tokio-tar = "0.5.1"

--- a/image-rs/Cargo.toml
+++ b/image-rs/Cargo.toml
@@ -54,6 +54,7 @@ sigstore = { git = "https://github.com/sigstore/sigstore-rs.git", rev = "5df33d6
 strum.workspace = true
 strum_macros = "0.27"
 astral-tokio-tar = "0.5.1"
+thiserror.workspace = true
 tokio.workspace = true
 tokio-util = "0.7.15"
 toml.workspace = true

--- a/image-rs/libs/test-utils/src/lib.rs
+++ b/image-rs/libs/test-utils/src/lib.rs
@@ -18,9 +18,9 @@ macro_rules! assert_result {
             assert!($actual_result.is_err(), "{}", $msg);
 
             let expected_error = $expected_result.as_ref().unwrap_err();
-            let expected_error_msg = format!("{:?}", expected_error);
+            let expected_error_msg = format!("{}", expected_error);
 
-            let actual_error_msg = format!("{:?}", $actual_result.unwrap_err());
+            let actual_error_msg = format!("{}", $actual_result.unwrap_err());
 
             assert!(expected_error_msg == actual_error_msg, "{}", $msg);
         }

--- a/image-rs/src/builder.rs
+++ b/image-rs/src/builder.rs
@@ -133,7 +133,6 @@ impl ClientBuilder {
                     &policy_bytes,
                     sigstore_config,
                     &self.config.work_dir,
-                    self.config.skip_proxy_ips.clone(),
                     self.config.image_pull_proxy.clone(),
                     self.config.extra_root_certificates.clone(),
                     resource_provider.clone(),

--- a/image-rs/src/builder.rs
+++ b/image-rs/src/builder.rs
@@ -3,24 +3,49 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-use std::{path::PathBuf, str::FromStr, sync::Arc};
+use std::{path::PathBuf, sync::Arc};
 
 use log::{info, warn};
+use thiserror::Error;
 use tokio::sync::RwLock;
 
 use crate::{
-    auth::Auth,
+    auth::{Auth, AuthError},
     config::{ImageConfig, NydusConfig},
     image::ImageClient,
     layer_store::LayerStore,
     meta_store::{MetaStore, METAFILE},
     registry::RegistryHandler,
-    resource::ResourceProvider,
-    signature::SignatureValidator,
+    resource::{ResourceError, ResourceProvider},
+    signature::{SignatureError, SignatureValidator},
     snapshots::SnapshotType,
 };
 
-use anyhow::{Context, Result};
+pub type BuilderResult<T> = std::result::Result<T, BuilderError>;
+
+#[derive(Error, Debug)]
+pub enum BuilderError {
+    #[error("Malwared registry configuration: {source}")]
+    InvalidRegistryConfiguration {
+        #[source]
+        source: anyhow::Error,
+    },
+
+    #[error("Initialize layer store failed: {source}")]
+    InitializeLayerStoreFailed {
+        #[source]
+        source: anyhow::Error,
+    },
+
+    #[error("Initialize resource provider failed: {0}")]
+    InitializeResourceProviderFailed(#[from] ResourceError),
+
+    #[error("Initialize auth module failed: {0}")]
+    InitializeAuthFailed(#[from] AuthError),
+
+    #[error("Initialize signature validator failed: {0}")]
+    InitializeSignatureValidatorFailed(#[from] SignatureError),
+}
 
 #[derive(Default)]
 pub struct ClientBuilder {
@@ -71,7 +96,7 @@ impl ClientBuilder {
     #[cfg(feature = "keywrap-native")]
     __impl_config!(kbs_uri, kbs_uri, String);
 
-    pub async fn build(self) -> Result<ImageClient> {
+    pub async fn build(self) -> BuilderResult<ImageClient> {
         #[cfg(feature = "keywrap-native")]
         let resource_provider = Arc::new(ResourceProvider::new(
             &self.config.kbc,
@@ -104,7 +129,7 @@ impl ClientBuilder {
             Some(uri) => {
                 info!("getting image security policy from {uri} ...");
                 let policy_bytes = resource_provider.get_resource(uri).await?;
-                let auth = SignatureValidator::new(
+                let signature_validator = SignatureValidator::new(
                     &policy_bytes,
                     sigstore_config,
                     &self.config.work_dir,
@@ -114,7 +139,7 @@ impl ClientBuilder {
                     resource_provider.clone(),
                 )
                 .await?;
-                Some(auth)
+                Some(signature_validator)
             }
             None => {
                 warn!("No `image_security_policy_uri` given, thus all images can be pulled by the image client without filtering.");
@@ -126,9 +151,8 @@ impl ClientBuilder {
             Some(uri) => {
                 info!("getting registry configuration from {uri} ...");
                 let registry_configuration = resource_provider.get_resource(uri).await?;
-                let registry_configuration = String::from_utf8(registry_configuration)
-                    .context("illegal registry configuration")?;
-                let registry_handler = RegistryHandler::from_str(&registry_configuration)?;
+                let registry_handler = RegistryHandler::from_vec(registry_configuration)
+                    .map_err(|source| BuilderError::InvalidRegistryConfiguration { source })?;
                 Some(registry_handler)
             }
             None => None,
@@ -153,7 +177,8 @@ impl ClientBuilder {
         info!("Image work directory: {:?}", self.config.work_dir);
         let meta_store = Arc::new(RwLock::new(meta_store));
 
-        let layer_store = LayerStore::new(self.config.work_dir.clone())?;
+        let layer_store = LayerStore::new(self.config.work_dir.clone())
+            .map_err(|source| BuilderError::InitializeLayerStoreFailed { source })?;
 
         Ok(ImageClient {
             registry_auth,

--- a/image-rs/src/builder.rs
+++ b/image-rs/src/builder.rs
@@ -145,7 +145,11 @@ impl ClientBuilder {
             }
         };
 
-        let snapshots = ImageClient::init_snapshots(&self.config.work_dir, &meta_store);
+        let snapshot = ImageClient::init_snapshot(
+            &self.config.default_snapshot,
+            &self.config.work_dir,
+            &meta_store,
+        );
         info!("Image work directory: {:?}", self.config.work_dir);
         let meta_store = Arc::new(RwLock::new(meta_store));
 
@@ -156,7 +160,7 @@ impl ClientBuilder {
             signature_validator,
             registry_handler,
             meta_store,
-            snapshots,
+            snapshot,
             config: self.config,
             layer_store,
         })

--- a/image-rs/src/config.rs
+++ b/image-rs/src/config.rs
@@ -164,10 +164,7 @@ impl Default for ImageConfig {
     fn default() -> ImageConfig {
         ImageConfig {
             work_dir: PathBuf::from(DEFAULT_WORK_DIR.to_string()),
-            #[cfg(feature = "snapshot-overlayfs")]
-            default_snapshot: SnapshotType::Overlay,
-            #[cfg(not(feature = "snapshot-overlayfs"))]
-            default_snapshot: SnapshotType::Unknown,
+            default_snapshot: SnapshotType::default(),
             max_concurrent_layer_downloads_per_image: DEFAULT_MAX_CONCURRENT_DOWNLOAD,
             #[cfg(feature = "nydus")]
             nydus_config: Some(NydusConfig::default()),
@@ -252,10 +249,7 @@ impl ImageConfig {
     pub fn from_kernel_cmdline() -> Self {
         let mut res = ImageConfig {
             work_dir: PathBuf::from(DEFAULT_WORK_DIR.to_string()),
-            #[cfg(feature = "snapshot-overlayfs")]
-            default_snapshot: SnapshotType::Overlay,
-            #[cfg(not(feature = "snapshot-overlayfs"))]
-            default_snapshot: SnapshotType::Unknown,
+            default_snapshot: SnapshotType::default(),
             max_concurrent_layer_downloads_per_image: DEFAULT_MAX_CONCURRENT_DOWNLOAD,
             #[cfg(feature = "nydus")]
             nydus_config: Some(NydusConfig::default()),

--- a/image-rs/src/decoder/mod.rs
+++ b/image-rs/src/decoder/mod.rs
@@ -5,14 +5,19 @@
 use std::fmt;
 use std::io;
 
-use anyhow::{bail, Result};
 use oci_client::manifest;
 use oci_spec::image::MediaType;
 use serde::{Deserialize, Serialize};
+use thiserror::Error;
 use tokio::io::{AsyncRead, BufReader};
 
-/// Error message for unhandled media type.
-pub const ERR_BAD_MEDIA_TYPE: &str = "unhandled media type";
+pub type DecodeResult<T> = std::result::Result<T, DecodeError>;
+
+#[derive(Error, Debug)]
+pub enum DecodeError {
+    #[error("unhandled media type: {0}")]
+    BadMediaType(String),
+}
 
 /// Represents the layer compression algorithm type,
 /// and allows to decompress corresponding compressed data.
@@ -104,7 +109,7 @@ where
 }
 
 impl TryFrom<&str> for Compression {
-    type Error = anyhow::Error;
+    type Error = DecodeError;
 
     fn try_from(s: &str) -> Result<Self, Self::Error> {
         let mut media_type_str = s;
@@ -126,7 +131,7 @@ impl TryFrom<&str> for Compression {
             MediaType::ImageLayerZstd | MediaType::ImageLayerNonDistributableZstd => {
                 Compression::Zstd
             }
-            _ => bail!("{}: {}", ERR_BAD_MEDIA_TYPE, media_type),
+            _ => return Err(DecodeError::BadMediaType(media_type_str.into())),
         };
 
         Ok(decoder)
@@ -136,7 +141,6 @@ impl TryFrom<&str> for Compression {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use anyhow::anyhow;
     use flate2::write::GzEncoder;
     use std::io::Write;
 
@@ -245,21 +249,21 @@ mod tests {
         #[derive(Debug)]
         struct TestData<'a> {
             media_type_str: &'a str,
-            result: Result<Compression>,
+            result: DecodeResult<Compression>,
         }
 
         let tests = &[
             TestData {
                 media_type_str: "",
-                result: Err(anyhow!("{}: {}", ERR_BAD_MEDIA_TYPE, "")),
+                result: Err(DecodeError::BadMediaType("".into())),
             },
             TestData {
                 media_type_str: "foo",
-                result: Err(anyhow!("{}: {}", ERR_BAD_MEDIA_TYPE, "foo")),
+                result: Err(DecodeError::BadMediaType("foo".into())),
             },
             TestData {
                 media_type_str: "foo/ bar",
-                result: Err(anyhow!("{}: {}", ERR_BAD_MEDIA_TYPE, "foo/ bar")),
+                result: Err(DecodeError::BadMediaType("foo/ bar".into())),
             },
             TestData {
                 media_type_str: manifest::IMAGE_LAYER_MEDIA_TYPE,

--- a/image-rs/src/image.rs
+++ b/image-rs/src/image.rs
@@ -351,17 +351,29 @@ impl ImageClient {
             client_config.protocol = ClientProtocol::Http;
         }
 
-        if let Some(no_proxy) = &self.config.skip_proxy_ips {
-            client_config.no_proxy = Some(no_proxy.clone())
-        }
+        if let Some(proxy_config) = &self.config.image_pull_proxy {
+            if let Some(no_proxy) = &proxy_config.no_proxy {
+                client_config.no_proxy = Some(no_proxy.clone())
+            }
 
-        if let Some(https_proxy) = &self.config.image_pull_proxy {
-            client_config.https_proxy = Some(https_proxy.clone());
-            if task.task_type != TaskType::Origininal && !task.use_http {
-                warn!(
-                    "The image pull try from {} will use the configured https proxy",
-                    task.image_reference
-                );
+            if let Some(https_proxy) = &proxy_config.https_proxy {
+                client_config.https_proxy = Some(https_proxy.clone());
+                if task.task_type != TaskType::Origininal && !task.use_http {
+                    warn!(
+                        "The image pull try from {} will use the configured https proxy",
+                        task.image_reference
+                    );
+                }
+            }
+
+            if let Some(http_proxy) = &proxy_config.http_proxy {
+                client_config.http_proxy = Some(http_proxy.clone());
+                if task.task_type != TaskType::Origininal && task.use_http {
+                    warn!(
+                        "The image pull try from {} will use the configured http proxy",
+                        task.image_reference
+                    );
+                }
             }
         }
 

--- a/image-rs/src/lib.rs
+++ b/image-rs/src/lib.rs
@@ -2,8 +2,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-pub const ERR_BAD_UNCOMPRESSED_DIGEST: &str = "unsupported uncompressed digest format";
-
 pub mod auth;
 pub mod builder;
 pub mod bundle;
@@ -23,6 +21,5 @@ pub mod resource;
 pub mod signature;
 pub mod snapshots;
 pub mod stream;
-pub mod unpack;
 #[cfg(feature = "verity")]
 pub mod verity;

--- a/image-rs/src/registry/mod.rs
+++ b/image-rs/src/registry/mod.rs
@@ -112,17 +112,14 @@ enum MatchResult {
     Unmatched,
 }
 
-impl FromStr for RegistryHandler {
-    type Err = anyhow::Error;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let mut config: Config = toml::from_str(s)?;
+impl RegistryHandler {
+    pub fn from_vec(s: Vec<u8>) -> Result<Self> {
+        let registry_configuration = String::from_utf8(s)?;
+        let mut config: Config = toml::from_str(&registry_configuration)?;
         config.validate_and_tidy()?;
         Ok(Self { config })
     }
-}
 
-impl RegistryHandler {
     fn generate_unqualified_search_tasks(&self, reference: &Reference) -> Vec<ImagePullTask> {
         let mut tasks = Vec::new();
 
@@ -371,7 +368,7 @@ location = "docker.io"
 location = "123456.mirror.aliyuncs.com"
 "#;
 
-        RegistryHandler::from_str(config).unwrap()
+        RegistryHandler::from_vec(config.as_bytes().to_vec()).unwrap()
     }
 
     #[test]

--- a/image-rs/src/resource/mod.rs
+++ b/image-rs/src/resource/mod.rs
@@ -10,13 +10,43 @@
 //! - `file://`: from the local filesystem
 //! - `kbs://`: using secure channel to fetch from the KBS
 
-use std::path::Path;
+use std::{io, path::Path};
 
-use anyhow::*;
+use anyhow::anyhow;
+use thiserror::Error;
 use tokio::fs;
 
 #[cfg(feature = "kbs")]
 pub mod kbs;
+
+pub type ResourceResult<T> = std::result::Result<T, ResourceError>;
+
+#[derive(Error, Debug)]
+pub enum ResourceError {
+    #[error("Failed to establish secure channel: {source}")]
+    EstablishSecureChannel {
+        #[source]
+        source: anyhow::Error,
+    },
+
+    #[error("Get resource failed: {source}")]
+    GetResource {
+        #[source]
+        source: anyhow::Error,
+    },
+
+    #[error("`kbs` feature not enabled, cannot support fetch resource")]
+    KbsFeatureNotEnabled,
+
+    #[error("Resource URI scheme `{0}` not supported")]
+    UnsupportedScheme(String),
+
+    #[error("Failed to read local file")]
+    ReadLocalFile {
+        #[source]
+        source: io::Error,
+    },
+}
 
 #[derive(Default)]
 pub struct ResourceProvider {
@@ -25,9 +55,10 @@ pub struct ResourceProvider {
 }
 
 impl ResourceProvider {
-    pub fn new(_kbc_name: &str, _kbs_uri: &str, _work_dir: &Path) -> Result<Self> {
+    pub fn new(_kbc_name: &str, _kbs_uri: &str, _work_dir: &Path) -> ResourceResult<Self> {
         #[cfg(feature = "kbs")]
-        let secure_channel = kbs::SecureChannel::new(_kbc_name, _kbs_uri, _work_dir)?;
+        let secure_channel = kbs::SecureChannel::new(_kbc_name, _kbs_uri, _work_dir)
+            .map_err(|source| ResourceError::EstablishSecureChannel { source })?;
         Ok(Self {
             #[cfg(feature = "kbs")]
             secure_channel,
@@ -39,35 +70,39 @@ impl ResourceProvider {
     /// The resource will be retrieved in different ways due to different schemes.
     /// If no scheme is given, it will by default use `file://` to look for the file
     /// in the local filesystem.
-    pub async fn get_resource(&self, uri: &str) -> Result<Vec<u8>> {
+    pub async fn get_resource(&self, uri: &str) -> ResourceResult<Vec<u8>> {
         let uri = if uri.contains("://") {
             uri.to_string()
         } else {
             "file://".to_owned() + uri
         };
 
-        let url = url::Url::parse(&uri).map_err(|e| anyhow!("Failed to parse: {:?}", e))?;
+        let url = url::Url::parse(&uri).map_err(|e| ResourceError::GetResource {
+            source: anyhow!("Failed to parse resource uri: {:?}", e),
+        })?;
         match url.scheme() {
             "kbs" => {
                 #[cfg(feature = "kbs")]
                 {
-                    self.secure_channel.get_resource(&uri).await
+                    self.secure_channel
+                        .get_resource(&uri)
+                        .await
+                        .map_err(|source| ResourceError::GetResource { source })
                 }
 
                 #[cfg(not(feature = "kbs"))]
                 {
-                    bail!(
-                        "`kbs` feature not enabled, cannot support fetch resource uri {}",
-                        uri
-                    )
+                    Err(ResourceError::KbsFeatureNotEnabled)
                 }
             }
             "file" => {
                 let path = url.path();
-                let content = fs::read(path).await?;
+                let content = fs::read(path)
+                    .await
+                    .map_err(|source| ResourceError::ReadLocalFile { source })?;
                 Ok(content)
             }
-            others => bail!("not support scheme {}", others),
+            others => Err(ResourceError::UnsupportedScheme(others.into())),
         }
     }
 }

--- a/image-rs/src/signature/mod.rs
+++ b/image-rs/src/signature/mod.rs
@@ -17,7 +17,7 @@ use anyhow::{bail, Context, Result};
 use oci_client::secrets::RegistryAuth;
 use thiserror::Error;
 
-use crate::resource::ResourceProvider;
+use crate::{config::ProxyConfig, resource::ResourceProvider};
 
 /// Image security config dir contains important information such as
 /// security policy configuration file and signature verification configuration file.
@@ -62,8 +62,7 @@ pub struct SignatureValidator {
 
     resource_provider: Arc<ResourceProvider>,
 
-    no_proxy: Option<String>,
-    https_proxy: Option<String>,
+    proxy_config: Option<ProxyConfig>,
 
     #[cfg(feature = "signature-simple")]
     simple_signing_sigstore_config: Option<policy::SigstoreConfig>,
@@ -157,8 +156,7 @@ impl SignatureValidator {
         policy: &[u8],
         _simple_signing_sigstore_config: Option<Vec<u8>>,
         workdir: &Path,
-        no_proxy: Option<String>,
-        https_proxy: Option<String>,
+        proxy_config: Option<ProxyConfig>,
         certificates: Vec<String>,
         resource_provider: Arc<ResourceProvider>,
     ) -> SignatureResult<Self> {
@@ -200,8 +198,7 @@ impl SignatureValidator {
         Ok(Self {
             policy,
             resource_provider,
-            no_proxy,
-            https_proxy,
+            proxy_config,
             certificates,
             #[cfg(feature = "signature-simple")]
             simple_signing_sigstore_config,

--- a/image-rs/src/signature/mod.rs
+++ b/image-rs/src/signature/mod.rs
@@ -139,7 +139,8 @@ impl SignatureValidator {
         // Get the policy set that matches the image.
         let reqs = self.policy.requirements_for_image(&image);
         if reqs.is_empty() {
-            bail!("List of verification policy requirements must not be empty");
+            // Note that if no policy covers the image, the image is considered to be allowed.
+            return Ok(());
         }
 
         // The image must meet the requirements of each policy in the policy set.

--- a/image-rs/src/signature/mod.rs
+++ b/image-rs/src/signature/mod.rs
@@ -15,12 +15,47 @@ pub use policy::Policy;
 
 use anyhow::{bail, Context, Result};
 use oci_client::secrets::RegistryAuth;
+use thiserror::Error;
 
 use crate::resource::ResourceProvider;
 
 /// Image security config dir contains important information such as
 /// security policy configuration file and signature verification configuration file.
 pub const IMAGE_SECURITY_CONFIG_SUBDIR: &str = "image-security";
+
+pub type SignatureResult<T> = std::result::Result<T, SignatureError>;
+
+#[derive(Error, Debug)]
+pub enum SignatureError {
+    #[error("Failed to parse image reference: {0}")]
+    IllegalImageReference(String),
+
+    #[error("Illegal image digest: {0}")]
+    IllegalImageDigest(String),
+
+    #[error("Denied by policy: {source}")]
+    DeniedByPolicy {
+        #[source]
+        source: anyhow::Error,
+    },
+
+    #[error("Invalid image policy file")]
+    InvalidPolicyFile,
+
+    #[error("Failed to initialize work dir")]
+    InitializeWorkDir,
+
+    #[cfg(feature = "signature-simple")]
+    #[error("Invalid simple signing sigstore config")]
+    InvalidSimpleSigningSigstoreConfig,
+
+    #[cfg(feature = "signature-simple")]
+    #[error("Failed to update sigstore config")]
+    SigstoreConfigUpdateFailed {
+        #[source]
+        source: anyhow::Error,
+    },
+}
 
 pub struct SignatureValidator {
     policy: Policy,
@@ -70,10 +105,14 @@ impl SignatureValidator {
                 "Policy `reject` rejects image {}",
                 image.reference.to_string()
             ),
-            PolicyReqType::SimpleSigning(inner) => {
-                self.simple_signing_allows_image(inner, image, auth).await
-            }
-            PolicyReqType::Cosign(inner) => self.cosign_allows_image(inner, image, auth).await,
+            PolicyReqType::SimpleSigning(inner) => self
+                .simple_signing_allows_image(inner, image, auth)
+                .await
+                .context("rejected by `signedBy` rule"),
+            PolicyReqType::Cosign(inner) => self
+                .cosign_allows_image(inner, image, auth)
+                .await
+                .context("rejected by `sigstoreSigned` rule"),
         }
     }
 
@@ -89,10 +128,13 @@ impl SignatureValidator {
         image_reference: &str,
         image_digest: &str,
         auth: &RegistryAuth,
-    ) -> Result<()> {
-        let reference = oci_client::Reference::try_from(image_reference)?;
+    ) -> SignatureResult<()> {
+        let reference = oci_client::Reference::try_from(image_reference)
+            .map_err(|_| SignatureError::IllegalImageReference(image_reference.to_string()))?;
         let mut image = Image::default_with_reference(reference);
-        image.set_manifest_digest(image_digest)?;
+        image
+            .set_manifest_digest(image_digest)
+            .map_err(|_| SignatureError::IllegalImageDigest(image_digest.to_string()))?;
 
         // Get the policy set that matches the image.
         let reqs = self.policy.requirements_for_image(&image);
@@ -102,7 +144,9 @@ impl SignatureValidator {
 
         // The image must meet the requirements of each policy in the policy set.
         for req in reqs.iter() {
-            self.check_image_requirement(req, &image, auth).await?;
+            self.check_image_requirement(req, &image, auth)
+                .await
+                .map_err(|source| SignatureError::DeniedByPolicy { source })?;
         }
 
         Ok(())
@@ -116,9 +160,12 @@ impl SignatureValidator {
         https_proxy: Option<String>,
         certificates: Vec<String>,
         resource_provider: Arc<ResourceProvider>,
-    ) -> Result<Self> {
-        let policy: Policy = serde_json::from_slice(policy).context("parse image policy")?;
-        tokio::fs::create_dir_all(workdir.join(IMAGE_SECURITY_CONFIG_SUBDIR)).await?;
+    ) -> SignatureResult<Self> {
+        let policy: Policy =
+            serde_json::from_slice(policy).map_err(|_| SignatureError::InvalidPolicyFile)?;
+        tokio::fs::create_dir_all(workdir.join(IMAGE_SECURITY_CONFIG_SUBDIR))
+            .await
+            .map_err(|_| SignatureError::InitializeWorkDir)?;
 
         #[cfg(feature = "signature-simple")]
         let simple_signing_sigstore_config = match _simple_signing_sigstore_config {
@@ -126,12 +173,14 @@ impl SignatureValidator {
                 let sig_store_config_dir = workdir.join(policy::simple::SIG_STORE_CONFIG_SUB_DIR);
                 tokio::fs::create_dir_all(&sig_store_config_dir)
                     .await
-                    .context("Create Simple Signing sigstore-config dir failed")?;
-                let mut sigstore_config: policy::SigstoreConfig =
-                    serde_yaml::from_slice(&cfg).context("parse simple signing sigstore config")?;
+                    .map_err(|_| SignatureError::InitializeWorkDir)?;
+                let mut sigstore_config: policy::SigstoreConfig = serde_yaml::from_slice(&cfg)
+                    .context("parse simple signing sigstore config")
+                    .map_err(|_| SignatureError::InvalidSimpleSigningSigstoreConfig)?;
                 sigstore_config
                     .update_from_path(&sig_store_config_dir)
-                    .await?;
+                    .await
+                    .map_err(|source| SignatureError::SigstoreConfigUpdateFailed { source })?;
                 Some(sigstore_config)
             }
             None => None,

--- a/image-rs/src/signature/policy/cosign/mod.rs
+++ b/image-rs/src/signature/policy/cosign/mod.rs
@@ -21,8 +21,11 @@ use sigstore::{
 };
 use std::{str::FromStr, sync::Arc};
 
-use crate::signature::{
-    image::Image, payload::simple_signing::SigPayload, policy::ref_match::PolicyReqMatchType,
+use crate::{
+    config::ProxyConfig,
+    signature::{
+        image::Image, payload::simple_signing::SigPayload, policy::ref_match::PolicyReqMatchType,
+    },
 };
 use crate::{resource::ResourceProvider, signature::SignatureValidator};
 
@@ -42,8 +45,7 @@ impl SignatureValidator {
                 image,
                 auth,
                 self.certificates.iter().collect(),
-                self.no_proxy.as_ref(),
-                self.https_proxy.as_ref(),
+                self.proxy_config.as_ref(),
             )
             .await
     }
@@ -56,8 +58,7 @@ impl CosignParameters {
         image: &Image,
         auth: &RegistryAuth,
         certificates: Vec<&Certificate>,
-        no_proxy: Option<&String>,
-        https_proxy: Option<&String>,
+        proxy_config: Option<&ProxyConfig>,
     ) -> Result<()> {
         // Check before we access the network
         self.check_reference_rule_types()?;
@@ -72,7 +73,7 @@ impl CosignParameters {
 
         // Verification, will access the network
         let payloads = self
-            .verify_signature_and_get_payload(image, auth, key, certificates, no_proxy, https_proxy)
+            .verify_signature_and_get_payload(image, auth, key, certificates, proxy_config)
             .await?;
 
         // check the reference rules (signed identity)
@@ -112,14 +113,14 @@ impl CosignParameters {
     ///   using the pubkey.
     ///
     /// If succeeds, the payloads of the signature will be returned.
+    #[allow(clippy::too_many_arguments)]
     async fn verify_signature_and_get_payload(
         &self,
         image: &Image,
         auth: &RegistryAuth,
         key: Vec<u8>,
         certificates: Vec<&Certificate>,
-        no_proxy: Option<&String>,
-        https_proxy: Option<&String>,
+        proxy_config: Option<&ProxyConfig>,
     ) -> Result<Vec<SigPayload>> {
         let image_ref = OciReference::from_str(&image.reference.whole())?;
         let auth = match auth {
@@ -128,12 +129,17 @@ impl CosignParameters {
             RegistryAuth::Bearer(token) => Auth::Bearer(token.clone()),
         };
 
-        let config = ClientConfig {
-            no_proxy: no_proxy.cloned(),
-            https_proxy: https_proxy.cloned(),
+        let mut config = ClientConfig {
             extra_root_certificates: certificates.into_iter().cloned().collect(),
             ..Default::default()
         };
+
+        if let Some(proxy) = proxy_config {
+            config.http_proxy = proxy.http_proxy.clone();
+            config.https_proxy = proxy.https_proxy.clone();
+            config.no_proxy = proxy.no_proxy.clone();
+        }
+
         let mut client = ClientBuilder::default()
             .with_oci_client_config(config)
             .build()?;
@@ -243,7 +249,6 @@ mod tests {
                 &oci_client::secrets::RegistryAuth::Anonymous,
                 key,
                 vec![],
-                None,
                 None,
             )
             .await;
@@ -359,7 +364,6 @@ mod tests {
                     &image,
                     &oci_client::secrets::RegistryAuth::Anonymous,
                     vec![],
-                    None,
                     None,
                 )
                 .await;

--- a/image-rs/src/snapshots/mod.rs
+++ b/image-rs/src/snapshots/mod.rs
@@ -15,7 +15,6 @@ pub mod overlay;
 #[derive(Clone, Copy, Debug, Deserialize, PartialEq, Eq, Hash)]
 #[serde(rename_all = "lowercase")]
 pub enum SnapshotType {
-    Unknown,
     #[cfg(feature = "snapshot-overlayfs")]
     Overlay,
     #[cfg(feature = "snapshot-unionfs")]
@@ -27,8 +26,10 @@ impl Default for SnapshotType {
         cfg_if::cfg_if! {
             if #[cfg(feature = "snapshot-overlayfs")] {
                 Self::Overlay
+            } else if #[cfg(feature = "snapshot-unionfs")] {
+                Self::OcclumUnionfs
             } else {
-                Self::Unknown
+                compile_error!("Either 'snapshot-overlayfs' or 'snapshot-unionfs' must be enabled to have at least one usable snapshot type.");
             }
         }
     }
@@ -37,7 +38,6 @@ impl Default for SnapshotType {
 impl std::fmt::Display for SnapshotType {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let out = match self {
-            Self::Unknown => "unknown",
             #[cfg(feature = "snapshot-overlayfs")]
             Self::Overlay => "overlay",
             #[cfg(feature = "snapshot-unionfs")]

--- a/ocicrypt-rs/src/blockcipher/mod.rs
+++ b/ocicrypt-rs/src/blockcipher/mod.rs
@@ -153,11 +153,11 @@ pub enum LayerBlockCipherHandler<R> {
     Aes256Ctr(AESCTRBlockCipher<R>),
 }
 
-impl<R> LayerBlockCipherHandler<R> {
+impl<R> Default for LayerBlockCipherHandler<R> {
     /// Create a [`LayerBlockCipherHandler`] object with default aes ctr block cipher
-    pub fn new() -> Result<LayerBlockCipherHandler<R>> {
-        let aes_ctr_block_cipher = AESCTRBlockCipher::new(256)?;
-        Ok(LayerBlockCipherHandler::Aes256Ctr(aes_ctr_block_cipher))
+    fn default() -> LayerBlockCipherHandler<R> {
+        let aes_ctr_block_cipher = AESCTRBlockCipher::new(256).unwrap();
+        LayerBlockCipherHandler::Aes256Ctr(aes_ctr_block_cipher)
     }
 }
 
@@ -246,7 +246,7 @@ mod tests {
         let layer_data: Vec<u8> = b"this is some data".to_vec();
 
         let mut lbco = LayerBlockCipherOptions::default();
-        let mut lbch = LayerBlockCipherHandler::new().unwrap();
+        let mut lbch = LayerBlockCipherHandler::default();
         assert!(lbch
             .encrypt(layer_data.as_slice(), AES256CTR, &mut lbco)
             .is_ok());
@@ -262,7 +262,7 @@ mod tests {
         let serialized_json = serde_json::to_string(&lbco).unwrap();
 
         // Decrypt with valid key
-        let mut lbch = LayerBlockCipherHandler::new().unwrap();
+        let mut lbch = LayerBlockCipherHandler::default();
         let mut lbco: LayerBlockCipherOptions =
             serde_json::from_str(&serialized_json).unwrap_or_default();
 
@@ -275,7 +275,7 @@ mod tests {
         assert_eq!(layer_data, plaintxt_data);
 
         // Decrypt with invalid key
-        let mut lbch = LayerBlockCipherHandler::new().unwrap();
+        let mut lbch = LayerBlockCipherHandler::default();
         lbco.private.symmetric_key = vec![0; 32];
         assert!(lbch.decrypt(encrypted_data.as_slice(), &mut lbco).is_ok());
         let LayerBlockCipherHandler::Aes256Ctr(mut decryptor) = lbch;

--- a/ocicrypt-rs/src/encryption.rs
+++ b/ocicrypt-rs/src/encryption.rs
@@ -233,7 +233,7 @@ pub fn encrypt_layer<'a, R: 'a + Read>(
     }
 
     if !encrypted {
-        let mut lbch = LayerBlockCipherHandler::new()?;
+        let mut lbch = LayerBlockCipherHandler::default();
         let mut lbco = LayerBlockCipherOptions::default();
 
         lbch.encrypt(layer_reader, AES256CTR, &mut lbco)?;
@@ -269,7 +269,7 @@ pub fn decrypt_layer<R: Read>(
         public: pub_opts,
         private: priv_opts,
     };
-    let mut lbch = LayerBlockCipherHandler::new()?;
+    let mut lbch = LayerBlockCipherHandler::default();
 
     lbch.decrypt(layer_reader, &mut opts)?;
 
@@ -293,7 +293,7 @@ pub fn async_decrypt_layer<R: tokio::io::AsyncRead + Send>(
         public: pub_opts,
         private: priv_opts,
     };
-    let mut lbch = LayerBlockCipherHandler::new()?;
+    let mut lbch = LayerBlockCipherHandler::default();
 
     lbch.decrypt(layer_reader, &mut opts)?;
 


### PR DESCRIPTION
This PR is mainly for move image-pull to cdh. It improves the log printing after CDH RPC call failure to keep the error information consistent with that when calling image-rs directly, and avoids a lot of useless debug trace information.

In addition, this PR includes an additional commit to abandon the Unknown Snapshot type. Please see the commit message for the specific reason.  cc @ChengyuZhu6 