### PR TITLE
ci: disable link checker temporarily

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -13,16 +13,16 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+      #  TODO: fix this workflow
+      # - name: Restore lychee cache
+      #   uses: actions/cache@v4
+      #   with:
+      #     path: .lycheecache
+      #     key: cache-lychee-${{ github.sha }}
+      #     restore-keys: cache-lychee-
 
-      - name: Restore lychee cache
-        uses: actions/cache@v4
-        with:
-          path: .lycheecache
-          key: cache-lychee-${{ github.sha }}
-          restore-keys: cache-lychee-
-
-      - name: Check links
-        uses: lycheeverse/lychee-action@v2
-        with:
-          args: "--cache --max-cache-age 1d ."
-          fail: true
+      # - name: Check links
+      #   uses: lycheeverse/lychee-action@v2
+      #   with:
+      #     args: "--cache --max-cache-age 1d ."
+      #     fail: true


### PR DESCRIPTION
Before we get closer to a better solution of link checker, let's temporarily disable this link checker.

This is fair and we can do fix-ups to broken links after the link checker goes back well.