### PR TITLE
chore(dep): update tempfile to 3.20

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6638,9 +6638,9 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.19.1"
+version = "3.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7437ac7763b9b123ccf33c338a5cc1bac6f69b45a136c19bdd8a65e3916435bf"
+checksum = "e8a64e3985349f2441a1a9ef0b853f869006c3855f2cda6862a94d26ebb9d6a1"
 dependencies = [
  "fastrand",
  "getrandom 0.3.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,7 +56,7 @@ serde_json = "1.0"
 serial_test = "3"
 sha2 = "0.10.9"
 strum = { version = "0.27", features = ["derive"] }
-tempfile = "3.19"
+tempfile = "3.20"
 testcontainers = "0.22"
 thiserror = "2.0"
 tokio = "1.45"

--- a/attestation-agent/attester/src/tsm_report/mod.rs
+++ b/attestation-agent/attester/src/tsm_report/mod.rs
@@ -73,7 +73,7 @@ impl TsmReportPath {
         // Remove the Drop set by tempdir_in() since it errors on ConfigFS
         // and leaks the created path. We implement our own Drop that removes the
         // path (rmdir way) when TsmReportPath instance goes out of scope.
-        let path = p.into_path();
+        let path = p.keep();
 
         check_tsm_report_provider(path.as_path(), wanted).inspect_err(|_| {
             let _ = std::fs::remove_dir(path.as_path());

--- a/image-rs/tests/credential.rs
+++ b/image-rs/tests/credential.rs
@@ -28,7 +28,7 @@ async fn test_use_credential(#[case] image_ref: &str, #[case] auth_file_uri: &st
     // of cache of old client.
     let mut image_client = image_rs::builder::ClientBuilder::default()
         .authenticated_registry_credentials_uri(auth_file_uri.to_string())
-        .work_dir(work_dir.into_path())
+        .work_dir(work_dir.path().to_path_buf())
         .build()
         .await
         .unwrap();

--- a/image-rs/tests/registry_configuration.rs
+++ b/image-rs/tests/registry_configuration.rs
@@ -80,7 +80,7 @@ async fn test_use_registry_configuration(#[case] image_ref: &str, #[case] succes
     // of cache of old client.
     let mut image_client = image_rs::builder::ClientBuilder::default()
         .registry_configuration_uri("kbs:///default/registry-configuration/test".into())
-        .work_dir(work_dir.into_path())
+        .work_dir(work_dir.path().to_path_buf())
         .build()
         .await
         .unwrap();

--- a/image-rs/tests/signature_verification.rs
+++ b/image-rs/tests/signature_verification.rs
@@ -182,7 +182,7 @@ async fn do_signature_verification_tests(
 
         let mut client_builder = image_rs::builder::ClientBuilder::default()
             .image_security_policy_uri(POLICY_URI.to_string())
-            .work_dir(work_dir.into_path());
+            .work_dir(work_dir.path().to_path_buf());
 
         #[cfg(feature = "signature-simple")]
         {


### PR DESCRIPTION
The new version of tempfile changes API `into_path` to `keep`

Close #997