### PR TITLE
add nvidia-attester

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -380,6 +380,7 @@ dependencies = [
  "kbs-types",
  "log",
  "num-traits",
+ "nvml-wrapper",
  "occlum_dcap",
  "picky-asn1 0.10.1",
  "picky-asn1-der 0.5.2",
@@ -3925,6 +3926,29 @@ checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
  "libm",
+]
+
+[[package]]
+name = "nvml-wrapper"
+version = "0.11.0"
+source = "git+https://github.com/rust-nvml/nvml-wrapper?rev=7e0752f331#7e0752f331d37a62a46ef2fb6329a33fae36dd8d"
+dependencies = [
+ "bitflags 2.9.0",
+ "libloading",
+ "nvml-wrapper-sys",
+ "serde",
+ "serde_derive",
+ "static_assertions",
+ "thiserror 1.0.69",
+ "wrapcenum-derive",
+]
+
+[[package]]
+name = "nvml-wrapper-sys"
+version = "0.9.0"
+source = "git+https://github.com/rust-nvml/nvml-wrapper?rev=7e0752f331#7e0752f331d37a62a46ef2fb6329a33fae36dd8d"
+dependencies = [
+ "libloading",
 ]
 
 [[package]]
@@ -7797,6 +7821,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3268f3d866458b787f390cf61f4bbb563b922d091359f9608842999eaee3943c"
 dependencies = [
  "bitflags 2.9.0",
+]
+
+[[package]]
+name = "wrapcenum-derive"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a76ff259533532054cfbaefb115c613203c73707017459206380f03b3b3f266e"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.99",
 ]
 
 [[package]]

--- a/attestation-agent/attestation-agent/Cargo.toml
+++ b/attestation-agent/attestation-agent/Cargo.toml
@@ -77,6 +77,7 @@ all-attesters = [
     "se-attester",
     "cca-attester",
     "tpm-attester",
+    "nvidia-attester",
 ]
 tdx-attester = ["kbs_protocol?/tdx-attester", "attester/tdx-attester"]
 tdx-attester-libtdx = [
@@ -102,6 +103,7 @@ hygon-dcu-attester = [
     "attester/hygon-dcu-attester",
 ]
 tpm-attester = ["kbs_protocol?/tpm-attester", "attester/tpm-attester"]
+nvidia-attester = ["kbs_protocol?/nvidia-attester", "attester/nvidia-attester"]
 
 # Either `rust-crypto` or `openssl` should be enabled to work as underlying crypto module
 rust-crypto = ["kbs_protocol?/rust-crypto"]

--- a/attestation-agent/attester/Cargo.toml
+++ b/attestation-agent/attester/Cargo.toml
@@ -23,6 +23,7 @@ hex.workspace = true
 iocuddle = { version = "0.1.1", optional = true }
 kbs-types.workspace = true
 log.workspace = true
+nvml-wrapper = { git = "https://github.com/rust-nvml/nvml-wrapper", rev="7e0752f331" , optional = true, default-features = false, features = ["serde"]}
 occlum_dcap = { git = "https://github.com/occlum/occlum", tag = "v0.29.7", optional = true }
 pv = { version = "0.10.0", package = "s390_pv", optional = true }
 scroll = { version = "0.13.0", default-features = false, features = [
@@ -75,6 +76,7 @@ all-attesters = [
     "cca-attester",
     "se-attester",
     "tpm-attester",
+    "nvidia-attester",
 ]
 
 # tsm-report enables a module that helps attesters to use Linux TSM_REPORTS for generating
@@ -84,6 +86,7 @@ tsm-report = ["tempfile"]
 tdx-attester = ["scroll", "tsm-report", "iocuddle"]
 tdx-attest-dcap-ioctls = ["tdx-attest-rs"]
 sgx-attester = ["occlum_dcap"]
+nvidia-attester = ["nvml-wrapper"]
 az-snp-vtpm-attester = ["az-snp-vtpm"]
 az-tdx-vtpm-attester = ["az-snp-vtpm-attester", "az-tdx-vtpm"]
 snp-attester = ["sev"]

--- a/attestation-agent/attester/src/nvidia/mod.rs
+++ b/attestation-agent/attester/src/nvidia/mod.rs
@@ -1,0 +1,111 @@
+// Copyright (c) 2025 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+use super::{Attester, TeeEvidence};
+use anyhow::{bail, Context, Result};
+use base64::{engine::general_purpose::STANDARD, Engine};
+use nvml_wrapper::{enums::device::DeviceArchitecture, Nvml};
+use serde::Serialize;
+
+const NVIDIA_NONCE_SIZE: usize = 32;
+
+pub fn detect_platform() -> bool {
+    // Return true iff one GPU is found and it has CC mode set.
+    match Nvml::init() {
+        Ok(nvml) => {
+            nvml.device_count().is_ok_and(|count| count == 1)
+                && nvml
+                    .device_by_index(0)
+                    .is_ok_and(|device| device.is_cc_enabled().unwrap_or_default())
+        }
+        Err(_) => false,
+    }
+}
+
+/// NRAS knows about "switch" and "gpu" but the expected evidence
+/// content is the same. nvidia-attester can compose a list of
+/// all CC enabled nvml/nscq devices using this evidence struct.
+#[derive(Serialize)]
+struct NvDeviceReportAndCert {
+    arch: DeviceArchitecture,
+    uuid: String,
+    evidence: String,
+    certificate: String,
+}
+
+#[derive(Serialize)]
+struct NvDeviceEvidence {
+    device_evidence_list: Vec<NvDeviceReportAndCert>,
+}
+
+#[derive(Debug, Default)]
+pub struct NvAttester {}
+
+#[async_trait::async_trait]
+impl Attester for NvAttester {
+    /// Generate evidence for the NVIDIA devices. A 32 byte nonce is taken from the first 32
+    /// report_data bytes. report_data shorter than 32 bytes is zero padded.
+    async fn get_evidence(&self, mut report_data: Vec<u8>) -> Result<TeeEvidence> {
+        let nvml = Nvml::init()?;
+        let devices = nvml.device_count()?;
+
+        let mut device_evidence_list = vec![];
+
+        if report_data.len() < NVIDIA_NONCE_SIZE {
+            report_data.resize(NVIDIA_NONCE_SIZE, 0);
+        }
+
+        let nonce: [u8; NVIDIA_NONCE_SIZE] = report_data[0..NVIDIA_NONCE_SIZE].try_into()?;
+
+        for index in 0..devices {
+            let device = nvml.device_by_index(index)?;
+
+            let report = device
+                .confidential_compute_gpu_attestation_report(nonce)
+                .context("Failed to get attestation report for device {index}")?;
+
+            let certificate = device
+                .confidential_compute_gpu_certificate()
+                .context("Failed to get certificate for device {index}")?;
+
+            let dev_arch = device
+                .architecture()
+                .context("Failed to get architecture for device {index}")?;
+
+            let dev_uuid = device
+                .uuid()
+                .context("Failed to get UUID for device {index}")?;
+
+            device_evidence_list.push(NvDeviceReportAndCert {
+                arch: dev_arch,
+                uuid: dev_uuid,
+                // NRAS expects hex as the encoding for the report so it's used
+                // here instead of base64. With that, the relying parties that
+                // use this evidence with NRAS do not have to re-encode it.
+                evidence: hex::encode(report.attestation_report),
+                certificate: STANDARD.encode(certificate.attestation_cert_chain),
+            });
+
+            device
+                .set_confidential_compute_state(true)
+                .context("Failed to set device {index} to ready state")?;
+
+            // Run final sanity check to ensure the device confidential computing mode is enabled,
+            // it's in a production environment, and accepting client requests.
+            if !device
+                .check_confidential_compute_status()
+                .is_ok_and(|status| status)
+            {
+                bail!("NVIDIA attester: device {index} CC status check failed")
+            }
+        }
+
+        let full_evidence = NvDeviceEvidence {
+            device_evidence_list,
+        };
+
+        serde_json::to_value(&full_evidence).context("Serialize NVIDIA evidence failed")
+    }
+}

--- a/attestation-agent/kbs_protocol/Cargo.toml
+++ b/attestation-agent/kbs_protocol/Cargo.toml
@@ -67,6 +67,7 @@ hygon-dcu-attester = ["attester/hygon-dcu-attester"]
 cca-attester = ["attester/cca-attester"]
 se-attester = ["attester/se-attester"]
 tpm-attester = ["attester/tpm-attester"]
+nvidia-attester = ["attester/nvidia-attester"]
 
 rust-crypto = ["reqwest/rustls-tls", "crypto/rust-crypto"]
 openssl = ["reqwest/native-tls-vendored", "crypto/openssl"]


### PR DESCRIPTION
https://github.com/confidential-containers/confidential-containers/issues/278 wasn't clear whether we can use pure Rust in the nvidia-attester. I gave `nvml-wrapper` a try and that resulted in this PR. Build-tested only at the moment but any help to get this to run on real HW would be nice.

This PR targets to get simple experiments started using `evidence_getter` using `cargo build --no-default-features --features bin,nvidia-attester,tdx-attester --bin evidence_getter --release`.

TODO

- [x] testing
- [x] rebase to #991 
- [x] improve commit messages
- [x] ~[`nvml-wrapper` release](https://github.com/rust-nvml/nvml-wrapper/issues/114)~
