### PR TITLE
attester/tdx: fix build error for feature tdx-attest-dcap-ioctls

### DIFF
--- a/attestation-agent/attester/src/tdx/mod.rs
+++ b/attestation-agent/attester/src/tdx/mod.rs
@@ -33,7 +33,7 @@ fn get_quote_ioctl(report_data: &[u8]) -> Result<Vec<u8>> {
                 let tdx_report_data = tdx_attest_rs::tdx_report_data_t {
                     // report_data.resize() ensures copying report_data to
                     // tdx_attest_rs::tdx_report_data_t cannot panic.
-                    d: report_data.as_slice().try_into().unwrap(),
+                    d: report_data.try_into().unwrap(),
                 };
 
                 match tdx_attest_rs::tdx_att_get_quote(Some(&tdx_report_data), None, None, 0) {


### PR DESCRIPTION
This fixes the build error
```
error[E0599]: no method named `as_slice` found for reference `&[u8]` in the current scope
  --> attestation-agent/attester/src/tdx/mod.rs:36:36
   |
36 |                     d: report_data.as_slice().try_into().unwrap(),
   |                                    ^^^^^^^^ method not found in `&[u8]`
   |
   = help: items from traits can only be used if the trait is in scope
```

when we use feature `tdx-attest-dcap-ioctls`.

cc @mythi 