### PR TITLE
attester: tdx-attester: extend RTMRs

### DIFF
--- a/attestation-agent/attester/src/tdx/mod.rs
+++ b/attestation-agent/attester/src/tdx/mod.rs
@@ -20,6 +20,7 @@ mod rtmr;
 
 const TDX_REPORT_DATA_SIZE: usize = 64;
 
+const TDX_RTMR_PATH: &str = "/sys/devices/virtual/misc/tdx_guest/measurements";
 const TDX_GUEST_IOCTL: &str = "/dev/tdx_guest";
 
 pub fn detect_platform() -> bool {
@@ -49,16 +50,18 @@ fn get_quote_ioctl(report_data: &[u8]) -> Result<Vec<u8>> {
     }
 }
 
-// Return true if the TD environment can extend runtime measurement,
-// else false. The best guess at the moment is that if "TSM reports"
-// is available, the TD runs Linux upstream kernel and is _currently_
-// not able to do it.
+// Return true if the TD environment can extend runtime measurement.
+// The best guess at the moment is that if tdx-attest-dcap-ioctls
+// is enabled, runtime measurement is possible. It's also possible
+// if TDX_RTMR_PATH exits. The two are mutually exclusive.
 fn runtime_measurement_extend_available() -> bool {
-    if Path::new("/sys/kernel/config/tsm/report").exists() {
-        return false;
+    cfg_if::cfg_if! {
+            if #[cfg(feature = "tdx-attest-dcap-ioctls")] {
+                true
+            } else {
+                Path::new(TDX_RTMR_PATH).exists()
+        }
     }
-
-    true
 }
 
 #[derive(Serialize, Deserialize)]
@@ -158,9 +161,16 @@ impl Attester for TdxAttester {
         let extend_data: [u8; 48] = pad(&event_digest);
 
         log::debug!(
-            "TDX Attester: extend RTRM{rtmr_index}: {}",
+            "TDX Attester: extend RTMR{rtmr_index}: {}",
             hex::encode(extend_data)
         );
+
+        #[cfg(not(feature = "tdx-attest-dcap-ioctls"))]
+        std::fs::write(
+            Path::new(TDX_RTMR_PATH).join(format!("rtmr{rtmr_index}:sha384")),
+            extend_data,
+        )
+        .context("TDX Attester: failed to extend RTMR")?;
 
         #[cfg(feature = "tdx-attest-dcap-ioctls")]
         let event: Vec<u8> = rtmr::TdxRtmrEvent::default()


### PR DESCRIPTION
Linux 6.16 adds the RTMR ABI that lets userspace to extend TEE RTMRs. Initially the support is added for TDX and follows https://github.com/torvalds/linux/blob/master/Documentation/ABI/testing/sysfs-devices-virtual-misc-tdx_guest

Change tdx-attester to use the ABI defined by the spec to do RTMR extend.

TODO:
- [x] testing