### PR TITLE
kbs_protocol: update rcar_client test policy rules

### DIFF
--- a/attestation-agent/kbs_protocol/test/policy.rego
+++ b/attestation-agent/kbs_protocol/test/policy.rego
@@ -3,5 +3,5 @@ package policy
 default allow = false
 
 allow {
-	input["submods"]["cpu"]["ear.veraison.annotated-evidence"]["sample"]
+	input["submods"]["cpu0"]["ear.veraison.annotated-evidence"]["sample"]
 }


### PR DESCRIPTION
Trustee multi-device support changed the EAR token cpu submod path to include an index.

Update rcar_client test policy rules accordingly to get the test passing. Without the change, the test fails with an 'unauthorized' error.