### PR TITLE
Inject etc hosts into guest for private registry DNS resolution

### DIFF
--- a/confidential-data-hub/hub/src/config.rs
+++ b/confidential-data-hub/hub/src/config.rs
@@ -188,6 +188,7 @@ sigstore_config_uri = "kbs:///default/sigstore-config/test"
 image_security_policy_uri = "kbs:///default/security-policy/test"
 authenticated_registry_credentials_uri = "kbs:///default/credential/test"
 extra_root_certificates = ["cert1", "cert2"]
+dns_mappings = "172.20.1.2 trust.hub,dockerx.hub"
 
 [image.image_pull_proxy]
 https_proxy = "http://127.0.0.1:8080"
@@ -210,6 +211,7 @@ https_proxy = "http://127.0.0.1:8080"
                     no_proxy: None,
                 }),
                 extra_root_certificates: vec!["cert1".into(), "cert2".into()],
+                dns_mappings: Some("172.20.1.2 trust.hub,dockerx.hub".into()),
                 ..Default::default()
             },
             socket: "unix:///run/confidential-containers/cdh.sock".to_string(),

--- a/image-rs/Cargo.toml
+++ b/image-rs/Cargo.toml
@@ -67,6 +67,7 @@ zstd = "0.13"
 
 nydus-api = { version = "0.3.0", optional = true }
 nydus-service = { version = "0.3.0", features = ["coco"], optional = true }
+tempfile = "3.20.0"
 
 [build-dependencies]
 anyhow.workspace = true
@@ -176,7 +177,12 @@ keywrap-ttrpc = [
 keywrap-jwe = ["ocicrypt-rs/keywrap-jwe"]
 
 signature = ["hex"]
-signature-cosign = ["signature", "futures", "sigstore/registry", "sigstore/cosign"]
+signature-cosign = [
+    "signature",
+    "futures",
+    "sigstore/registry",
+    "sigstore/cosign",
+]
 signature-cosign-rustls = [
     "signature-cosign",
     "sigstore/rustls-tls",

--- a/image-rs/src/config.rs
+++ b/image-rs/src/config.rs
@@ -142,6 +142,18 @@ pub struct ImageConfig {
     #[serde(default = "Vec::default")]
     pub extra_root_certificates: Vec<String>,
 
+    /// dns_mappings is used for local registry configuration, specifically to support resolving
+    /// private registry domains within the guest VM.
+    ///
+    /// This field holds custom domain-to-IP address mappings (similar to entries found in an
+    /// `/etc/hosts` file). These mappings enable the guest to correctly resolve the private
+    /// registry's domain (e.g., `trust.hub`) to the host registry's IP address, thereby
+    /// enabling successful image pulls.
+    ///
+    /// This value defaults to `None`.
+    #[serde(default = "Option::default")]
+    pub dns_mappings: Option<String>,
+
     /// Nydus services configuration
     #[serde(rename = "nydus")]
     pub nydus_config: Option<NydusConfig>,
@@ -194,6 +206,7 @@ impl Default for ImageConfig {
             registry_configuration_uri: None,
             image_pull_proxy: None,
             extra_root_certificates: Vec::new(),
+            dns_mappings: None,
 
             #[cfg(feature = "keywrap-native")]
             kbc: default_kbc(),
@@ -280,6 +293,7 @@ impl ImageConfig {
             registry_configuration_uri: None,
             image_pull_proxy: None,
             extra_root_certificates: Vec::new(),
+            dns_mappings: None,
 
             #[cfg(feature = "keywrap-native")]
             kbc: default_kbc(),

--- a/image-rs/src/image.rs
+++ b/image-rs/src/image.rs
@@ -277,6 +277,11 @@ impl ImageClient {
         let reference = Reference::try_from(image_url)
             .map_err(|source| PullImageError::IllegalImageReference { source })?;
 
+        if let Some(hosts_content) = &self.config.dns_mappings {
+            atomic_write_hosts(hosts_content)
+                .map_err(|source| PullImageError::IllegalRegistryConfigurationFormat { source })?
+        }
+
         let tasks = match &self.registry_handler {
             Some(handler) => handler
                 .process(reference)
@@ -656,7 +661,6 @@ fn create_bundle(
     Ok(image_id)
 }
 
-#[allow(dead_code)]
 fn atomic_write_hosts(content: &str) -> anyhow::Result<()> {
     let hosts_path = Path::new("/etc/hosts");
 


### PR DESCRIPTION
  image-rs: Inject /etc/hosts into guest for private registry DNS resolution
  
  This commit implements the injection of the host's `/etc/hosts` file via
  writing hosts content coming from initdata into the guest in CoCo scenarios.
  This is crucial for enabling guest-side image pulls from a cluster's local
  registry that uses custom domain names.
  
  Previously, guests could not resolve private registry domains (e.g.,
  `trust.hub`) via public DNS, leading to failed image pulls. By injecting
  a `dns_mappings` entry (e.g., `172.20.1.2 trust.hub`), the guest can now
  correctly resolve the private registry's domain to the host registry's
  IP address.
  
  It is more robust and simpler to manage than complex DNS configurations,
  avoiding the need for dynamic DNS updates as nodes change.
  
  Fixes #1034

  Signed-off-by: alex.lyn <alex.lyn@antgroup.com>