### PR TITLE
CDH: add registy configuration item for example config

### DIFF
--- a/confidential-data-hub/example.config.json
+++ b/confidential-data-hub/example.config.json
@@ -20,6 +20,7 @@
         "sigstore_config_uri": "kbs:///default/sigstore-config/test",
         "image_security_policy_uri": "kbs:///default/security-policy/test",
         "authenticated_registry_credentials_uri": "kbs:///default/credential/test",
+        "registry_configuration_uri": "kbs:///default/registry-configuration/test",
         "image_pull_proxy": {
             "https_proxy": "http://127.0.0.1:5432",
             "http_proxy": "http://127.0.0.1:5432",

--- a/confidential-data-hub/example.config.toml
+++ b/confidential-data-hub/example.config.toml
@@ -117,13 +117,28 @@ image_security_policy_uri = "kbs:///default/security-policy/test"
 # By default this value is not set.
 authenticated_registry_credentials_uri = "kbs:///default/credential/test"
 
+# Registry configuration supports defining registry blocking, mirroring,
+# and remapping rules. This field points to a registry configuration file,
+# which can either be stored locally in the rootfs or retrieved from the KBS.
+#
+# See https://github.com/confidential-containers/guest-components/blob/main/image-rs/docs/registry_configuration.md
+# for more details about the registry configuration file.
+#
+# Now it supports two different forms:
+# - `KBS URI`: the registry configuration will be fetched from KBS,
+# e.g. `kbs:///default/registry-configuration/test`.
+# - `Local Path`: the registry configuration will be fetched from somewhere locally,
+# e.g. `file:///etc/registry-configuration.json`.
+#
+# By default this value is not set.
+registry_configuration_uri = "kbs:///default/registry-configuration/test"
+
 # To support registries with self signed certs. This config item
 # is used to add extra trusted root certifications. The certificates
 # must be encoded by PEM.
 #
 # By default this value is not set.
-extra_root_certificates = [
-"""
+extra_root_certificates = ["""
 -----BEGIN CERTIFICATE-----
 MIIFTDCCAvugAwIBAgIBADBGBgkqhkiG9w0BAQowOaAPMA0GCWCGSAFlAwQCAgUA
 oRwwGgYJKoZIhvcNAQEIMA0GCWCGSAFlAwQCAgUAogMCATCjAwIBATB7MRQwEgYD
@@ -155,8 +170,7 @@ xynud/f525jppJMcD/ofbQxUZuGKvb3f3zy+aLxqidoX7gca2Xd9jyUy5Y/83+ZN
 bz4PZx81UJzXVI9ABEh8/xilATh1ZxOePTBJjN7lgr0lXtKYjV/43yyxgUYrXNZS
 oLSG2dLCK9mjjraPjau34Q==
 -----END CERTIFICATE-----
-"""
-]
+"""]
 
 # The path to store the pulled image layer data.
 #

--- a/image-rs/src/config.rs
+++ b/image-rs/src/config.rs
@@ -118,7 +118,7 @@ pub struct ImageConfig {
     #[serde(default = "Option::default")]
     pub authenticated_registry_credentials_uri: Option<String>,
 
-    /// Registry configuration supports define registry blocking, mirroring,
+    /// Registry configuration supports defining registry blocking, mirroring,
     /// and remapping rules. This field points to a registry configuration file,
     /// which can either be stored locally in the rootfs or retrieved from the KBS.
     ///


### PR DESCRIPTION
Now the registry configuration takes effect via CDH configuration file, but we did not show it in the example config.