### PR TITLE
ci: fix image-rs and ocicrypt-rs build dependency installation

### DIFF
--- a/.github/workflows/image_rs_build.yml
+++ b/.github/workflows/image_rs_build.yml
@@ -47,13 +47,13 @@ jobs:
         with:
           components: rustfmt, clippy
 
-      - name: Install nettle-sys building dependence
+      - name: Install nettle-sys building dependencies
         run: |
+          sudo apt update
           sudo apt install -y clang llvm pkg-config nettle-dev protobuf-compiler libprotobuf-dev
 
       - name: Install TPM dependencies
         run: |
-          sudo apt-get update
           sudo apt-get install -y libtss2-dev
         if: matrix.instance == 'ubuntu-24.04'
 

--- a/.github/workflows/ocicrypt_rs_build.yml
+++ b/.github/workflows/ocicrypt_rs_build.yml
@@ -46,6 +46,7 @@ jobs:
 
       - name: Install tonic's protoc dependencies
         run: |
+          sudo apt update
           sudo apt install -y protobuf-compiler libprotobuf-dev
 
       - name: Run cargo build


### PR DESCRIPTION
Make sure apt package db is up-to-date before install. Otherwise we might get 404's for some packages.