### PR TITLE
Fix CVE in  crossbeam-channel,  curl-sys, openssl-src

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1405,9 +1405,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.14"
+version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06ba6d68e24814cb8de6bb986db8222d3a027d15872cabc0d18817bc3c0e4471"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -1592,9 +1592,9 @@ dependencies = [
 
 [[package]]
 name = "curl-sys"
-version = "0.4.80+curl-8.12.1"
+version = "0.4.81+curl-8.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55f7df2eac63200c3ab25bde3b2268ef2ee56af3d238e76d61f01c3c49bff734"
+checksum = "f40f83946e6627dac558eb9ccc799b8894f36da8ea7470334c5fd7046ddd6a43"
 dependencies = [
  "cc",
  "libc",
@@ -1602,7 +1602,7 @@ dependencies = [
  "openssl-sys",
  "pkg-config",
  "vcpkg",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4306,9 +4306,9 @@ checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
 name = "openssl-src"
-version = "300.4.2+3.4.1"
+version = "300.5.0+3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "168ce4e058f975fe43e89d9ccf78ca668601887ae736090aacc23ae353c298e2"
+checksum = "e8ce546f549326b0e6052b649198487d91320875da901e7bd11a06d1ee3f9c2f"
 dependencies = [
  "cc",
 ]


### PR DESCRIPTION
Bump crossbeam-channel to v0.5.15 to fix [CVE-2025-4574](https://www.mend.io/vulnerability-database/CVE-2025-4574)
Bump curl-sys to v0.4.81+curl-8.14.1 to fix [CVE-2025-5025](https://www.mend.io/vulnerability-database/CVE-2025-5025)
Bump openssl-src to 300.5.0+3.5.0 to fix [CVE-2024-12797](https://vuln.whitesourcesoftware.com/vulnerability/CVE-2024-12797)