### PR TITLE
hygon_dcu attester: fix detect_platform

### DIFF
--- a/attestation-agent/attester/src/hygon_dcu/mod.rs
+++ b/attestation-agent/attester/src/hygon_dcu/mod.rs
@@ -8,11 +8,15 @@ use anyhow::{Context, Result};
 use csv_rs::api::dcu::{AttestationReport, DcuDevice};
 use log::warn;
 use serde::{Deserialize, Serialize};
-use std::{cmp::min, fs};
+use std::{cmp::min, fs, path::Path};
 
 const DCU_NODES_DIR: &str = "/sys/devices/virtual/kfd/kfd/topology/nodes";
 
 pub fn detect_platform() -> bool {
+    if !Path::new("/dev/mkfd").exists() {
+        return false;
+    }
+
     let std::result::Result::Ok(entries) = fs::read_dir(DCU_NODES_DIR) else {
         warn!("Cannot read DCU nodes directory: {DCU_NODES_DIR}");
         return false;


### PR DESCRIPTION
When detect_platform is called for attester hygon_dcu, it only checks /sys/devices/virtual/kfd/kfd/topology/nodes, but get_evidence tries to open /dev/mkfd and may fail with file-not-found.

Fix it by verifying /dev/mkfd exists in detect_platform().