### PR TITLE
cdh: disable eHSM by default

### DIFF
--- a/confidential-data-hub/Makefile
+++ b/confidential-data-hub/Makefile
@@ -26,7 +26,7 @@ else
     LIBC ?= musl
 endif
 RESOURCE_PROVIDER ?= kbs,sev
-KMS_PROVIDER ?= aliyun,ehsm
+KMS_PROVIDER ?= aliyun
 DESTDIR ?= $(PREFIX)/bin
 RUSTFLAGS_ARGS ?=
 features ?=

--- a/confidential-data-hub/docs/SEALED_SECRET.md
+++ b/confidential-data-hub/docs/SEALED_SECRET.md
@@ -211,6 +211,6 @@ Your secret will be provisioned to the `PROTECTED_SECRET` environment variable.
 | Provider Name      | README                                                      			| Maintainer                |
 | ------------------ | -------------------------------------------------------------------- | ------------------------- |
 | aliyun       	     |  [aliyun](kms-providers/alibaba.md)                               	| Alibaba                   |
-| ehsm       	     |  [ehsm](kms-providers/ehsm-kms.md)                              		| Intel                   	|
+| ehsm       	     |  [ehsm](kms-providers/ehsm-kms.md)                              		| Unmaintained                   	|
 | kbs                |                                                                          | CoCo                  |
 


### PR DESCRIPTION
The eHSM project is no longer maintained so it's better to make it disabled by default.