### PR TITLE
Update rstest from 0.17 to 0.26

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4821,6 +4821,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-crate"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edce586971a4dfaa28950c6f18ed55e0406c1ab88bbce2c6f6293a7aaba73d35"
+dependencies = [
+ "toml_edit",
+]
+
+[[package]]
 name = "proc-macro-error-attr2"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4895,7 +4904,7 @@ version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "itertools 0.14.0",
  "log",
  "multimap 0.10.0",
@@ -5275,6 +5284,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
+name = "relative-path"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
+
+[[package]]
 name = "reqwest"
 version = "0.11.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5455,27 +5470,30 @@ dependencies = [
 
 [[package]]
 name = "rstest"
-version = "0.17.0"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de1bb486a691878cd320c2f0d319ba91eeaa2e894066d8b5f8f117c000e9d962"
+checksum = "f5a3193c063baaa2a95a33f03035c8a72b83d97a54916055ba22d35ed3839d49"
 dependencies = [
- "futures",
  "futures-timer",
+ "futures-util",
  "rstest_macros",
- "rustc_version",
 ]
 
 [[package]]
 name = "rstest_macros"
-version = "0.17.0"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "290ca1a1c8ca7edb7c3283bd44dc35dd54fdec6253a3912e201ba1072018fca8"
+checksum = "9c845311f0ff7951c5506121a9ad75aec44d083c31583b2ea5a30bcb0b0abba0"
 dependencies = [
  "cfg-if",
+ "glob",
+ "proc-macro-crate",
  "proc-macro2",
  "quote",
+ "regex",
+ "relative-path",
  "rustc_version",
- "syn 1.0.109",
+ "syn 2.0.99",
  "unicode-ident",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ reqwest = { version = "0.12", default-features = false }
 resource_uri = { path = "attestation-agent/deps/resource_uri" }
 ring = "0.17"
 rsa = "0.9.8"
-rstest = "0.17"
+rstest = "0.26"
 serde = { version = "1.0", features = ["derive"] }
 serde_with = { version = "3.14.0", features = ["base64"] }
 serde_json = "1.0"


### PR DESCRIPTION
Due to the nature of this project, this isn’t especially easy for me to test locally, but I tried a [test build](https://koji.fedoraproject.org/koji/taskinfo?taskID=136199932) of the [`trustee-guest-components` package](https://src.fedoraproject.org/rpms/trustee-guest-components) in Fedora with `rstest` 0.26, and that went well.

(My motivation is that I am working on removing the last dependencies on compat packages for older versions of `rstest` in Fedora, and it’s our policy to offer patches upstream wherever possible.)