### PR TITLE
cargo: switch to coco kbs-types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3442,7 +3442,7 @@ dependencies = [
 [[package]]
 name = "kbs-types"
 version = "0.12.0"
-source = "git+https://github.com/virtee/kbs-types.git?rev=900aa8f#900aa8fd2fceb9dc07aa835091bf12076a899ec1"
+source = "git+https://github.com/confidential-containers/kbs-types.git?rev=900aa8f#900aa8fd2fceb9dc07aa835091bf12076a899ec1"
 dependencies = [
  "base64 0.22.1",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ hmac = "0.12.1"
 jwt-simple = { version = "0.12", default-features = false, features = [
     "pure-rust",
 ] }
-kbs-types = { "git" = "https://github.com/virtee/kbs-types.git", rev = "900aa8f" }
+kbs-types = { "git" = "https://github.com/confidential-containers/kbs-types.git", rev = "900aa8f" }
 log = "0.4.27"
 nix = "0.30"
 openssl = "0.10"


### PR DESCRIPTION
We've moved kbs-types to the coco repo, so let's update the cargo file.