### PR TITLE
image-rs: fix rust 1.90 clippy warnings

### DIFF
--- a/image-rs/src/decoder/mod.rs
+++ b/image-rs/src/decoder/mod.rs
@@ -59,7 +59,7 @@ impl Compression {
     /// Create an `AsyncRead` to decode input stream.
     pub fn async_decompress<'a>(
         &self,
-        input: (impl AsyncRead + Unpin + 'a + Send),
+        input: impl AsyncRead + Unpin + 'a + Send,
     ) -> Box<dyn AsyncRead + Unpin + 'a + Send> {
         match self {
             Self::Gzip => {
@@ -76,12 +76,12 @@ impl Compression {
     }
 
     /// Create an `AsyncRead` to decode input gzip stream.
-    pub fn async_gzip_decompress(input: (impl AsyncRead + Unpin)) -> impl AsyncRead + Unpin {
+    pub fn async_gzip_decompress(input: impl AsyncRead + Unpin) -> impl AsyncRead + Unpin {
         async_compression::tokio::bufread::GzipDecoder::new(BufReader::new(input))
     }
 
     /// Create an `AsyncRead` to decode input zstd stream.
-    pub fn async_zstd_decompress(input: (impl AsyncRead + Unpin)) -> impl AsyncRead + Unpin {
+    pub fn async_zstd_decompress(input: impl AsyncRead + Unpin) -> impl AsyncRead + Unpin {
         async_compression::tokio::bufread::ZstdDecoder::new(BufReader::new(input))
     }
 }

--- a/image-rs/src/pull.rs
+++ b/image-rs/src/pull.rs
@@ -172,7 +172,7 @@ impl<'a> PullClient<'a> {
         layer: OciDescriptor,
         diff_id: String,
         decrypt_config: &Option<&str>,
-        layer_reader: (impl tokio::io::AsyncRead + Unpin + Send),
+        layer_reader: impl tokio::io::AsyncRead + Unpin + Send,
         ms: Arc<RwLock<MetaStore>>,
     ) -> PullLayerResult<LayerMeta> {
         if let Some(layer_meta) = ms.read().await.layer_db.get(&layer.digest) {
@@ -236,7 +236,7 @@ impl<'a> PullClient<'a> {
     /// digest of the uncompressed layer.
     async fn async_decompress_unpack_layer(
         &self,
-        input_reader: (impl tokio::io::AsyncRead + Unpin + Send),
+        input_reader: impl tokio::io::AsyncRead + Unpin + Send,
         diff_id: &str,
         media_type: &str,
         destination: &Path,

--- a/image-rs/src/stream/mod.rs
+++ b/image-rs/src/stream/mod.rs
@@ -94,7 +94,7 @@ pub async fn stream_processing(
 }
 
 async fn async_processing(
-    layer_reader: (impl AsyncRead + Unpin),
+    layer_reader: impl AsyncRead + Unpin,
     hasher: LayerDigestHasher,
     destination: PathBuf,
 ) -> StreamResult<String> {


### PR DESCRIPTION
the weekly 'rust stable' check started failing with rust 1.90 for image-rs due to unused-parens:
```
error: unnecessary parentheses around type
  --> image-rs/src/decoder/mod.rs:62:16
   |
62 |         input: (impl AsyncRead + Unpin + 'a + Send),
   |                ^                                  ^
   |
   = note: `-D unused-parens` implied by `-D warnings`
```
Run cargo clippy --fix -p image-rs to fix.