### PR TITLE
workflows: publish artifacts: checkout code before toolchain install

### DIFF
--- a/.github/workflows/publish-artifacts.yml
+++ b/.github/workflows/publish-artifacts.yml
@@ -131,6 +131,8 @@ jobs:
         version: 1.2.0
       if: matrix.arch != 's390x'
 
+    - uses: actions/checkout@v4
+
     - uses: actions-rust-lang/setup-rust-toolchain@v1
       with:
         target: ${{ env.RUST_TARGET }}
@@ -140,8 +142,6 @@ jobs:
         sudo apt-get update
         sudo apt-get install -y --no-install-recommends \
           libdevmapper-dev
-
-    - uses: actions/checkout@v4
 
     - name: Build CDH
       env:


### PR DESCRIPTION
We use rust-toolchain.toml to pin toolchain version and actions-rust-lang/setup-rust-toolchain knows to set an override accordingly.

However, the repository must be checked out for rust-toolchain.toml to be available. Without it, the latest Rust stable is used.

Building CDH using rust stable fails currently so the publish to ORAS post-merge job fails to run.

Fixes: #1116