### PR TITLE
grpc-cdh: Return detailed error in get_resource

### DIFF
--- a/confidential-data-hub/hub/src/bin/grpc_server/mod.rs
+++ b/confidential-data-hub/hub/src/bin/grpc_server/mod.rs
@@ -80,7 +80,7 @@ impl GetResourceService for Cdh {
             .map_err(|e| {
                 let detailed_error = format_error!(e);
                 error!("[gRPC CDH] Call CDH to get resource failed:\n{detailed_error}");
-                Status::internal(format!("[CDH] [ERROR]: {e}"))
+                Status::internal(format!("[CDH] [ERROR]: {detailed_error}"))
             })?;
 
         debug!("[gRPC CDH] Get resource successfully!");


### PR DESCRIPTION
The get_resource endpoint currently returns only the top-level error message (e.g., "Get Resource failed") while logging the full error chain with root causes.

The detailed error is already computed using format_error!() but only used for logging. This changes the response to include the full chain, which would help with debugging without the need to see server logs.