### PR TITLE
Downgrade rust edition for protos

### DIFF
--- a/protos/Cargo.toml
+++ b/protos/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "protos"
 version = "0.1.0"
-edition = "2024"
+edition = "2021"
 
 [dependencies]
 async-trait = { workspace = true, optional = true }


### PR DESCRIPTION
PR #1090 introduced a new crate and tagged it with edition 2024. This breaks the build of downstream users that cannot use rust 1.85 yet.

After double-checking with the author, it appears that the crate doesn't strictly require the 2024 edition.

Downgrade the edition to 2021 :
- this reflects better what the crate actually requires
- this allow builds with older rust versions