### PR TITLE
attester: nvidia: change evidence encoding to base64

### DIFF
--- a/attestation-agent/attester/src/nvidia/mod.rs
+++ b/attestation-agent/attester/src/nvidia/mod.rs
@@ -81,10 +81,7 @@ impl Attester for NvAttester {
             device_evidence_list.push(NvDeviceReportAndCert {
                 arch: dev_arch,
                 uuid: dev_uuid,
-                // NRAS expects hex as the encoding for the report so it's used
-                // here instead of base64. With that, the relying parties that
-                // use this evidence with NRAS do not have to re-encode it.
-                evidence: hex::encode(report.attestation_report),
+                evidence: STANDARD.encode(report.attestation_report),
                 certificate: STANDARD.encode(certificate.attestation_cert_chain),
             });
 


### PR DESCRIPTION
NRAS API v2 expected the evidence to be hex+base64 encoded. hex was used as the base encoding to avoid unnecessary re-encoding when sending the evidence to ITA.

Things have changed since: NRAS API v3+ does not require this double encoding anymore, we have nvidia-verifier's remote verifier using v4 API and ITA is following.

Therefore, forget hex and change envidence encoding to be base64.