### PR TITLE
Minor fixes for building guest-components on ppc64le

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,10 @@ else
   RESOURCE_PROVIDER ?= kbs
 endif
 
+ifeq ($(ARCH), ppc64le)
+  ARCH=powerpc64le
+endif
+
 ifeq ($(TEE_PLATFORM), none)
   ATTESTER = none
 else ifeq ($(TEE_PLATFORM), fs)

--- a/confidential-data-hub/Makefile
+++ b/confidential-data-hub/Makefile
@@ -20,6 +20,11 @@ SOURCE_ARCH := $(shell uname -m)
 RPC ?= ttrpc
 ARCH ?= $(shell uname -m)
 DEBUG ?=
+
+ifeq ($(SOURCE_ARCH), ppc64le)
+  ARCH=powerpc64le
+endif
+
 ifeq ($(ARCH), $(filter $(ARCH), s390x powerpc64le))
     LIBC ?= gnu
 else
@@ -45,10 +50,6 @@ else
     binary = --bin grpc-cdh
     features += bin,grpc
     binary_name = grpc-cdh
-endif
-
-ifeq ($(SOURCE_ARCH), ppc64le)
-  ARCH=powerpc64le
 endif
 
 ifneq ($(RESOURCE_PROVIDER), none)


### PR DESCRIPTION
- When building ASR and AA from root, the builds on ppc64le fail with
```
build api-server-rest for fs
cd api-server-rest && make ARCH=ppc64le LIBC=gnu
make[1]: Entering directory '/root/guest-components/api-server-rest'
DEBIANOS is: false
cargo build --release --target ppc64le-unknown-linux-gnu
error: failed to run `rustc` to learn about target-specific information

Caused by:
  process didn't exit successfully: `rustc - --crate-name ___ --print=file-names --target ppc64le-unknown-linux-gnu --crate-type bin --crate-type rlib --crate-type dylib --crate-type cdylib --crate-type staticlib -
-crate-type proc-macro --print=sysroot --print=split-debuginfo --print=crate-name --print=cfg -Wwarnings` (exit status: 1)
  --- stderr
  error: error loading target specification: could not find specification for target "ppc64le-unknown-linux-gnu"
    |
    = help: run `rustc --print target-list` for a list of built-in targets
```
This is because the ARCH is overridden and set to ppc64le from the root dir Makefile

- Building CDH standalone from its dir exits with
```
confidential-data-hub]# make
DEBIANOS is: false
Makefile:64: *** ERROR: Confidential Data Hub does not support building with the musl libc target for s390x and ppc64le architectures!.  Stop.
```
Set the ARCH to powerpc64le before setting LIBC.
