### PR TITLE
ci: Fix arm64 aa build issue

### DIFF
--- a/.github/workflows/aa_cc_kbc.yml
+++ b/.github/workflows/aa_cc_kbc.yml
@@ -71,6 +71,7 @@ jobs:
 
       - name: Build and install with ${{ matrix.attester }} feature
         run: |
+          sudo apt-get update
           make ATTESTER=${{ matrix.attester }} && make install
 
       - name: Run rust lint check

--- a/.github/workflows/aa_sev_kbc.yml
+++ b/.github/workflows/aa_sev_kbc.yml
@@ -57,6 +57,7 @@ jobs:
 
       - name: Build and install with ${{ matrix.kbc }} feature
         run: |
+          sudo apt-get update
           make KBC=${{ matrix.kbc }} && make install
 
       - name: Musl build with ${{ matrix.kbc }} feature

--- a/.github/workflows/publish-artifacts.yml
+++ b/.github/workflows/publish-artifacts.yml
@@ -70,7 +70,9 @@ jobs:
     - name: Build
       env:
         ARCH: ${{ matrix.platform.arch }}
-      run: make ./target/${{ env.RUST_TARGET }}/release/attestation-agent
+      run: |
+        sudo apt-get update
+        make ./target/${{ env.RUST_TARGET }}/release/attestation-agent
 
     - name: Publish with ORAS
       id: publish


### PR DESCRIPTION
`apt-get install` failed without `apt-get update`, so add `apt-get update` before using `apt-get install`.

fix #1168 