### PR TITLE
refactor: extract apt-get update as separate step in CI workflows

### DIFF
--- a/.github/workflows/aa_cc_kbc.yml
+++ b/.github/workflows/aa_cc_kbc.yml
@@ -63,15 +63,17 @@ jobs:
         with:
           components: rustfmt, clippy
 
-      - name: Install TPM dependencies
+      - name: Update apt source list
         run: |
           sudo apt-get update
+
+      - name: Install TPM dependencies
+        run: |
           sudo apt-get install -y libtss2-dev
         if: matrix.instance == 'ubuntu-24.04'
 
       - name: Build and install with ${{ matrix.attester }} feature
         run: |
-          sudo apt-get update
           make ATTESTER=${{ matrix.attester }} && make install
 
       - name: Run rust lint check

--- a/.github/workflows/publish-artifacts.yml
+++ b/.github/workflows/publish-artifacts.yml
@@ -59,10 +59,13 @@ jobs:
       with:
         target: ${{ env.RUST_TARGET }}
 
+    - name: Update apt source list
+      run: |
+        sudo apt-get update
+
     - name: Install tpm dependencies
       if: matrix.platform.tee == 'az-cvm-vtpm'
       run: |
-        sudo apt-get update
         sudo apt-get install -y --no-install-recommends libtss2-dev
 
     - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
@@ -71,7 +74,6 @@ jobs:
       env:
         ARCH: ${{ matrix.platform.arch }}
       run: |
-        sudo apt-get update
         make ./target/${{ env.RUST_TARGET }}/release/attestation-agent
 
     - name: Publish with ORAS


### PR DESCRIPTION
- Move apt-get update to a dedicated step in aa_cc_kbc.yml
- Move apt-get update to a dedicated step in publish-artifacts.yml
- Remove duplicate apt-get update calls from build and install steps
- This improves workflow clarity and avoids redundant package index updates

cc @mythi 