### PR TITLE
github: Publish guest-components for ppc64le

### DIFF
--- a/.github/workflows/publish-artifacts.yml
+++ b/.github/workflows/publish-artifacts.yml
@@ -27,8 +27,9 @@ jobs:
           { tee: cca,         arch: x86_64,  libc: musl },
           { tee: cca,         arch: aarch64, libc: gnu  },
           { tee: se,          arch: s390x,   libc: gnu  },
+          { tee: none,        arch: powerpc64le,  libc: gnu },
         ]
-    runs-on: ${{ matrix.platform.arch == 's390x' && 's390x' || 'ubuntu-24.04' }}
+    runs-on: ${{ matrix.platform.arch == 's390x' && 's390x' || matrix.platform.arch == 'powerpc64le' && 'ubuntu-24.04-ppc64le' || 'ubuntu-24.04' }}
     env:
       TEE_PLATFORM: ${{ matrix.platform.tee }}
       LIBC: ${{ matrix.platform.libc }}
@@ -79,7 +80,7 @@ jobs:
     - name: Publish with ORAS
       id: publish
       env:
-        OCI_ARCH: ${{ matrix.platform.arch == 'x86_64' && 'amd64' || matrix.platform.arch == 'aarch64' && 'arm64' || matrix.platform.arch }}
+        OCI_ARCH: ${{ matrix.platform.arch == 'x86_64' && 'amd64' || matrix.platform.arch == 'aarch64' && 'arm64' || matrix.platform.arch == 'powerpc64le' && 'ppc64le' || matrix.platform.arch }}
       run: |
         mkdir oras
         cd oras
@@ -117,6 +118,7 @@ jobs:
         - x86_64
         - s390x
         - aarch64
+        - ppc64le
         include:
         - arch: x86_64
           libc: musl
@@ -124,7 +126,9 @@ jobs:
           libc: gnu
         - arch: aarch64
           libc: gnu
-    runs-on: ${{ matrix.arch == 's390x' && 's390x' || 'ubuntu-24.04' }}
+        - arch: ppc64le
+          libc: gnu
+    runs-on: ${{ matrix.arch == 's390x' && 's390x' || matrix.arch == 'ppc64le' && 'ubuntu-24.04-ppc64le' || 'ubuntu-24.04' }}
     env:
       LIBC: ${{ matrix.libc }}
       REGISTRY: ghcr.io


### PR DESCRIPTION
Publish guest components for ppc64le using the new IBM runners.