### PR TITLE
fix(attestation-agent/attester): update attester's Cargo.toml, change the dep:csv-rs's rev to a valid ref.

### DIFF
--- a/attestation-agent/attester/Cargo.toml
+++ b/attestation-agent/attester/Cargo.toml
@@ -41,7 +41,7 @@ strum.workspace = true
 tdx-attest-rs = { git = "https://github.com/intel/SGXDataCenterAttestationPrimitives", tag = "DCAP_1.23", optional = true }
 thiserror.workspace = true
 # TODO: change it to "0.1", once released.
-csv-rs = { git = "https://github.com/openanolis/csv-rs.git", rev = "9e92ac7", optional = true }
+csv-rs = { git = "https://github.com/openanolis/csv-rs.git", rev = "2243c67", optional = true }
 codicon = { version = "3.0", optional = true }
 hyper = { version = "0.14", features = ["full"], optional = true }
 hyper-tls = { version = "0.5", optional = true }


### PR DESCRIPTION
Currently the `csv-rs` crate's rev is `9e92ac7`, introduced by [here](https://github.com/openanolis/csv-rs/commit/9e92ac7e73379c1206ce90c98e91b1b5391eb7f8). Howerver this commit will introduce the import bug:
```bash
error: cannot find macro `trace` in this scope
   --> /builds/vendor/csv-rs/src/certs/csv/cert/mod.rs:337:5
    |
337 |     trace!("kds_url: {}", kds_url);
    |     ^^^^^
    |
help: consider importing this macro
    |
9   + use log::trace;
    |
error: cannot find macro `debug` in this scope
   --> /builds/vendor/csv-rs/src/certs/csv/cert/mod.rs:367:9
    |
367 |         debug!("Reading certificate from: {}", cert_path);
    |         ^^^^^
    |
help: consider importing this macro
    |
9   + use log::debug;
    |
error: cannot find macro `debug` in this scope
   --> /builds/vendor/csv-rs/src/certs/csv/cert/mod.rs:370:9
    |
370 |         debug!(
    |         ^^^^^
    |
help: consider importing this macro
    |
9   + use log::debug;
    |
error[E0433]: failed to resolve: use of unresolved module or unlinked crate `env`
   --> /builds/vendor/csv-rs/src/certs/csv/cert/mod.rs:356:20
    |
356 |     let cert_dir = env::var("HSK_CEK_CERT_PATH").unwrap_or_else(|_| "/opt/dcu/certs".to_string());
    |                    ^^^ use of unresolved module or unlinked crate `env`
    |
    = help: if you wanted to use a crate named `env`, use `cargo add env` to add it to your `Cargo.toml`
help: consider importing this module
    |
9   + use std::env;
    |
```
Then this [commit 2243c67](https://github.com/openanolis/csv-rs/commit/2243c67bc9c77794bd070cd0a8fd7ae26e7c77a3) fix this fatal error. This PR replace the wrong ref with the valid commit ref.