### PR TITLE
github: fix the arch mapping for ppc64le for CDH and ASR builds

### DIFF
--- a/.github/workflows/publish-artifacts.yml
+++ b/.github/workflows/publish-artifacts.yml
@@ -121,7 +121,7 @@ jobs:
         - x86_64
         - s390x
         - aarch64
-        - ppc64le
+        - powerpc64le
         include:
         - arch: x86_64
           libc: musl
@@ -131,7 +131,7 @@ jobs:
           libc: gnu
         - arch: powerpc64le
           libc: gnu
-    runs-on: ${{ matrix.arch == 's390x' && 's390x' || matrix.arch == 'ppc64le' && 'ubuntu-24.04-ppc64le' || 'ubuntu-24.04' }}
+    runs-on: ${{ matrix.arch == 's390x' && 's390x' || matrix.arch == 'powerpc64le' && 'ubuntu-24.04-ppc64le' || 'ubuntu-24.04' }}
     env:
       LIBC: ${{ matrix.libc }}
       REGISTRY: ghcr.io


### PR DESCRIPTION
This PR fixes the failures with arch mapping for ppc64le. 
Ref: https://github.com/confidential-containers/guest-components/actions/runs/19257574542/job/55055074699