### PR TITLE
github: install missing dependencies for ppc64le while building CDH and ASR

### DIFF
--- a/.github/workflows/publish-artifacts.yml
+++ b/.github/workflows/publish-artifacts.yml
@@ -166,6 +166,7 @@ jobs:
         sudo apt-get update
         sudo apt-get install -y --no-install-recommends \
           libdevmapper-dev
+        [ "${{ matrix.arch }}" = "powerpc64le" ] && sudo apt-get install -y libclang-dev cmake protobuf-compiler
 
     - name: Build CDH
       env:


### PR DESCRIPTION
This PR fixes failures with https://github.com/confidential-containers/guest-components/actions/runs/19261170340/job/55066097060