### PR TITLE
github: avoid using short circuit evaluation in workflow

### DIFF
--- a/.github/workflows/publish-artifacts.yml
+++ b/.github/workflows/publish-artifacts.yml
@@ -166,7 +166,9 @@ jobs:
         sudo apt-get update
         sudo apt-get install -y --no-install-recommends \
           libdevmapper-dev
-        [ "${{ matrix.arch }}" = "powerpc64le" ] && sudo apt-get install -y libclang-dev cmake protobuf-compiler
+        if [ "${{ matrix.arch }}" = "powerpc64le" ]; then
+          sudo apt-get install -y libclang-dev cmake protobuf-compiler
+        fi
 
     - name: Build CDH
       env:


### PR DESCRIPTION
Short circuit evaluation returns an error code when condition evaluates to false. Change the format of if condition to avoid exiting the workflow on error.