### PR TITLE
image-rs: add image pull benchmark

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -81,6 +81,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
 name = "anstream"
 version = "0.6.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -974,6 +980,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "cast5"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1443,6 +1455,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "criterion"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1c047a62b0cc3e145fa84415a3191f628e980b194c2755aa12300a4e6cbd928"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "itertools 0.13.0",
+ "num-traits",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b1bcc0dc7dfae599d84ad0b1a55f80cde8af3725da8313b528da95ef783e338"
+dependencies = [
+ "cast",
+ "itertools 0.13.0",
 ]
 
 [[package]]
@@ -3179,6 +3224,7 @@ dependencies = [
  "async-trait",
  "base64 0.22.1",
  "cfg-if",
+ "criterion",
  "devicemapper",
  "dircpy",
  "filetime",
@@ -3319,6 +3365,15 @@ name = "itertools"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
 dependencies = [
  "either",
 ]
@@ -4392,6 +4447,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "945462a4b81e43c4e3ba96bd7b49d834c6f61198356aa858733bc4acf3cbe62e"
 
 [[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
 name = "opaque-debug"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4927,6 +4988,34 @@ name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "plotters"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
+dependencies = [
+ "plotters-backend",
+]
 
 [[package]]
 name = "poly1305"
@@ -7043,6 +7132,16 @@ checksum = "9117f5d4db391c1cf6927e7bea3db74b9a1c1add8f7eda9ffd5364f40f57b82f"
 dependencies = [
  "displaydoc",
  "zerovec",
+]
+
+[[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/image-rs/Cargo.toml
+++ b/image-rs/Cargo.toml
@@ -72,6 +72,7 @@ anyhow.workspace = true
 
 [dev-dependencies]
 cfg-if.workspace = true
+criterion = "0.7.0"
 nix = { workspace = true, features = ["user"] }
 ring.workspace = true
 rstest.workspace = true
@@ -201,3 +202,7 @@ kbs = []
 nydus = ["nydus-api", "nydus-service"]
 
 verity = ["devicemapper"]
+
+[[bench]]
+name = "image-pull"
+harness = false

--- a/image-rs/README.md
+++ b/image-rs/README.md
@@ -8,3 +8,21 @@ Container Images Rust Crate
 
 [CCv1 Image Security Design document](docs/ccv1_image_security_design.md)
 
+## Performance Testing
+
+This crate includes benchmark tests to measure image pull performance.
+
+### Running Benchmarks
+
+To run the image pull benchmark:
+
+```bash
+cargo bench --bench image-pull
+```
+
+The benchmark measures:
+- Image pull time
+- Throughput (bytes per second)
+
+Benchmark results are generated in the `target/criterion/` directory and include detailed performance metrics and visualizations.
+

--- a/image-rs/benches/image-pull.rs
+++ b/image-rs/benches/image-pull.rs
@@ -1,0 +1,74 @@
+// Copyright (c) 2025 Alibaba Cloud
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+use image_rs::image::ImageClient;
+use std::{fs, path::Path, time::Duration};
+use criterion::{criterion_group, criterion_main, Criterion, Throughput};
+
+fn get_total_file_size(path: &Path) -> u64 {
+    if !path.exists() {
+        return 0;
+    }
+
+    let metadata = fs::symlink_metadata(path).unwrap();
+
+    if metadata.is_file() {
+        return metadata.len();
+    }
+
+    if metadata.is_dir() {
+        let entries = fs::read_dir(path).unwrap();
+        return entries.map(|entry| get_total_file_size(&entry.unwrap().path())).sum();
+    }
+
+    0
+}
+
+fn pull_image() -> u64 {
+    let image_url = "ghcr.io/confidential-containers/test-container:unencrypted";
+    let bundle_dir = tempfile::tempdir().unwrap();
+    let bundle_dir_path = bundle_dir.path().to_path_buf();
+    let mut image_client = ImageClient::new(bundle_dir.path().to_path_buf());
+    let runtime = tokio::runtime::Runtime::new().unwrap();
+    let bundle_dir_path_clone = bundle_dir_path.clone();
+    runtime.block_on(async move { 
+        image_client.pull_image(image_url, &bundle_dir_path_clone, &None, &None).await 
+    }).unwrap();
+    let data_dir = bundle_dir_path.join("layers");
+    let total_size = get_total_file_size(&data_dir);
+
+    drop(bundle_dir);
+    total_size
+}
+
+fn criterion_benchmark(c: &mut Criterion) {
+    let mut group = c.benchmark_group("image-pull");
+    group.sample_size(10);
+    
+    // Run once to get the data size for throughput calculation
+    let sample_size = pull_image();
+    group.throughput(Throughput::Bytes(sample_size));
+    
+    group.bench_function("pull_image", |b| {
+        b.iter_custom(|iters| {
+            let mut total_duration = Duration::new(0, 0);
+            
+            for _ in 0..iters {
+                let start = std::time::Instant::now();
+                pull_image();
+                let elapsed = start.elapsed();
+                
+                total_duration += elapsed;
+            }
+            
+            total_duration
+        });
+    });
+    
+    group.finish();
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);


### PR DESCRIPTION
- Add criterion benchmark for image pull performance
- Configure benchmark harness in Cargo.toml
- Add image-pull benchmark that measures pull time and throughput

The terminal log can be
```
image-pull/pull_image   time:   [2.8439 s 4.1208 s 5.6908 s]
                        thrpt:  [1.5182 MiB/s 2.0966 MiB/s 3.0379 MiB/s]
                 change:
                        time:   [−55.955% −7.4571% +97.347%] (p = 0.88 > 0.05)
                        thrpt:  [−49.328% +8.0580% +127.04%]
                        No change in performance detected.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high mild
```

The generated webpage looks like

<img width="782" height="709" alt="image" src="https://github.com/user-attachments/assets/0148a9b2-c4b7-4be1-8203-91c99066f6a0" />
