### PR TITLE
image-rs: allow signature configs in config file

### DIFF
--- a/image-rs/src/config.rs
+++ b/image-rs/src/config.rs
@@ -98,6 +98,12 @@ pub struct ImageConfig {
     #[serde(default = "Option::default")]
     pub image_security_policy_uri: Option<String>,
 
+    /// The image security policy (see above) can also be specified directly
+    /// as a string. If the policy URI and this field are both set,
+    /// the policy URI will be used.
+    #[serde(default = "Option::default")]
+    pub image_security_policy: Option<String>,
+
     /// Sigstore config file URI for simple signing scheme.
     ///
     /// When `image_security_policy_uri` is set and `SimpleSigning` (signedBy) is
@@ -109,6 +115,12 @@ pub struct ImageConfig {
     /// This value defaults to `None`.
     #[serde(default = "Option::default")]
     pub sigstore_config_uri: Option<String>,
+
+    /// The sigstore config policy (see above) can be specified directly in the
+    /// config file as a string. If the config URI and this field are both
+    /// set, the config URI will be used.
+    #[serde(default = "Option::default")]
+    pub sigstore_config: Option<String>,
 
     /// To pull an image from an authenticated/private registry, credentials
     /// must be provided to image-rs. This field points to a credential file,
@@ -189,7 +201,9 @@ impl Default for ImageConfig {
             default_snapshot: SnapshotType::default(),
             max_concurrent_layer_downloads_per_image: DEFAULT_MAX_CONCURRENT_DOWNLOAD,
             image_security_policy_uri: None,
+            image_security_policy: None,
             sigstore_config_uri: None,
+            sigstore_config: None,
             authenticated_registry_credentials_uri: None,
             registry_configuration_uri: None,
             registry_config: None,
@@ -264,7 +278,9 @@ impl ImageConfig {
             default_snapshot: SnapshotType::default(),
             max_concurrent_layer_downloads_per_image: DEFAULT_MAX_CONCURRENT_DOWNLOAD,
             image_security_policy_uri: None,
+            image_security_policy: None,
             sigstore_config_uri: None,
+            sigstore_config: None,
             authenticated_registry_credentials_uri: None,
             registry_configuration_uri: None,
             registry_config: None,


### PR DESCRIPTION
Today the image signature configurations are referenced via a URI in the image config or the kernel command line. The URI can point to a remote resource or a local file inside the guest. In addition, let's allow the configuration to be specified directly in the image config. This will allow it to easily be set via the init-data.

Generally, it seems like a nicer flow to set the image signature configuration via init-data rather than provisioning the config files to Trustee. Also, retrieving unsigned configuration files over the network does have some subtleties.

Rather than overloading the existing URI fields, let's introduce a new field where the config can be set directly. This is similar to what we already do with the registry config. The URI will take priority if both fields are set and won't break any existing use cases (such as when the URI is set via the kernel command line).

Ideally these new fields would have Struct types allowing the configurations to be integrated directly into the image config and the cdh config, but to keep things simple we store them as strings.