### PR TITLE
ci: update apt repos in weekly Rust stable tests

### DIFF
--- a/.github/workflows/rust_stable_check.yml
+++ b/.github/workflows/rust_stable_check.yml
@@ -47,6 +47,9 @@ jobs:
           override: true
           components: rustfmt, clippy
 
+      - name: Update apt repositories
+        run: sudo apt update
+
       - name: Install TPM dependencies
         run: sudo apt install -y libtss2-dev
 


### PR DESCRIPTION
Workflow runs get 404 errors when installing packages if the runner apt metadata is outdated. Always refresh the metadata before installing anything.