### PR TITLE
image-rs: propagate unpack failures

### DIFF
--- a/image-rs/src/stream/mod.rs
+++ b/image-rs/src/stream/mod.rs
@@ -30,7 +30,7 @@ pub enum StreamError {
     #[error("Unsupported uncompressed digest format: {0}")]
     UnsupportedDigestFormat(String),
 
-    #[error("Failed to unpack layer")]
+    #[error("Failed to unpack layer: {0}")]
     UnPackLayerFailed(#[from] UnpackError),
 }
 


### PR DESCRIPTION
currently we swallow specific errors from the unpacking logic, which makes it hard to diagnose problems. this change will propagate a string repr of the error:

```
Got error on function call attempt 4. Will retry in 1s: AllTasksTried { original_image_url: "mcr.microsoft.com/hello-world", tried_list: "image: mcr.microsoft.com/hello-world:latest, error: Errors happened when pulling image: Failed to decode layer data stream: Failed to unpack layer }
```
vs

```
Got error on function call attempt 4. Will retry in 1s: AllTasksTried { original_image_url: "mcr.microsoft.com/hello-world", tried_list: "image: mcr.microsoft.com/hello-world:latest, error: Errors happened when pulling image: Failed to decode layer data stream: Failed to unpack layer: Failed to set ownership for path: /tmp/.tmp1h9nuz/layers/4/hello" }
```