### PR TITLE
attester: add versioned Evidence structs for azure

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -350,6 +350,7 @@ dependencies = [
  "num-traits",
  "nvml-wrapper",
  "occlum_dcap",
+ "pem-rfc7468 1.0.0",
  "picky-asn1 0.10.1",
  "picky-asn1-der 0.5.4",
  "picky-asn1-x509 0.15.2",
@@ -461,18 +462,17 @@ dependencies = [
 
 [[package]]
 name = "az-cvm-vtpm"
-version = "0.7.4"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b3d0900c6757c9674b05b0479236458297026e25fb505186dc8d7735091a21c"
+checksum = "460ceb8aa4047d086c6d1c1273015b0f19c2303d1502ee918e8e4b0a136b5a4e"
 dependencies = [
- "bincode 1.3.3",
  "jsonwebkey",
  "memoffset 0.9.1",
  "openssl",
  "serde",
  "serde-big-array",
  "serde_json",
- "sev 6.3.1",
+ "sev 7.1.0",
  "sha2 0.10.9",
  "thiserror 2.0.17",
  "tss-esapi",
@@ -481,28 +481,26 @@ dependencies = [
 
 [[package]]
 name = "az-snp-vtpm"
-version = "0.7.4"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e5f1a3838d56871fc7a37c1ffcaa892777fbebb246f7ddec18c12e14b6d6aa9"
+checksum = "c2fc021c171823a2cc58ce7af52154714464ce01ac0abe745d3cb8a8308a033e"
 dependencies = [
  "az-cvm-vtpm",
- "bincode 1.3.3",
  "clap",
  "serde",
- "sev 6.3.1",
+ "sev 7.1.0",
  "thiserror 2.0.17",
  "ureq",
 ]
 
 [[package]]
 name = "az-tdx-vtpm"
-version = "0.7.4"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04849677b3c0704d4593d89940cde0dc0caad2202bf9fb29352e153782b91ff8"
+checksum = "8b0b931862c6ea56cb89e8d345d757f06aec6f4530e9813dc7cd35fd5b8dad70"
 dependencies = [
  "az-cvm-vtpm",
  "base64-url",
- "bincode 1.3.3",
  "serde",
  "serde_json",
  "thiserror 2.0.17",
@@ -1802,7 +1800,7 @@ dependencies = [
  "const-oid",
  "der_derive",
  "flagset",
- "pem-rfc7468",
+ "pem-rfc7468 0.7.0",
  "zeroize",
 ]
 
@@ -2207,7 +2205,7 @@ dependencies = [
  "generic-array",
  "group",
  "hkdf",
- "pem-rfc7468",
+ "pem-rfc7468 0.7.0",
  "pkcs8",
  "rand_core 0.6.4",
  "sec1",
@@ -4540,6 +4538,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "pem-rfc7468"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6305423e0e7738146434843d1694d621cce767262b2a86910beab705e4493d9"
+dependencies = [
+ "base64ct",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6257,11 +6264,30 @@ dependencies = [
  "iocuddle",
  "lazy_static",
  "libc",
- "openssl",
- "rdrand",
  "serde",
  "serde-big-array",
  "serde_bytes",
+ "static_assertions",
+ "uuid",
+]
+
+[[package]]
+name = "sev"
+version = "7.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2ff74d7e7d1cc172f3a45adec74fbeee928d71df095b85aaaf66eb84e1e31e6"
+dependencies = [
+ "base64 0.22.1",
+ "bitfield 0.19.1",
+ "bitflags 2.9.0",
+ "byteorder",
+ "dirs 6.0.0",
+ "hex",
+ "iocuddle",
+ "lazy_static",
+ "libc",
+ "openssl",
+ "rdrand",
  "static_assertions",
  "uuid",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,7 @@ ring = "0.17"
 rsa = "0.9.10"
 rstest = "0.26"
 serde = { version = "1.0", features = ["derive"] }
-serde_with = { version = "3.16.1", features = ["base64"] }
+serde_with = { version = "3.16.1", features = ["base64", "hex"] }
 serde_json = "1.0"
 serial_test = "3"
 sha2 = "0.10.9"

--- a/attestation-agent/attester/Cargo.toml
+++ b/attestation-agent/attester/Cargo.toml
@@ -9,10 +9,10 @@ license = "Apache-2.0"
 [dependencies]
 anyhow.workspace = true
 async-trait.workspace = true
-az-snp-vtpm = { version = "0.7.4", default-features = false, features = [
+az-snp-vtpm = { version = "0.8.0", default-features = false, features = [
     "attester",
 ], optional = true }
-az-tdx-vtpm = { version = "0.7.4", default-features = false, features = [
+az-tdx-vtpm = { version = "0.8.0", default-features = false, features = [
     "attester",
 ], optional = true }
 base64.workspace = true
@@ -25,6 +25,7 @@ kbs-types.workspace = true
 log.workspace = true
 nvml-wrapper = { git = "https://github.com/rust-nvml/nvml-wrapper", rev="7e0752f331" , optional = true, default-features = false, features = ["serde"]}
 occlum_dcap = { git = "https://github.com/occlum/occlum", tag = "v0.29.7", optional = true }
+pem-rfc7468 = { version = "1", optional = true, features = ["alloc"] }
 pv = { version = "0.10.0", package = "s390_pv", optional = true }
 scroll = { version = "0.13.0", default-features = false, features = [
     "derive",
@@ -86,7 +87,7 @@ tdx-attester = ["scroll", "tsm-report", "iocuddle"]
 tdx-attest-dcap-ioctls = ["tdx-attest-rs"]
 sgx-attester = ["occlum_dcap"]
 nvidia-attester = ["nvml-wrapper"]
-az-snp-vtpm-attester = ["az-snp-vtpm"]
+az-snp-vtpm-attester = ["az-snp-vtpm", "pem-rfc7468"]
 az-tdx-vtpm-attester = ["az-snp-vtpm-attester", "az-tdx-vtpm"]
 snp-attester = ["sev"]
 csv-attester = ["hygon", "codicon", "hyper", "hyper-tls"]

--- a/attestation-agent/attester/src/az_snp_vtpm/mod.rs
+++ b/attestation-agent/attester/src/az_snp_vtpm/mod.rs
@@ -9,6 +9,9 @@ use az_snp_vtpm::{imds, is_snp_cvm, vtpm};
 use kbs_types::HashAlgorithm;
 use log::{debug, info};
 use serde::{Deserialize, Serialize};
+use serde_with::{base64::Base64, hex::Hex, serde_as};
+
+type UrlSafeBase64 = Base64<serde_with::base64::UrlSafe>;
 
 pub fn detect_platform() -> bool {
     match is_snp_cvm() {
@@ -23,24 +26,81 @@ pub fn detect_platform() -> bool {
 #[derive(Debug, Default)]
 pub struct AzSnpVtpmAttester;
 
+const EVIDENCE_VERSION: u32 = 1;
+
+/// TPM quote containing PCR values and attestation data.
+///
+/// # Fields (in hex representation)
+/// - `signature` - RSA signature over the quote message
+/// - `message` - TPM attestation structure containing nonce and PCR digest
+/// - `pcrs` - SHA-256 PCR values (24 registers, 32 bytes each)
+#[serde_as]
+#[derive(Serialize, Deserialize)]
+pub(crate) struct TpmQuote {
+    #[serde_as(as = "Hex")]
+    signature: Vec<u8>,
+    #[serde_as(as = "Hex")]
+    message: Vec<u8>,
+    #[serde_as(as = "Vec<Hex>")]
+    pcrs: Vec<Vec<u8>>,
+}
+
+impl TryFrom<vtpm::Quote> for TpmQuote {
+    type Error = serde_json::Error;
+
+    fn try_from(q: vtpm::Quote) -> Result<Self, Self::Error> {
+        // Re-serialize through JSON to access private fields
+        let json = serde_json::to_value(&q)?;
+        serde_json::from_value(json)
+    }
+}
+
+/// Attestation evidence for Azure SNP vTPM.
+///
+/// This struct contains all the cryptographic evidence needed to verify
+/// that code is running in a genuine AMD SEV-SNP confidential VM on Azure.
+///
+/// # Fields (vcek + hcl_report in URL-safe base64 representation)
+/// - `version` - Schema version for forward compatibility
+/// - `tpm_quote` - TPM quote containing PCR values and a signature
+/// - `hcl_report` - Hardware Compatibility Layer report containing the
+///    Hardware attestation report from the AMD SEV-SNP platform
+/// - `vcek` - Versioned Chip Endorsement Key certificate (DER-encoded)
+#[serde_as]
 #[derive(Serialize, Deserialize)]
 struct Evidence {
-    quote: vtpm::Quote,
-    report: Vec<u8>,
-    vcek: String,
+    version: u32,
+    tpm_quote: TpmQuote,
+    #[serde_as(as = "UrlSafeBase64")]
+    hcl_report: Vec<u8>,
+    #[serde_as(as = "UrlSafeBase64")]
+    vcek: Vec<u8>,
+}
+
+/// Convert a PEM-encoded certificate to DER format
+fn pem_to_der(pem: &str) -> Result<Vec<u8>> {
+    let (label, der) =
+        pem_rfc7468::decode_vec(pem.as_bytes()).context("Failed to decode VCEK PEM")?;
+    if label != "CERTIFICATE" {
+        bail!("Expected CERTIFICATE label in PEM, got {}", label);
+    }
+
+    Ok(der)
 }
 
 #[async_trait::async_trait]
 impl Attester for AzSnpVtpmAttester {
     async fn get_evidence(&self, report_data: Vec<u8>) -> anyhow::Result<TeeEvidence> {
-        let report = vtpm::get_report()?;
+        let hcl_report = vtpm::get_report()?;
         let quote = vtpm::get_quote(&report_data)?;
+        let tpm_quote = TpmQuote::try_from(quote)?;
         let certs = imds::get_certs()?;
-        let vcek = certs.vcek;
+        let vcek = pem_to_der(&certs.vcek)?;
 
         let evidence = Evidence {
-            quote,
-            report,
+            version: EVIDENCE_VERSION,
+            tpm_quote,
+            hcl_report,
             vcek,
         };
 
@@ -91,5 +151,83 @@ pub(crate) mod utils {
         vtpm::extend_pcr(pcr, &sha256_digest)?;
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use base64::Engine;
+
+    const TEST_PEM: &str = "-----BEGIN CERTIFICATE-----
+MIIB0zCCAXqgAwIBAgIJALg0
+-----END CERTIFICATE-----";
+
+    #[test]
+    fn test_pem_to_der() {
+        let der = pem_to_der(TEST_PEM).unwrap();
+        // "MIIB0zCCAXqgAwIBAgIJALg0" decodes to these bytes
+        assert_eq!(
+            der,
+            base64::engine::general_purpose::STANDARD
+                .decode("MIIB0zCCAXqgAwIBAgIJALg0")
+                .unwrap()
+        );
+    }
+
+    #[test]
+    fn test_tpm_quote_hex_serialization() {
+        let json = serde_json::json!({
+            "signature": "deadbeef",
+            "message": "cafebabe",
+            "pcrs": ["00112233", "44556677"]
+        });
+
+        let tpm_quote: TpmQuote = serde_json::from_value(json).unwrap();
+        assert_eq!(tpm_quote.signature, vec![0xde, 0xad, 0xbe, 0xef]);
+        assert_eq!(tpm_quote.message, vec![0xca, 0xfe, 0xba, 0xbe]);
+        assert_eq!(
+            tpm_quote.pcrs,
+            vec![vec![0x00, 0x11, 0x22, 0x33], vec![0x44, 0x55, 0x66, 0x77]]
+        );
+    }
+
+    #[test]
+    fn test_base64_urlsafe_serialization() {
+        // URL-safe base64 of [0xde, 0xad, 0xbe, 0xef] is "3q2-7w=="
+        // URL-safe base64 of [0xca, 0xfe, 0xba, 0xbe] is "yv66vg=="
+        let json = serde_json::json!({
+            "version": 1,
+            "report": "3q2-7w==",
+            "vcek": "yv66vg=="
+        });
+
+        #[serde_as]
+        #[derive(Deserialize)]
+        struct TestEvidence {
+            version: u32,
+            #[serde_as(as = "UrlSafeBase64")]
+            report: Vec<u8>,
+            #[serde_as(as = "UrlSafeBase64")]
+            vcek: Vec<u8>,
+        }
+
+        let evidence: TestEvidence = serde_json::from_value(json).unwrap();
+        assert_eq!(evidence.version, 1);
+        assert_eq!(evidence.report, vec![0xde, 0xad, 0xbe, 0xef]);
+        assert_eq!(evidence.vcek, vec![0xca, 0xfe, 0xba, 0xbe]);
+
+        #[serde_as]
+        #[derive(Serialize)]
+        struct TestEvidenceOut {
+            #[serde_as(as = "UrlSafeBase64")]
+            report: Vec<u8>,
+        }
+
+        let out = TestEvidenceOut {
+            report: vec![0xde, 0xad, 0xbe, 0xef],
+        };
+        let json_out = serde_json::to_value(&out).unwrap();
+        assert_eq!(json_out["report"], "3q2-7w==");
     }
 }

--- a/attestation-agent/attester/src/az_tdx_vtpm/mod.rs
+++ b/attestation-agent/attester/src/az_tdx_vtpm/mod.rs
@@ -4,14 +4,16 @@
 //
 
 use super::{Attester, InitDataResult, TeeEvidence};
-use crate::az_snp_vtpm::utils;
+use crate::az_snp_vtpm::{utils, TpmQuote};
 use anyhow::*;
-use az_tdx_vtpm::vtpm::Quote as TpmQuote;
 use az_tdx_vtpm::{hcl, imds, is_tdx_cvm, vtpm};
 use kbs_types::HashAlgorithm;
 use log::debug;
 use serde::{Deserialize, Serialize};
+use serde_with::{base64::Base64, serde_as};
 use std::result::Result::Ok;
+
+type UrlSafeBase64 = Base64<serde_with::base64::UrlSafe>;
 
 pub fn detect_platform() -> bool {
     match is_tdx_cvm() {
@@ -26,10 +28,26 @@ pub fn detect_platform() -> bool {
 #[derive(Debug, Default)]
 pub struct AzTdxVtpmAttester;
 
+const EVIDENCE_VERSION: u32 = 1;
+
+/// Attestation evidence for Azure TDX vTPM.
+///
+/// This struct contains all the cryptographic evidence needed to verify
+/// that code is running in a genuine Intel TDX confidential VM on Azure.
+///
+/// # Fields (hcl_report and td_quote are base64-url encoded)
+/// - `version` - Schema version for forward compatibility
+/// - `tpm_quote` - TPM quote containing PCR values and a signature
+/// - `hcl_report` - Hardware Compatibility Layer report containing the TD report
+/// - `td_quote` - Intel TDX quote signed by the Quoting Enclave
+#[serde_as]
 #[derive(Serialize, Deserialize)]
 struct Evidence {
+    version: u32,
     tpm_quote: TpmQuote,
+    #[serde_as(as = "UrlSafeBase64")]
     hcl_report: Vec<u8>,
+    #[serde_as(as = "UrlSafeBase64")]
     td_quote: Vec<u8>,
 }
 
@@ -39,14 +57,16 @@ impl Attester for AzTdxVtpmAttester {
         let hcl_report_bytes = vtpm::get_report_with_report_data(&report_data)?;
         let hcl_report = hcl::HclReport::new(hcl_report_bytes.clone())?;
         let td_report = hcl_report.try_into()?;
-        let td_quote_bytes = imds::get_td_quote(&td_report)?;
+        let td_quote = imds::get_td_quote(&td_report)?;
 
-        let tpm_quote = vtpm::get_quote(&report_data)?;
+        let quote = vtpm::get_quote(&report_data)?;
+        let tpm_quote = TpmQuote::try_from(quote)?;
 
         let evidence = Evidence {
+            version: EVIDENCE_VERSION,
             tpm_quote,
             hcl_report: hcl_report_bytes,
-            td_quote: td_quote_bytes,
+            td_quote,
         };
         Ok(serde_json::to_value(&evidence)?)
     }


### PR DESCRIPTION
This is the introduction of versioned evidences payloads. This is crucial for making statements about compatibility between guest-components and trustee. We will probably have to have a mirror of those structs in trustee and perform deserialization by taking the version into account. Absence of a version string would imply v0, which is the schema that we had before this change.

- Bump az-*-vtpm crates to 0.8.0 (bincode is dropped, sev bumped to v7)
- Use URL-safe base64 encoding for all binary fields (report, vcek, quotes) in the json represenation. The ootb rendering defaults to a line for every entry in Vec<u8>, which is unusable
- Convert VCEK from PEM to DER format in az-snp-vtpm
- Create local TpmQuote wrapper with adjusted serialization

Affects az-snp-vtpm and az-tdx-vtpm attesters.