### PR TITLE
toolchain: bump to rust 1.90.0

### DIFF
--- a/attestation-agent/docker/Dockerfile.keyprovider
+++ b/attestation-agent/docker/Dockerfile.keyprovider
@@ -1,7 +1,7 @@
 # Copyright (c) 2023 by Alibaba.
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-FROM rust:1.85.1-slim-bookworm as builder
+FROM rust:1.90-slim-bookworm as builder
 
 LABEL org.opencontainers.image.source="https://github.com/confidential-containers/guest-components/blob/main/attestation-agent/docker/Dockerfile.keyprovider"
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.85.1"
+channel = "1.90.0"


### PR DESCRIPTION
Move guest-components to use a more recent Rust toolchain.