### PR TITLE
Add basic Trustee plugin support to guest-components

### DIFF
--- a/attestation-agent/deps/resource_uri/src/lib.rs
+++ b/attestation-agent/deps/resource_uri/src/lib.rs
@@ -160,10 +160,10 @@ mod tests {
     #[rstest]
     #[case("kbs:///alice/cosign-key/213", "alice", "cosign-key", "213", None)]
     #[case(
-        "kbs:///plugin/plugname/resourcename?param1=value1&param2=value2",
-        "plugin",
-        "plugname",
-        "resourcename",
+        "kbs:///a/b/c?param1=value1&param2=value2",
+        "a",
+        "b",
+        "c",
         Some("param1=value1&param2=value2")
     )]
     fn test_resource_uri_serialization_conversion(

--- a/attestation-agent/kbc/src/cc_kbc/mod.rs
+++ b/attestation-agent/kbc/src/cc_kbc/mod.rs
@@ -30,7 +30,10 @@ impl KbcInterface for Kbc {
     }
 
     async fn decrypt_payload(&mut self, annotation_packet: AnnotationPacket) -> Result<Vec<u8>> {
-        let key_data = self.kbs_client.get_resource(annotation_packet.kid).await?;
+        let key_data = self
+            .kbs_client
+            .get_resource(annotation_packet.kid, "resource".to_string())
+            .await?;
         let key = Zeroizing::new(key_data);
 
         let wrap_type = WrapType::try_from(&annotation_packet.wrap_type[..])?;
@@ -43,7 +46,10 @@ impl KbcInterface for Kbc {
     }
 
     async fn get_resource(&mut self, desc: ResourceUri) -> Result<Vec<u8>> {
-        let data = self.kbs_client.get_resource(desc).await?;
+        let data = self
+            .kbs_client
+            .get_resource(desc, "resource".to_string())
+            .await?;
 
         Ok(data)
     }

--- a/attestation-agent/kbs_protocol/src/api.rs
+++ b/attestation-agent/kbs_protocol/src/api.rs
@@ -9,5 +9,5 @@ pub use resource_uri::ResourceUri;
 
 #[async_trait]
 pub trait KbsClientCapabilities {
-    async fn get_resource(&mut self, resource_uri: ResourceUri) -> Result<Vec<u8>>;
+    async fn get_resource(&mut self, resource_uri: ResourceUri, plugin: String) -> Result<Vec<u8>>;
 }

--- a/attestation-agent/kbs_protocol/src/bin/trustee-attester/README.md
+++ b/attestation-agent/kbs_protocol/src/bin/trustee-attester/README.md
@@ -23,7 +23,7 @@ cargo build -p kbs_protocol --bin trustee-attester --no-default-features
 ## Run: ##
 
 ```bash
-$ trustee-attester --url <Trustee-URL> [--cert-file <path>] get-resource --path <resource-path> [--initdata <initdata>]
+$ trustee-attester --url <Trustee-URL> [--cert-file <path>] get-resource --path <resource-path> [--initdata <initdata> --plugin <plugin>]
 ```
 
 ## Example: ##

--- a/attestation-agent/kbs_protocol/src/bin/trustee-attester/main.rs
+++ b/attestation-agent/kbs_protocol/src/bin/trustee-attester/main.rs
@@ -45,6 +45,12 @@ enum Commands {
         /// Initdata string
         #[clap(long)]
         initdata: Option<String>,
+
+        /// The Trustee plugin to use for the resource.
+        /// The default is the resource plugin
+
+        #[clap(long)]
+        plugin: Option<String>,
     },
 }
 
@@ -74,7 +80,11 @@ async fn main() -> Result<()> {
     }
 
     match cli.command {
-        Commands::GetResource { path, initdata } => {
+        Commands::GetResource {
+            path,
+            initdata,
+            plugin,
+        } => {
             // resource_path should start with '/' but not with '//'
             let resource_path = match path.starts_with('/') {
                 false => format!("/{path}"),
@@ -87,8 +97,9 @@ async fn main() -> Result<()> {
             let mut client = client_builder.build()?;
 
             let resource = ResourceUri::new("", &resource_path)?;
+            let plugin = plugin.unwrap_or("resource".to_string());
             let (_token, _key) = client.get_token().await?; // attest first
-            let resource_bytes = client.get_resource(resource).await?;
+            let resource_bytes = client.get_resource(resource, plugin).await?;
 
             println!("{}", STANDARD.encode(resource_bytes));
         }

--- a/attestation-agent/kbs_protocol/src/bin/trustee-attester/trustee-attester.1
+++ b/attestation-agent/kbs_protocol/src/bin/trustee-attester/trustee-attester.1
@@ -27,7 +27,7 @@ Optional. When <protocol> is https, add a certificate to verify the Trustee serv
 
 .SH SUBCOMMAND
 .IR get-resource
-\-\-path <resource-path> [\-\-initdata <initdata-string>]
+\-\-path <resource-path> [\-\-initdata <initdata-string> \-\-plugin <plugin-string>]
 
 .RS
 Do attestation and get a secret from Trustee.
@@ -40,6 +40,10 @@ Plaintext initdata can optionally be passed as a string with the
 .B \-\-initdata
 flag. The verifier will generally expect its hash to be measured,
 e.g. in PCR8 when using the TPM attester.
+
+.B \-\-plugin
+flag. Trustee can fulfill resources via a plugin that is specified
+here. The default is "resource"
 
 For more information look at
 https://github.com/confidential-containers/guest-components/blob/main/attestation-agent/docs/KBS_URI.md

--- a/attestation-agent/kbs_protocol/src/client/rcar_client.rs
+++ b/attestation-agent/kbs_protocol/src/client/rcar_client.rs
@@ -308,9 +308,9 @@ impl KbsClient<Box<dyn EvidenceProvider>> {
 
 #[async_trait]
 impl KbsClientCapabilities for KbsClient<Box<dyn EvidenceProvider>> {
-    async fn get_resource(&mut self, resource_uri: ResourceUri) -> Result<Vec<u8>> {
+    async fn get_resource(&mut self, resource_uri: ResourceUri, plugin: String) -> Result<Vec<u8>> {
         let mut remote_url = format!(
-            "{}/{KBS_PREFIX}/resource/{}/{}/{}",
+            "{}/{KBS_PREFIX}/{plugin}/{}/{}/{}",
             self.kbs_host_url, resource_uri.repository, resource_uri.r#type, resource_uri.tag
         );
         if let Some(ref q) = resource_uri.query {
@@ -471,7 +471,10 @@ mod test {
             .try_into()
             .expect("resource uri");
 
-        let resource = match client.get_resource(resource_uri).await {
+        let resource = match client
+            .get_resource(resource_uri, "resource".to_string())
+            .await
+        {
             Ok(resource) => resource,
             Err(e) => {
                 // Skip the test if the kbs server returned ProtocolVersion error. Any other

--- a/attestation-agent/kbs_protocol/src/client/token_client.rs
+++ b/attestation-agent/kbs_protocol/src/client/token_client.rs
@@ -30,9 +30,9 @@ impl KbsClient<Box<dyn TokenProvider>> {
 
 #[async_trait]
 impl KbsClientCapabilities for KbsClient<Box<dyn TokenProvider>> {
-    async fn get_resource(&mut self, resource_uri: ResourceUri) -> Result<Vec<u8>> {
+    async fn get_resource(&mut self, resource_uri: ResourceUri, plugin: String) -> Result<Vec<u8>> {
         let mut remote_url = format!(
-            "{}/{KBS_PREFIX}/resource/{}/{}/{}",
+            "{}/{KBS_PREFIX}/{plugin}/{}/{}/{}",
             self.kbs_host_url, resource_uri.repository, resource_uri.r#type, resource_uri.tag
         );
         if let Some(ref q) = resource_uri.query {

--- a/attestation-agent/kbs_protocol/src/lib.rs
+++ b/attestation-agent/kbs_protocol/src/lib.rs
@@ -37,7 +37,7 @@
 //!         .unwrap();
 //!
 //!     // the get_resource call will perform attestation
-//!     let resource = client.get_resource("kbs:///default/key/1".try_into().unwrap()).await.unwrap();
+//!     let resource = client.get_resource("kbs:///default/key/1".try_into().unwrap(), "resource".to_string()).await.unwrap();
 //!
 //!     // the client can also generate a token
 //!     let (token, tee_key) = client.get_token().await.unwrap();
@@ -63,7 +63,7 @@
 //!         .build()
 //!         .unwrap();
 //!
-//!     let resource = client.get_resource("kbs:///default/key/1".try_into().unwrap()).await.unwrap();
+//!     let resource = client.get_resource("kbs:///default/key/1".try_into().unwrap(), "resource".to_string()).await.unwrap();
 //! }
 //! ```
 //!

--- a/confidential-data-hub/kms/src/plugins/kbs/cc_kbc.rs
+++ b/confidential-data-hub/kms/src/plugins/kbs/cc_kbc.rs
@@ -55,7 +55,7 @@ impl Kbc for CcKbc {
     async fn get_resource(&mut self, rid: ResourceUri) -> Result<Vec<u8>> {
         let secret = self
             .client
-            .get_resource(rid)
+            .get_resource(rid, "resource".to_string())
             .await
             .map_err(|e| Error::KbsClientError(format!("get resource failed: {e:?}")))?;
         Ok(secret)


### PR DESCRIPTION
Following from #1208 and https://github.com/confidential-containers/trustee/issues/1158, let's make the handling of trustee plugins/endpoints in the guest-components.

Specifically, add a plugin parameter to `get_resource`. Use this to create the request to Trustee. This way it is explicit which plugin we are using.

Also, add support for plugins to the trustee-attester. Add an optional plugin argument that can specify a plugin.

This PR does not change the behavior of the CDH. Instead, we hardcode the CDH to always use the resource plugin. Again, this is much more explicit than what we do now. In the future we can extend the CDH to support other plugins via sealed-secret, ASR, and other interfaces.