### PR TITLE
cdh: store ephemeral LUKS headers in tmpfs

### DIFF
--- a/.github/workflows/cdh_basic.yml
+++ b/.github/workflows/cdh_basic.yml
@@ -72,4 +72,4 @@ jobs:
 
       - name: Run cargo test
         run: |
-          sudo -E PATH=$PATH -s cargo test --features kbs,aliyun,sev,bin -p kms -p confidential-data-hub
+          sudo -E PATH=$PATH -s cargo test --features kbs,aliyun,sev,bin,luks2 -p kms -p confidential-data-hub

--- a/confidential-data-hub/docs/kms-providers/alibaba.md
+++ b/confidential-data-hub/docs/kms-providers/alibaba.md
@@ -78,7 +78,7 @@ More details about accessing via EcsRamRole can be seen at [Access KMS from an E
 The client `AliyunKmsClient` supports `Encrypter`, `Decrypter`, and `Getter` api. When at the
 user side, the credential files can be directly given by the user.
 
-When in Tee, the credential files is supposed to be placed under `/run/confidential-containers/cdh/kms-credential/aliyun` directory.
+When in Tee, the credential files is supposed to be placed under `/run/confidential-containers/cdh/kbs/kms-credential/aliyun` directory.
 
 ## Sealed Secrets
 

--- a/confidential-data-hub/docs/kms-providers/ehsm-kms.md
+++ b/confidential-data-hub/docs/kms-providers/ehsm-kms.md
@@ -39,7 +39,7 @@ For more details please see the [`Enroll` operation of ehsm](https://github.com/
 The client `EhsmKmsClient` supports `Encrypter` and `Decrypter` api. When at the
 user side, the credential files can be directly given by the user.
 
-When in Tee, the credential files is supposed to be placed under `/run/confidential-containers/cdh/kms-credential/ehsm` directory.
+When in Tee, the credential files is supposed to be placed under `/run/confidential-containers/cdh/kbs/kms-credential/ehsm` directory.
 
 ## Sealed Secrets
 

--- a/confidential-data-hub/example.config.json
+++ b/confidential-data-hub/example.config.json
@@ -7,11 +7,11 @@
     },
     "credentials": [
         {
-            "path": "/run/confidential-containers/cdh/kms-credential/aliyun/ecsRamRole.json",
+            "path": "/run/confidential-containers/cdh/kbs/kms-credential/aliyun/ecsRamRole.json",
             "resource_uri": "kbs:///default/aliyun/ecs_ram_role"
         },
         {
-            "path": "/run/confidential-containers/cdh/test/file",
+            "path": "/run/confidential-containers/cdh/kbs/test/file",
             "resource_uri": "kbs:///default/test/file"
         }
     ],

--- a/confidential-data-hub/example.config.toml
+++ b/confidential-data-hub/example.config.toml
@@ -53,14 +53,14 @@ oLSG2dLCK9mjjraPjau34Q==
 # credentials are items that will be retrieved from KBS when CDH
 # is launched. `resource_uri` refers to the KBS resource uri and
 # `path` is where to place the file.
-# `path` must be with prefix `/run/confidential-containers/cdh`,
+# `path` must be with prefix `/run/confidential-containers/cdh/kbs`,
 # or it will be blocked by CDH.
 [[credentials]]
-path = "/run/confidential-containers/cdh/kms-credential/aliyun/ecsRamRole.json"
+path = "/run/confidential-containers/cdh/kbs/kms-credential/aliyun/ecsRamRole.json"
 resource_uri = "kbs:///default/aliyun/ecs_ram_role"
 
 [[credentials]]
-path = "/run/confidential-containers/cdh/test/file"
+path = "/run/confidential-containers/cdh/kbs/test/file"
 resource_uri = "kbs:///default/test/file"
 
 [image]

--- a/confidential-data-hub/hub/Cargo.toml
+++ b/confidential-data-hub/hub/Cargo.toml
@@ -40,6 +40,7 @@ base64.workspace = true
 cfg-if.workspace = true
 clap = { workspace = true, features = ["derive"], optional = true }
 config = { workspace = true }
+const_format.workspace = true
 crypto.path = "../../attestation-agent/deps/crypto"
 tracing.workspace = true
 tracing-subscriber = { workspace = true, optional = true }

--- a/confidential-data-hub/hub/src/auth/kbs.rs
+++ b/confidential-data-hub/hub/src/auth/kbs.rs
@@ -8,15 +8,16 @@
 
 use std::path::PathBuf;
 
+use const_format::concatcp;
 use kms::{plugins::kbs::KbcClient, Annotations, Getter};
 use tokio::fs;
 use tracing::debug;
 
-use crate::{hub::Hub, Error, Result};
+use crate::{hub::Hub, hub::CDH_BASE_DIR, Error, Result};
 
-/// This directory is used to store all the kbs resources get by CDH's init
-/// function, s.t. `[[Credential]]` sections in the config.toml file.
-pub const KBS_RESOURCE_STORAGE_DIR: &str = "/run/confidential-containers/cdh";
+/// Directory for KBS resources (credentials, etc.) fetched at init, see the `[[credentials]]`
+/// sections in CDH's `config.toml` file, for an example, see `example.config.toml`.
+const KBS_RESOURCE_STORAGE_DIR: &str = concatcp!(CDH_BASE_DIR, "/kbs");
 
 impl Hub {
     pub(crate) async fn init_kbs_resources(&self) -> Result<()> {
@@ -86,11 +87,11 @@ fn is_path_valid(path: &str) -> bool {
 mod tests {
     use rstest::rstest;
 
-    use crate::auth::kbs::{is_path_valid, KBS_RESOURCE_STORAGE_DIR};
+    use super::{is_path_valid, KBS_RESOURCE_STORAGE_DIR};
 
     #[rstest]
     #[case("/etc/config.toml".into(), false)]
-    #[case(format!("{KBS_RESOURCE_STORAGE_DIR}/../../config.toml"), false)]
+    #[case(format!("{KBS_RESOURCE_STORAGE_DIR}/../../config.toml",), false)]
     #[case(format!("{KBS_RESOURCE_STORAGE_DIR}/kms-credential/../../../config.toml"), false)]
     #[case(format!("{KBS_RESOURCE_STORAGE_DIR}/kms-credential/./config.toml"), false)]
     #[case(format!("{KBS_RESOURCE_STORAGE_DIR}/kms-credential/aliyun/config.toml"), true)]

--- a/confidential-data-hub/hub/src/config.rs
+++ b/confidential-data-hub/hub/src/config.rs
@@ -142,7 +142,7 @@ impl CdhConfig {
     /// ```
     ///
     /// It is supposed that all the `target path` should be with prefix
-    /// `/run/confidential-containers/cdh` or it will be treated as dangerous
+    /// `/run/confidential-containers/cdh/kbs` or it will be treated as dangerous
     /// path.
     ///
     /// TODO: delete this way after initdata mechanism could cover CDH's launch config.

--- a/confidential-data-hub/hub/src/hub.rs
+++ b/confidential-data-hub/hub/src/hub.rs
@@ -5,6 +5,9 @@
 
 use std::{collections::HashMap, path::Path};
 
+/// Base directory for CDH runtime data.
+pub(crate) const CDH_BASE_DIR: &str = "/run/confidential-containers/cdh";
+
 use async_trait::async_trait;
 use image_rs::{builder::ClientBuilder, config::ImageConfig, image::ImageClient};
 use kms::{Annotations, ProviderSettings};

--- a/confidential-data-hub/hub/src/secret/mod.rs
+++ b/confidential-data-hub/hub/src/secret/mod.rs
@@ -7,6 +7,7 @@ pub mod error;
 pub mod layout;
 
 use base64::{engine::general_purpose::URL_SAFE_NO_PAD as b64, Engine};
+use const_format::concatcp;
 use jose_jwa::Signing;
 use jose_jwk::{EcCurves, Jwk};
 use jose_jws::{Flattened, Protected, Unprotected};
@@ -19,9 +20,12 @@ use self::layout::{envelope::EnvelopeSecret, vault::VaultSecret};
 
 use kms::{Annotations, ProviderSettings};
 
+use crate::hub::CDH_BASE_DIR;
+
 pub use error::{Result, SecretError};
 
-pub const SIGNING_CREDENTIALS_PATH: &str = "/run/confidential-containers/cdh/sealed-secret";
+/// Path to the directory containing sealed-secret signing credentials.
+pub const SIGNING_CREDENTIALS_PATH: &str = concatcp!(CDH_BASE_DIR, "/sealed-secret");
 
 #[derive(Serialize, Deserialize, PartialEq, Debug)]
 #[serde(tag = "type", rename_all = "lowercase")]

--- a/confidential-data-hub/hub/src/storage/drivers/luks2.rs
+++ b/confidential-data-hub/hub/src/storage/drivers/luks2.rs
@@ -13,6 +13,10 @@
 use std::path::Path;
 
 use anyhow::Context;
+use base64::{engine::general_purpose::URL_SAFE_NO_PAD as b64, Engine};
+use const_format::concatcp;
+
+use crate::hub::CDH_BASE_DIR;
 use libcryptsetup_rs::consts::flags::{CryptActivate, CryptDeactivate, CryptVolumeKey};
 use libcryptsetup_rs::consts::vals::EncryptionFormat;
 use libcryptsetup_rs::{CryptInit, CryptParamsLuks2, CryptParamsLuks2Ref};
@@ -30,6 +34,34 @@ const LUKS2_VOLUME_KEY_SIZE_BIT_WITHOUT_INTEGRITY: usize = 256;
 
 const SECTOR_SIZE: u32 = 4096;
 
+pub const LUKS_HEADERS_STORAGE_DIR: &str = concatcp!(CDH_BASE_DIR, "/luks-headers");
+pub const LUKS_HEADER_FILE_SUFFIX: &str = ".header";
+pub const LUKS2_HEADER_MIN_SIZE_BYTES: u64 = 16 * 1024 * 1024;
+
+/// Returns the path where the detached LUKS header for the given device is stored.
+pub fn luks_header_path(device_path: &str) -> String {
+    let name = b64.encode(device_path.as_bytes());
+    format!(
+        "{}/{}{}",
+        LUKS_HEADERS_STORAGE_DIR, name, LUKS_HEADER_FILE_SUFFIX
+    )
+}
+
+/// Creates and sizes the LUKS header file at `header_path`.
+pub fn prepare_luks_header_file(header_path: &str) -> std::io::Result<()> {
+    if let Some(parent) = Path::new(header_path).parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    // error "LUKS header file not found: <path/to/header>" from libcryptsetup if header file doesn't exist.
+    let file = std::fs::OpenOptions::new()
+        .create_new(true)
+        .write(true)
+        .open(header_path)?;
+    // error "Device ... is too small" / OS error 5" from libcryptsetup if header isn't sized.
+    file.set_len(LUKS2_HEADER_MIN_SIZE_BYTES)?;
+    Ok(())
+}
+
 #[derive(Default)]
 pub struct Luks2Formatter {
     pub integrity: bool,
@@ -44,10 +76,10 @@ impl Luks2Formatter {
     pub fn encrypt_device(
         &self,
         device_path: &str,
+        header_path: Option<&str>,
         passphrase: Zeroizing<Vec<u8>>,
     ) -> anyhow::Result<()> {
-        let path = Path::new(device_path);
-        let mut device = CryptInit::init(path)?;
+        let mut device = init_device(device_path, header_path)?;
         let mut volume_key_length = LUKS2_VOLUME_KEY_SIZE_BIT_WITHOUT_INTEGRITY / 8;
         let mut params = CryptParamsLuks2 {
             pbkdf: None,
@@ -82,11 +114,11 @@ impl Luks2Formatter {
     pub fn open_device(
         &self,
         device_path: &str,
+        header_path: Option<&str>,
         name: &str,
         passphrase: Zeroizing<Vec<u8>>,
     ) -> anyhow::Result<()> {
-        let path = Path::new(device_path);
-        let mut device = CryptInit::init(path)?;
+        let mut device = init_device(device_path, header_path)?;
 
         let mut params = CryptParamsLuks2 {
             pbkdf: None,
@@ -130,6 +162,19 @@ impl Luks2Formatter {
     }
 }
 
+fn init_device(
+    device_path: &str,
+    header_path: Option<&str>,
+) -> anyhow::Result<libcryptsetup_rs::CryptDevice> {
+    let device_path = Path::new(device_path);
+    let device_paths = match header_path {
+        Some(header_path) => libcryptsetup_rs::Either::Right((Path::new(header_path), device_path)),
+        None => libcryptsetup_rs::Either::Left(device_path),
+    };
+
+    Ok(CryptInit::init_with_data_device(device_paths)?)
+}
+
 #[cfg(test)]
 mod tests {
     use std::io::Write;
@@ -137,10 +182,19 @@ mod tests {
     use serial_test::serial;
     use zeroize::Zeroizing;
 
-    use crate::storage::drivers::luks2::Luks2Formatter;
+    use super::{luks_header_path, prepare_luks_header_file, Luks2Formatter};
 
     const TEST_PASSPHRASE: &[u8] = b"test";
     const NAME: &str = "test";
+
+    /// Removes the LUKS header file on drop so tests don't leave files behind on panic.
+    /// TODO: Similarly, clean dm-crypt devices when a panic occurs.
+    struct RemoveHeaderOnDrop(String);
+    impl Drop for RemoveHeaderOnDrop {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_file(&self.0);
+        }
+    }
 
     #[test]
     #[serial]
@@ -156,10 +210,12 @@ mod tests {
         let passphrase = Zeroizing::new(TEST_PASSPHRASE.to_vec());
         let luks2_formatter = Luks2Formatter { integrity: false };
         luks2_formatter
-            .encrypt_device(path, passphrase.clone())
+            .encrypt_device(path, None, passphrase.clone())
             .unwrap();
 
-        luks2_formatter.open_device(path, NAME, passphrase).unwrap();
+        luks2_formatter
+            .open_device(path, None, NAME, passphrase)
+            .unwrap();
 
         luks2_formatter.close_device(NAME).unwrap();
     }
@@ -178,12 +234,135 @@ mod tests {
         let passphrase = Zeroizing::new(TEST_PASSPHRASE.to_vec());
         let luks2_formatter = Luks2Formatter { integrity: true };
         luks2_formatter
-            .encrypt_device(path, passphrase.clone())
+            .encrypt_device(path, None, passphrase.clone())
             .unwrap();
 
-        luks2_formatter.open_device(path, NAME, passphrase).unwrap();
+        luks2_formatter
+            .open_device(path, None, NAME, passphrase)
+            .unwrap();
 
         luks2_formatter.close_device(NAME).unwrap();
+    }
+
+    #[test]
+    #[serial]
+    fn encrypt_open_device_no_integrity_with_header() {
+        let mut bin_file = tempfile::NamedTempFile::new().unwrap();
+        bin_file
+            .as_file_mut()
+            .write_all(&vec![0; 20 * 1024 * 1024])
+            .unwrap();
+        let path = bin_file.path().to_str().unwrap();
+        let header_path = luks_header_path(path);
+        prepare_luks_header_file(&header_path).unwrap();
+        let _guard = RemoveHeaderOnDrop(header_path.clone());
+
+        let passphrase = Zeroizing::new(TEST_PASSPHRASE.to_vec());
+        let luks2_formatter = Luks2Formatter { integrity: false };
+        luks2_formatter
+            .encrypt_device(path, Some(&header_path), passphrase.clone())
+            .unwrap();
+
+        luks2_formatter
+            .open_device(path, Some(&header_path), NAME, passphrase)
+            .unwrap();
+
+        luks2_formatter.close_device(NAME).unwrap();
+    }
+
+    #[test]
+    #[serial]
+    fn encrypt_open_device_integrity_with_header() {
+        let mut bin_file = tempfile::NamedTempFile::new().unwrap();
+        bin_file
+            .as_file_mut()
+            .write_all(&vec![0; 20 * 1024 * 1024])
+            .unwrap();
+        let path = bin_file.path().to_str().unwrap();
+        let header_path = luks_header_path(path);
+        prepare_luks_header_file(&header_path).unwrap();
+        let _guard = RemoveHeaderOnDrop(header_path.clone());
+
+        let passphrase = Zeroizing::new(TEST_PASSPHRASE.to_vec());
+        let luks2_formatter = Luks2Formatter { integrity: true };
+        luks2_formatter
+            .encrypt_device(path, Some(&header_path), passphrase.clone())
+            .unwrap();
+
+        luks2_formatter
+            .open_device(path, Some(&header_path), NAME, passphrase)
+            .unwrap();
+
+        luks2_formatter.close_device(NAME).unwrap();
+    }
+
+    #[test]
+    #[serial]
+    fn encrypt_with_existing_header_file() {
+        let mut bin_file = tempfile::NamedTempFile::new().unwrap();
+        bin_file
+            .as_file_mut()
+            .write_all(&vec![0; 20 * 1024 * 1024])
+            .unwrap();
+        let path = bin_file.path().to_str().unwrap();
+        let header_path = luks_header_path(path);
+        prepare_luks_header_file(&header_path).unwrap();
+        let _guard = RemoveHeaderOnDrop(header_path.clone());
+
+        let passphrase = Zeroizing::new(TEST_PASSPHRASE.to_vec());
+        let luks2_formatter = Luks2Formatter { integrity: false };
+        let result = luks2_formatter.encrypt_device(path, Some(&header_path), passphrase);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    #[serial]
+    fn open_device_missing_header_file_fails() {
+        let mut bin_file = tempfile::NamedTempFile::new().unwrap();
+        bin_file
+            .as_file_mut()
+            .write_all(&vec![0; 20 * 1024 * 1024])
+            .unwrap();
+        let path = bin_file.path().to_str().unwrap();
+        let header_path = luks_header_path(path);
+        prepare_luks_header_file(&header_path).unwrap();
+        let _guard = RemoveHeaderOnDrop(header_path.clone());
+
+        let passphrase = Zeroizing::new(TEST_PASSPHRASE.to_vec());
+        let luks2_formatter = Luks2Formatter { integrity: false };
+        luks2_formatter
+            .encrypt_device(path, Some(&header_path), passphrase.clone())
+            .unwrap();
+
+        std::fs::remove_file(&header_path).unwrap();
+
+        let result =
+            luks2_formatter.open_device(path, Some(header_path.as_str()), NAME, passphrase);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn prepare_luks_header_file_rejects_existing_path() {
+        use rand::{distr::Alphanumeric, rng, Rng};
+
+        let path_str = format!(
+            "/dev/{}",
+            rng()
+                .sample_iter(&Alphanumeric)
+                .take(16)
+                .map(char::from)
+                .collect::<String>()
+        );
+
+        let header_path = luks_header_path(&path_str);
+        prepare_luks_header_file(&header_path).unwrap();
+        let result = prepare_luks_header_file(&header_path);
+
+        match result {
+            Err(err) => assert_eq!(err.kind(), std::io::ErrorKind::AlreadyExists),
+            other => panic!("unexpected result: {other:?}"),
+        }
+        let _ = std::fs::remove_file(&header_path);
     }
 
     /// This test can be used to clean useless devices under /dev/mapper/

--- a/confidential-data-hub/hub/src/storage/volume_type/blockdevice/mod.rs
+++ b/confidential-data-hub/hub/src/storage/volume_type/blockdevice/mod.rs
@@ -459,6 +459,7 @@ mod tests {
         assert!(device_path.len() > 4); // "/dev/" is 4 characters long
     }
 
+    #[cfg(feature = "luks2")]
     #[tokio::test]
     #[rstest]
     #[serial]

--- a/confidential-data-hub/kms/src/plugins/ehsm/README.md
+++ b/confidential-data-hub/kms/src/plugins/ehsm/README.md
@@ -125,7 +125,7 @@ Congratulations! eHSM-KMS service should be ready by now.
 
 # eHSM-KMS Client
 
-eHSM-KMS client requires a credential file to run. The file name of the credential file is `credential.{your_app_id}.json`. The credential file need to be placed in `/run/confidential-containers/cdh/kms-credential/ehsm/`. And the structure of the credential file is shown in `ehsm/example_credential/` folder.
+eHSM-KMS client requires a credential file to run. The file name of the credential file is `credential.{your_app_id}.json`. The credential file need to be placed in `/run/confidential-containers/cdh/kbs/kms-credential/ehsm/`. And the structure of the credential file is shown in `ehsm/example_credential/` folder.
 
 To test eHSM-KMS client, run
 ``` shell

--- a/confidential-data-hub/kms/src/plugins/mod.rs
+++ b/confidential-data-hub/kms/src/plugins/mod.rs
@@ -9,7 +9,7 @@ use strum::{AsRefStr, EnumString};
 
 use crate::{Decrypter, Error, Getter, ProviderSettings, Result};
 
-const _IN_GUEST_DEFAULT_KEY_PATH: &str = "/run/confidential-containers/cdh/kms-credential";
+const _IN_GUEST_DEFAULT_KEY_PATH: &str = "/run/confidential-containers/cdh/kbs/kms-credential";
 
 #[cfg(feature = "aliyun")]
 pub mod aliyun;


### PR DESCRIPTION
**Outline:**
When creating ephemeral storages, place the LUKS headers in guest memory rather than onto the storage device itself. For this, create LUKS header files in the CDH storage directory, and call into `CryptInit::init_with_data_device` instead of into `CryptInit::init`. This aims to mitigate [Vulnerabilities in LUKS2 disk encryption for confidential VMs](https://blog.trailofbits.com/2025/10/30/vulnerabilities-in-luks2-disk-encryption-for-confidential-vms/) for ephemeral storages.

The path where existing, encrypted storages are utilized remains untouched. We should evaluate switch to utilizing different encryption schemes, such as using ZFS, or VeraCrypt, instead.

**Testing:**
I tested this end-to-end flow against kata-containers for which I created this draft PR for integration of the new CDH bits: https://github.com/kata-containers/kata-containers/pull/12459
In my tests, I was using the [trusted image store functionality](https://github.com/kata-containers/kata-containers/blob/main/docs/how-to/how-to-pull-images-in-guest-with-kata.md) in combination with the `kata-qemu-gpu-snp` handler.

I have also onboarded the luks2 tests to CI, and CI tests pass.

**Outlook:**
The ongoing work stream to support [ephemeral container storage](https://github.com/kata-containers/kata-containers/pull/10559/files) in Kata Containers should benefit from this PR and from the integration branch as well once the guest components are updated in Kata Containers.

**Output:**
In the guest:
```
root@26a7f28fc681:/# ls -lha /run/confidential-containers/cdh/luks-headers/
total 16M
drwxr-xr-x 2 root root  60 Feb 11 19:17 .
drwxr-xr-x 3 root root  60 Feb 11 19:17 ..
-rw-r--r-- 1 root root 16M Feb 11 19:17 ODow
< 160 /run/confidential-containers/cdh/luks-headers/ODow | head -n 10
000000 4c 55 4b 53 ba be 00 02 00 00 00 00 00 00 40 00
000010 00 00 00 00 00 00 00 03 00 00 00 00 00 00 00 00
000020 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
*
000040 00 00 00 00 00 00 00 00 73 68 61 32 35 36 00 00
000050 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
000060 00 00 00 00 00 00 00 00 3d 7b bb b5 fd eb 88 c6
000070 98 53 9b 77 84 ad a5 98 4e 73 bb fe 77 2e 6a b6
000080 3d e3 88 5a 6d 0d 5d 68 77 a0 5c 51 db bb 88 79
000090 bc 09 89 d6 c6 e3 54 ec 82 73 0b f1 91 d9 e8 40
```
`4c 55 4b 53` = LUKS magic
`ba be 00 02` = LUKS2
sha256 appears in the header metadata

On the host:
```
$ od -Ax -tx1 -N 64 /tmp/trusted-image-storage.img
000000 69 6e 74 65 67 72 74 00 04 0f 20 00 f0 01 00 00
000010 78 67 0c 06 00 00 00 00 08 00 00 00 03 0c 00 00
000020 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
*
000040
```
`69 6e 74 65 67 72 74 00` is the dm-integrity magic, which is ASCII integrt\0.

Log from CDH:
```
[2026-02-11T19:17:16Z INFO  ttrpc_cdh] [ttRPC] Confidential Data Hub starts to listen to request: unix:///run/confidential-containers/cdh.sock
[2026-02-11T19:17:17Z DEBUG ttrpc_cdh::ttrpc_server] [ttRPC CDH] get new secure mount request
[2026-02-11T19:17:17Z INFO  confidential_data_hub::hub] secure mount called
[2026-02-11T19:17:17Z DEBUG confidential_data_hub::storage::volume_type::blockdevice] generate a random key. All data on the device will be overwritten.
[2026-02-11T19:17:17Z WARN  confidential_data_hub::storage::volume_type::blockdevice] encrypting the device. This will wipe original data on the disk.
[2026-02-11T19:17:29Z DEBUG confidential_data_hub::storage::volume_type::blockdevice] No mapper name provided, generating a random one
[2026-02-11T19:17:29Z DEBUG confidential_data_hub::storage::volume_type::blockdevice] luks2 opening device: /dev/sda
[2026-02-11T19:17:29Z DEBUG confidential_data_hub::storage::drivers::luks2] activating device: 628918be-bb49-4f52-8ace-8df7ea05a8db
[2026-02-11T19:17:31Z DEBUG confidential_data_hub::storage::drivers::luks2] device activated: 628918be-bb49-4f52-8ace-8df7ea05a8db
[2026-02-11T19:17:31Z INFO  confidential_data_hub::storage::volume_type::blockdevice] formatting device: /dev/mapper/628918be-bb49-4f52-8ace-8df7ea05a8db and mounting it to mount point: /run/kata-containers/image/
[2026-02-11T19:17:31Z DEBUG confidential_data_hub::storage::volume_type::blockdevice] formatting device: /dev/mapper/628918be-bb49-4f52-8ace-8df7ea05a8db
[2026-02-11T19:17:31Z DEBUG confidential_data_hub::storage::volume_type::blockdevice] mounting device: /dev/mapper/628918be-bb49-4f52-8ace-8df7ea05a8db
[2026-02-11T19:17:31Z INFO  confidential_data_hub::storage::volume_type::blockdevice] Target path /run/kata-containers/image/ mounted successfully
[2026-02-11T19:17:31Z DEBUG ttrpc_cdh::ttrpc_server] [ttRPC CDH] secure mount succeeded.
[2026-02-11T19:17:31Z DEBUG ttrpc_cdh::ttrpc_server] [ttRPC CDH] get new image pull request
[2026-02-11T19:17:31Z DEBUG confidential_data_hub::hub] Image client lazy initializing...
[2026-02-11T19:17:31Z INFO  image_rs::resource::kbs] secure channel uses ttrpc
[2026-02-11T19:17:31Z WARN  image_rs::builder] No `image_security_policy` given, thus all images can be pulled by the image client without filtering.
[2026-02-11T19:17:31Z INFO  image_rs::builder] Initialize new metadata.
[2026-02-11T19:17:31Z INFO  image_rs::builder] Image work directory: "/run/kata-containers/image/"
```