### PR TITLE
ci: Use gnu libc to build CDH

### DIFF
--- a/.github/workflows/publish-artifacts.yml
+++ b/.github/workflows/publish-artifacts.yml
@@ -125,7 +125,7 @@ jobs:
         - powerpc64le
         include:
         - arch: x86_64
-          libc: musl
+          libc: gnu
         - arch: s390x
           libc: gnu
         - arch: aarch64


### PR DESCRIPTION
Align the CI task with recent changes to the CDH build process.