### PR TITLE
ci: Install new CDH dependencies

### DIFF
--- a/.github/workflows/publish-artifacts.yml
+++ b/.github/workflows/publish-artifacts.yml
@@ -166,7 +166,7 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get install -y --no-install-recommends \
-          libdevmapper-dev
+          libdevmapper-dev libcryptsetup-dev pkg-config
         if [ "${{ matrix.arch }}" = "powerpc64le" ]; then
           sudo apt-get install -y libclang-dev cmake protobuf-compiler
         fi


### PR DESCRIPTION
Install the libcryptsetup-dev, pkg-config packages similar to the recent change in `image_rs_build.yml`, see commit
`ba683043f7ca90bb2e7a121119a43a399216bb0b`. This should unblock the still failing "publish-cdh-and-asr (x86_64)" CI task.