### PR TITLE
ci: Run on ubuntu-24.04-arm for arch aarch64

### DIFF
--- a/.github/workflows/publish-artifacts.yml
+++ b/.github/workflows/publish-artifacts.yml
@@ -126,13 +126,17 @@ jobs:
         include:
         - arch: x86_64
           libc: gnu
+          instance: ubuntu-24.04
         - arch: s390x
           libc: gnu
+          instance: s390x
         - arch: aarch64
           libc: gnu
+          instance: ubuntu-24.04-arm
         - arch: powerpc64le
           libc: gnu
-    runs-on: ${{ matrix.arch == 's390x' && 's390x' || matrix.arch == 'powerpc64le' && 'ubuntu-24.04-ppc64le' || 'ubuntu-24.04' }}
+          instance: ubuntu-24.04-ppc64le
+    runs-on: ${{ matrix.instance }}
     env:
       LIBC: ${{ matrix.libc }}
       REGISTRY: ghcr.io


### PR DESCRIPTION
Run the publish-cdh-and-asr job for the aarch64 architecture on on the ubuntu-24.04-arm runner, aligned with other occurrences of builds for aarch64. This intends to avoid cross-compilation issues recently observed with new CDH builds.

A local build reproducing this flow on an ARM machine worked for me for CDH.