### PR TITLE
fix: update openssl-src to 300.5.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4596,9 +4596,9 @@ checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
 name = "openssl-src"
-version = "300.5.4+3.5.4"
+version = "300.5.5+3.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a507b3792995dae9b0df8a1c1e3771e8418b7c2d9f0baeba32e6fe8b06c7cb72"
+checksum = "3f1787d533e03597a7934fd0a765f0d28e94ecc5fb7789f8053b1e699a56f709"
 dependencies = [
  "cc",
 ]


### PR DESCRIPTION
this is vulnerability in previous version of openssl-src, so updated to 300.5.5+3.5.5

CVE-2025-69421 - check this for more info 

