### PR TITLE
workflows: Install oras for IBM Actions Z runners

### DIFF
--- a/.github/workflows/publish-artifacts.yml
+++ b/.github/workflows/publish-artifacts.yml
@@ -52,7 +52,6 @@ jobs:
     - uses: oras-project/setup-oras@22ce207df3b08e061f537244349aac6ae1d214f6 # v1.2.4
       with:
         version: 1.2.0
-      if: matrix.platform.arch != 's390x'
 
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
@@ -129,7 +128,7 @@ jobs:
           instance: ubuntu-24.04
         - arch: s390x
           libc: gnu
-          instance: s390x
+          instance: ubuntu-24.04-s390x
         - arch: aarch64
           libc: gnu
           instance: ubuntu-24.04-arm
@@ -158,7 +157,6 @@ jobs:
     - uses: oras-project/setup-oras@22ce207df3b08e061f537244349aac6ae1d214f6 # v1.2.4
       with:
         version: 1.2.0
-      if: matrix.arch != 's390x'
 
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 


### PR DESCRIPTION
This is a follow-up PR for #1375 as a CI error was observed due to lack of oras while publishing artifacts. Install the package for IBM Actions Z runners as well.

Signed-off-by: Hyounggyu Choi <Hyounggyu.Choi@ibm.com>