### PR TITLE
Make CDH statically built-able again with replacing libcryptsetup-rs with binary calling

### DIFF
--- a/.github/workflows/cdh_basic.yml
+++ b/.github/workflows/cdh_basic.yml
@@ -57,7 +57,7 @@ jobs:
 
       - name: Install cryptsetup and zfs
         run: |
-          sudo apt-get update && sudo apt-get install -y libcryptsetup-dev pkg-config zfsutils-linux
+          sudo apt-get update && sudo apt-get install -y cryptsetup pkg-config zfsutils-linux
 
       - name: Build and install
         run: |
@@ -72,4 +72,4 @@ jobs:
 
       - name: Run cargo test
         run: |
-          sudo -E PATH=$PATH -s RUST_LOG=warn cargo test --features kbs,aliyun,sev,bin,luks2 -p kms -p confidential-data-hub -- --nocapture
+          sudo -E PATH=$PATH -s RUST_LOG=warn cargo test --features kbs,aliyun,sev,bin -p kms -p confidential-data-hub -- --nocapture

--- a/.github/workflows/image_rs_build.yml
+++ b/.github/workflows/image_rs_build.yml
@@ -70,7 +70,8 @@ jobs:
       
       - name: Install cryptsetup
         run: |
-          sudo apt-get install -y libcryptsetup-dev pkg-config
+          sudo apt-get install -y cryptsetup pkg-config
+        if: matrix.instance == 'ubuntu-24.04'  || matrix.instance == 'ubuntu-24.04-arm'
 
       - name: Install cross-compliation support dependencies
         run: |

--- a/.github/workflows/publish-artifacts.yml
+++ b/.github/workflows/publish-artifacts.yml
@@ -124,7 +124,7 @@ jobs:
         - powerpc64le
         include:
         - arch: x86_64
-          libc: gnu
+          libc: musl
           instance: ubuntu-24.04
         - arch: s390x
           libc: gnu

--- a/.github/workflows/publish-artifacts.yml
+++ b/.github/workflows/publish-artifacts.yml
@@ -168,7 +168,7 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get install -y --no-install-recommends \
-          libdevmapper-dev libcryptsetup-dev pkg-config
+          libdevmapper-dev pkg-config
         if [ "${{ matrix.arch }}" = "powerpc64le" ]; then
           sudo apt-get install -y libclang-dev cmake protobuf-compiler
         fi

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1301,7 +1301,6 @@ dependencies = [
  "jose-jwk",
  "jose-jws",
  "kms",
- "libcryptsetup-rs",
  "nix 0.31.2",
  "p256",
  "prost 0.14.3",
@@ -3987,37 +3986,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
 
 [[package]]
-name = "libcryptsetup-rs"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ffd3642e85d0a4a7852c28545764754e8f7ca00c33ea5f2035f241a1da869ed"
-dependencies = [
- "bitflags 2.11.0",
- "either",
- "libc",
- "libcryptsetup-rs-sys",
- "log",
- "once_cell",
- "per-thread-mutex",
- "pkg-config",
- "semver",
- "serde_json",
- "uuid",
-]
-
-[[package]]
-name = "libcryptsetup-rs-sys"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "376e4a1f481c5f0b8354d370cfaf9f1322d56e628e2954c6b59c9729e6f4d5ee"
-dependencies = [
- "bindgen 0.72.1",
- "cc",
- "pkg-config",
- "semver",
-]
-
-[[package]]
 name = "libgit2-sys"
 version = "0.18.3+1.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4990,16 +4958,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6305423e0e7738146434843d1694d621cce767262b2a86910beab705e4493d9"
 dependencies = [
  "base64ct",
-]
-
-[[package]]
-name = "per-thread-mutex"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b20d1aaa7fcf3cd5a7b4506c38594d25e122ad45dec6da7f85bac52f3a3e562c"
-dependencies = [
- "libc",
- "log",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1321,6 +1321,7 @@ dependencies = [
  "tracing-subscriber",
  "ttrpc",
  "uuid",
+ "which 8.0.2",
  "zeroize",
 ]
 
@@ -5471,7 +5472,7 @@ dependencies = [
  "prost 0.8.0",
  "prost-types 0.8.0",
  "tempfile",
- "which",
+ "which 4.4.2",
 ]
 
 [[package]]
@@ -5579,7 +5580,7 @@ dependencies = [
  "protobuf-support",
  "tempfile",
  "thiserror 1.0.69",
- "which",
+ "which 4.4.2",
 ]
 
 [[package]]
@@ -8369,6 +8370,15 @@ dependencies = [
  "home",
  "once_cell",
  "rustix 0.38.44",
+]
+
+[[package]]
+name = "which"
+version = "8.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81995fafaaaf6ae47a7d0cc83c67caf92aeb7e5331650ae6ff856f7c0c60c459"
+dependencies = [
+ "libc",
 ]
 
 [[package]]

--- a/confidential-data-hub/Makefile
+++ b/confidential-data-hub/Makefile
@@ -32,7 +32,6 @@ else
 endif
 RESOURCE_PROVIDER ?= kbs,sev
 KMS_PROVIDER ?= aliyun
-STORAGE ?= luks2
 DESTDIR ?= $(PREFIX)/bin
 RUSTFLAGS_ARGS ?=
 features ?=
@@ -59,10 +58,6 @@ endif
 
 ifneq ($(KMS_PROVIDER), none)
     features += $(KMS_PROVIDER)
-endif
-
-ifneq ($(STORAGE), none)
-    features += $(STORAGE)
 endif
 
 ifeq ($(LIBC), musl)

--- a/confidential-data-hub/README.md
+++ b/confidential-data-hub/README.md
@@ -82,10 +82,6 @@ Secure mount plugins (flag `STORAGE`)
 Note:
 - If no `STORAGE` flag is given, then all the STORAGE plugins will be enabled by default.
 
-| Feature name        |           Note                                                     |
-| ------------------- | -----------------------------------------------------------------  |
-| luks2               | Support secure mount with [luks2 encrypted block device](./docs/use-cases/secure-mount-with-block-device.md) |
-
 ### Configuration file
 
 CDH will be launched by a configuration file by

--- a/confidential-data-hub/docs/SECURE_STORAGE.md
+++ b/confidential-data-hub/docs/SECURE_STORAGE.md
@@ -69,7 +69,7 @@ The [plugin](../hub/src/storage/volume_type/blockdevice) provides ways to encryp
 
 It supports **two secure mount modes**, selected by the `encryptionType` field in the `secure_mount()` request:
 
-- **LUKS2 mode (`"luks2"`)**: Uses `libcryptsetup` to create and open a LUKS2-encrypted device.
+- **LUKS2 mode (`"luks2"`)**: Uses `cryptsetup` to create and open a LUKS2-encrypted device.
 - **ZFS mode (`"zfs"`)**: Uses ZFS native encryption on top of a ZFS pool and encrypted dataset created on the block device.
 
 In both modes, the cleartext device or filesystem is only exposed inside the TEE guest.

--- a/confidential-data-hub/docs/use-cases/secure-mount-with-block-device.md
+++ b/confidential-data-hub/docs/use-cases/secure-mount-with-block-device.md
@@ -4,7 +4,7 @@ This guide helps an user to use confidential data hub to secure mount inside TEE
 
 ## Preliminaries
 
-- Ensure that `libcryptsetup-dev` is installed for **LUKS2** mode.
+- Ensure that `cryptsetup` is installed for **LUKS2** mode.
 - Ensure that `zfsutils-linux` is installed and the ZFS kernel module is enabled for **ZFS** mode.
 
 The block-device plugin supports two secure mount modes: **LUKS2** (`encryptionType: "luks2"`) and **ZFS** (`encryptionType: "zfs"`). The following [Configuration](#configuration) section summarizes common and mode-specific options; then [Best practices](#best-practices) covers loop-device preparation plus end-to-end flows for LUKS2 and ZFS.
@@ -96,10 +96,10 @@ Commands, steps, and expected behavior when using **LUKS2** secure mount (`encry
 ### Prerequisites
 
 - Build CDH and the client tool: see [CDH README](../../README.md#confidential-data-hub) and [Client Tool README](../../README.md#client-tool).
-- Install libcryptsetup and development library:
+- Install the `cryptsetup` CLI
 
 ```bash
-sudo apt install -y libcryptsetup-dev
+sudo apt install -y cryptsetup
 ```
 
 ### Step 1: Start CDH

--- a/confidential-data-hub/hub/Cargo.toml
+++ b/confidential-data-hub/hub/Cargo.toml
@@ -75,6 +75,7 @@ tokio = { workspace = true, features = [
 tonic = { workspace = true, optional = true }
 ttrpc = { workspace = true, features = ["async"], optional = true }
 uuid = { workspace = true, features = ["fast-rng", "v4"] }
+which = "8.0.2"
 zeroize.workspace = true
 
 [build-dependencies]

--- a/confidential-data-hub/hub/Cargo.toml
+++ b/confidential-data-hub/hub/Cargo.toml
@@ -52,7 +52,6 @@ jose-jwa = "0.1.2"
 jose-jwk = "0.1.2"
 jose-jws = "0.1.2"
 kms = { path = "../kms", default-features = false }
-libcryptsetup-rs = { version = "0.13.1", optional = true, features = ["mutex"] }
 nix.workspace = true
 p256 = "0.13.2"
 prost = { workspace = true, optional = true }
@@ -105,10 +104,6 @@ sev = ["kms/sev"]
 
 # support eHSM stacks (KMS, ...)
 ehsm = []
-
-# support luks2 encrypted block device storage enabled by cryptsetup.
-# It requires to install dependency `libcryptsetup-dev` for ubuntu.
-luks2 = ["libcryptsetup-rs"]
 
 # Binary RPC type
 bin = ["clap", "shadow-rs", "tracing-subscriber"]

--- a/confidential-data-hub/hub/src/storage/drivers/luks2.rs
+++ b/confidential-data-hub/hub/src/storage/drivers/luks2.rs
@@ -6,39 +6,30 @@
 
 //! # LUKS2
 //!
-//! This module leverages cryptsetup to encrypt/decrypt a block device with luks2.
+//! This module uses the `cryptsetup` binary to encrypt/decrypt a block device with LUKS2.
 //!
-//! It requires to install dependency `libcryptsetup-dev` for ubuntu.
+//! It requires the `cryptsetup` CLI to be installed (e.g. `cryptsetup-bin` on Debian/Ubuntu).
+//! No libcryptsetup-rs is linked, so the hub binary can be built as fully static.
 
 use std::path::Path;
 
 use anyhow::{Context, Result};
 use base64::{engine::general_purpose::URL_SAFE_NO_PAD as b64, Engine};
 use const_format::concatcp;
-
-use crate::hub::CDH_BASE_DIR;
-use libcryptsetup_rs::consts::flags::{CryptActivate, CryptDeactivate, CryptVolumeKey};
-use libcryptsetup_rs::consts::vals::EncryptionFormat;
-use libcryptsetup_rs::{CryptInit, CryptParamsLuks2, CryptParamsLuks2Ref};
-use nix::mount::{mount, MsFlags};
-use serde::{Deserialize, Serialize};
-use tokio::fs::symlink;
-use tracing::{debug, info, warn};
+use tracing::debug;
 use zeroize::Zeroizing;
 
+use crate::hub::CDH_BASE_DIR;
 use crate::storage::drivers::filesystem::{FsFormatter, FsType};
+use crate::storage::drivers::run_command;
 use crate::storage::volume_type::blockdevice::SourceType;
 
-/// Algorithm of the integrity hash
-const HMAC_SHA256: &str = "hmac(sha256)";
-
-/// The volume key size in bits with integrity
-const LUKS2_VOLUME_KEY_SIZE_BIT_WITH_INTEGRITY: usize = 768;
-
-/// The volume key size in bits without integrity
-const LUKS2_VOLUME_KEY_SIZE_BIT_WITHOUT_INTEGRITY: usize = 256;
+/// Algorithm of the integrity hash (dm-integrity format name)
+const HMAC_SHA256: &str = "hmac-sha256";
 
 const SECTOR_SIZE: u32 = 4096;
+
+const CRYPTSETUP_BIN: &str = "cryptsetup";
 
 pub const LUKS_HEADERS_STORAGE_DIR: &str = concatcp!(CDH_BASE_DIR, "/luks-headers");
 pub const LUKS_HEADER_FILE_SUFFIX: &str = ".header";
@@ -58,12 +49,10 @@ pub fn prepare_luks_header_file(header_path: &str) -> std::io::Result<()> {
     if let Some(parent) = Path::new(header_path).parent() {
         std::fs::create_dir_all(parent)?;
     }
-    // error "LUKS header file not found: <path/to/header>" from libcryptsetup if header file doesn't exist.
     let file = std::fs::OpenOptions::new()
         .create_new(true)
         .write(true)
         .open(header_path)?;
-    // error "Device ... is too small" / OS error 5" from libcryptsetup if header isn't sized.
     file.set_len(LUKS2_HEADER_MIN_SIZE_BYTES)?;
     Ok(())
 }
@@ -104,44 +93,45 @@ impl Luks2Formatter {
         self
     }
 
+    /// Encrypt (format) a block device as LUKS2 using the `cryptsetup` binary.
     pub fn encrypt_device(
         &self,
         device_path: &str,
         header_path: Option<&str>,
         passphrase: Zeroizing<Vec<u8>>,
     ) -> anyhow::Result<()> {
-        let mut device = init_device(device_path, header_path)?;
-        let mut volume_key_length = LUKS2_VOLUME_KEY_SIZE_BIT_WITHOUT_INTEGRITY / 8;
-        let mut params = CryptParamsLuks2 {
-            pbkdf: None,
-            integrity: None,
-            integrity_params: None,
-            data_alignment: 0,
-            data_device: None,
-            sector_size: SECTOR_SIZE,
-            label: None,
-            subsystem: None,
-        };
+        let sector_size_str = SECTOR_SIZE.to_string();
 
-        if self.integrity {
-            params.integrity = Some(HMAC_SHA256.to_string());
-            volume_key_length = LUKS2_VOLUME_KEY_SIZE_BIT_WITH_INTEGRITY / 8;
+        let mut args: Vec<&str> = vec![
+            "--batch-mode",
+            "luksFormat",
+            "--type",
+            "luks2",
+            "--cipher",
+            "aes-xts-plain64",
+            "--sector-size",
+            &sector_size_str,
+        ];
+
+        if let Some(h) = header_path {
+            args.push("--header");
+            args.push(h);
         }
 
-        device.context_handle().format(
-            EncryptionFormat::Luks2,
-            ("aes", "xts-plain"),
-            None,
-            libcryptsetup_rs::Either::Right(volume_key_length),
-            Some(&mut TryInto::<CryptParamsLuks2Ref>::try_into(&params)?),
-        )?;
+        if self.integrity {
+            args.push("--integrity");
+            args.push(HMAC_SHA256);
+            args.push("--integrity-no-wipe");
+        }
 
-        device
-            .keyslot_handle()
-            .add_by_key(None, None, &passphrase, CryptVolumeKey::empty())?;
+        args.push(device_path);
+        args.push("-"); // read passphrase from stdin
+
+        run_cryptsetup_stdin(&args, &passphrase).context("cryptsetup luksFormat failed")?;
         Ok(())
     }
 
+    /// Open a LUKS2 device using the `cryptsetup` binary.
     pub fn open_device(
         &self,
         device_path: &str,
@@ -149,61 +139,38 @@ impl Luks2Formatter {
         name: &str,
         passphrase: Zeroizing<Vec<u8>>,
     ) -> anyhow::Result<()> {
-        let mut device = init_device(device_path, header_path)?;
+        let mut args: Vec<&str> = vec!["luksOpen", "-d", "-", device_path, name];
 
-        let mut params = CryptParamsLuks2 {
-            pbkdf: None,
-            integrity: None,
-            integrity_params: None,
-            data_alignment: 0,
-            data_device: None,
-            sector_size: SECTOR_SIZE,
-            label: None,
-            subsystem: None,
-        };
-
-        if self.integrity {
-            params.integrity = Some(HMAC_SHA256.to_string());
+        if let Some(h) = header_path {
+            args.insert(1, h);
+            args.insert(1, "--header");
         }
 
-        device
-            .context_handle()
-            .load(
-                Some(EncryptionFormat::Luks2),
-                Some(&mut TryInto::<CryptParamsLuks2Ref>::try_into(&params)?),
-            )
-            .context("Failed to load LUKS2 device")?;
-
-        debug!("activating device: {}", name);
-        // We use NO_JOURNAL for performance
-        device
-            .activate_handle()
-            .activate_by_passphrase(Some(name), None, &passphrase, CryptActivate::NO_JOURNAL)
-            .context("Failed to activate LUKS2 device")?;
+        run_cryptsetup_stdin(&args, &passphrase).context("cryptsetup luksOpen failed")?;
         debug!("device activated: {}", name);
         Ok(())
     }
 
+    /// Close a LUKS2 mapping using the `cryptsetup` binary.
     pub fn close_device(&self, name: &str) -> anyhow::Result<()> {
-        let mut device = CryptInit::init_by_name_and_header(name, None)?;
-        device
-            .activate_handle()
-            .deactivate(name, CryptDeactivate::empty())?;
+        let args = ["luksClose", name];
+        run_cryptsetup(&args).context("cryptsetup luksClose failed")?;
         Ok(())
     }
 }
 
-fn init_device(
-    device_path: &str,
-    header_path: Option<&str>,
-) -> anyhow::Result<libcryptsetup_rs::CryptDevice> {
-    let device_path = Path::new(device_path);
-    let device_paths = match header_path {
-        Some(header_path) => libcryptsetup_rs::Either::Right((Path::new(header_path), device_path)),
-        None => libcryptsetup_rs::Either::Left(device_path),
-    };
+/// Run cryptsetup with passphrase on stdin. Does not append newline.
+fn run_cryptsetup_stdin(args: &[&str], passphrase: &[u8]) -> anyhow::Result<()> {
+    let inputs = passphrase.to_vec();
+    let _ = run_command(CRYPTSETUP_BIN, args, Some(inputs))
+        .context("failed to run cryptsetup with stdin")?;
+    Ok(())
+}
 
-    Ok(CryptInit::init_with_data_device(device_paths)?)
+/// Run cryptsetup without stdin (e.g. luksClose).
+fn run_cryptsetup(args: &[&str]) -> anyhow::Result<()> {
+    let _ = run_command(CRYPTSETUP_BIN, args, None).context("failed to run cryptsetup")?;
+    Ok(())
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]

--- a/confidential-data-hub/hub/src/storage/drivers/luks2.rs
+++ b/confidential-data-hub/hub/src/storage/drivers/luks2.rs
@@ -16,7 +16,10 @@ use std::path::Path;
 use anyhow::{Context, Result};
 use base64::{engine::general_purpose::URL_SAFE_NO_PAD as b64, Engine};
 use const_format::concatcp;
-use tracing::debug;
+use nix::mount::{mount, MsFlags};
+use serde::{Deserialize, Serialize};
+use tokio::fs::symlink;
+use tracing::{debug, info, warn};
 use zeroize::Zeroizing;
 
 use crate::hub::CDH_BASE_DIR;

--- a/confidential-data-hub/hub/src/storage/drivers/mod.rs
+++ b/confidential-data-hub/hub/src/storage/drivers/mod.rs
@@ -13,7 +13,6 @@ use tempfile::NamedTempFile;
 use tracing::debug;
 
 pub mod filesystem;
-#[cfg(feature = "luks2")]
 pub mod luks2;
 pub mod zfs;
 

--- a/confidential-data-hub/hub/src/storage/drivers/mod.rs
+++ b/confidential-data-hub/hub/src/storage/drivers/mod.rs
@@ -8,9 +8,10 @@ use std::{
     process::{Command, Stdio},
 };
 
-use anyhow::{anyhow, bail, Result};
+use anyhow::{anyhow, bail, Context, Result};
 use tempfile::NamedTempFile;
 use tracing::debug;
+use which::which;
 
 pub mod filesystem;
 pub mod luks2;
@@ -22,6 +23,7 @@ pub fn run_command(
     args: &[&str],
     inputs: Option<Vec<u8>>,
 ) -> Result<(String, String)> {
+    let _ = which(command).with_context(|| format!("command `{command}` not found"))?;
     let mut status = Command::new(command)
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())

--- a/confidential-data-hub/hub/src/storage/volume_type/blockdevice/mod.rs
+++ b/confidential-data-hub/hub/src/storage/volume_type/blockdevice/mod.rs
@@ -31,7 +31,6 @@ use zeroize::Zeroizing;
 #[derive(Serialize, Deserialize, Display, Debug, PartialEq, Eq)]
 #[serde(tag = "encryptionType")]
 pub enum BlockDeviceEncryptType {
-    #[cfg(feature = "luks2")]
     #[strum(serialize = "luks2")]
     #[serde(rename = "luks2")]
     Luks2(crate::storage::drivers::luks2::Luks2MountParameters),
@@ -133,7 +132,6 @@ pub struct BlockDevice {
     /// clean up.
     ///
     /// It is (device-path, dev-mapper-name)
-    #[cfg(feature = "luks2")]
     cryptsetup_pairs: Vec<(String, String)>,
 
     /// The zfs pools created by the operation. This is used to
@@ -176,7 +174,6 @@ impl BlockDevice {
 
         // 3. do the workflow according to the source type and target type according to different encryption types
         match parameters.encryption_type {
-            #[cfg(feature = "luks2")]
             BlockDeviceEncryptType::Luks2(luks2_parameters) => {
                 if luks2_parameters.target_type
                     == crate::storage::drivers::luks2::TargetType::Device
@@ -220,7 +217,6 @@ impl BlockDevice {
         }
 
         // 3. close luks2 devices
-        #[cfg(feature = "luks2")]
         for (_, name) in &self.cryptsetup_pairs {
             let formatter = crate::storage::drivers::luks2::Luks2Formatter::default();
             formatter
@@ -317,7 +313,6 @@ mod tests {
         assert!(device_path.len() > 4); // "/dev/" is 4 characters long
     }
 
-    #[cfg(feature = "luks2")]
     #[rstest::rstest]
     #[case::integrity("true")]
     #[case::no_integrity("false")]
@@ -362,7 +357,6 @@ mod tests {
         bd.umount().await.unwrap();
     }
 
-    #[cfg(feature = "luks2")]
     #[rstest::rstest]
     #[case::integrity("true")]
     #[case::no_integrity("false")]
@@ -409,7 +403,6 @@ mod tests {
         bd.umount().await.unwrap();
     }
 
-    #[cfg(feature = "luks2")]
     #[tokio::test]
     #[cfg_attr(target_arch = "s390x", ignore)]
     #[serial]
@@ -456,7 +449,6 @@ mod tests {
         bd.umount().await.unwrap();
     }
 
-    #[cfg(feature = "luks2")]
     #[tokio::test]
     #[cfg_attr(target_arch = "s390x", ignore)]
     #[serial]
@@ -512,7 +504,6 @@ mod tests {
         bd.umount().await.unwrap();
     }
 
-    #[cfg(feature = "luks2")]
     #[tokio::test]
     #[cfg_attr(target_arch = "s390x", ignore)]
     #[serial]

--- a/confidential-data-hub/hub/src/storage/volume_type/mod.rs
+++ b/confidential-data-hub/hub/src/storage/volume_type/mod.rs
@@ -6,6 +6,7 @@
 #[cfg(feature = "aliyun")]
 pub mod aliyun;
 pub mod blockdevice;
+
 use std::{collections::HashMap, str::FromStr};
 
 use super::error::Result;


### PR DESCRIPTION
Currently, CDH is not statically compileable, and I'm afraid we'll need to release different binaries for each different distribution, even on the same architecture. This is because the same binary might cause issues running on different distributions' dynamic link libraries.

This PR aims to solve this problem. However, this requires https://github.com/confidential-containers/guest-components/pull/1344, thus I've marked as a WIP for now, for replacing some common functions.