### PR TITLE
se-attester: Bind runtime data to IBM SEL attestation evidence

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -499,7 +499,7 @@ dependencies = [
  "sha2 0.10.9",
  "thiserror 2.0.18",
  "tss-esapi",
- "zerocopy 0.8.48",
+ "zerocopy",
 ]
 
 [[package]]
@@ -528,7 +528,7 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.18",
  "ureq",
- "zerocopy 0.8.48",
+ "zerocopy",
 ]
 
 [[package]]
@@ -2323,6 +2323,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "enum_dispatch"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa18ce2bc66555b3218614519ac839ddb759a7d6720732f979ef8d13be147ecd"
+dependencies = [
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "enumflags2"
 version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2797,7 +2809,7 @@ checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
 dependencies = [
  "cfg-if",
  "crunchy",
- "zerocopy 0.8.48",
+ "zerocopy",
 ]
 
 [[package]]
@@ -5293,7 +5305,7 @@ version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
- "zerocopy 0.8.48",
+ "zerocopy",
 ]
 
 [[package]]
@@ -6237,34 +6249,36 @@ checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "s390_pv"
-version = "0.10.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f75b3a6c5bb5b3e8e4fdced5e8b406fcfaf909a96975c4010e839799bf25f48"
+checksum = "73b3164010c1c8f2555721d3c2297158fc957e751d383b4e617610b40bf40ac6"
 dependencies = [
  "byteorder",
  "curl",
+ "enum_dispatch",
  "foreign-types",
  "log",
  "openssl",
  "openssl-sys",
  "s390_pv_core",
  "serde",
- "thiserror 1.0.69",
- "zerocopy 0.7.35",
+ "thiserror 2.0.18",
+ "zerocopy",
 ]
 
 [[package]]
 name = "s390_pv_core"
-version = "0.10.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dacc93d1903ab065f327d8c71745a9a48f4e812dd6707cec62538d5a84654627"
+checksum = "ba83bc04ef65f9a404af077f4e6b84d59569ae2ce6c473a923105059df79ec54"
 dependencies = [
  "byteorder",
  "libc",
  "log",
+ "regex",
  "serde",
- "thiserror 1.0.69",
- "zerocopy 0.7.35",
+ "thiserror 2.0.18",
+ "zerocopy",
 ]
 
 [[package]]
@@ -8866,32 +8880,11 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.7.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
-dependencies = [
- "byteorder",
- "zerocopy-derive 0.7.35",
-]
-
-[[package]]
-name = "zerocopy"
 version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
 dependencies = [
- "zerocopy-derive 0.8.48",
-]
-
-[[package]]
-name = "zerocopy-derive"
-version = "0.7.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
+ "zerocopy-derive",
 ]
 
 [[package]]

--- a/attestation-agent/attester/Cargo.toml
+++ b/attestation-agent/attester/Cargo.toml
@@ -25,7 +25,7 @@ kbs-types.workspace = true
 nv-attestation-sdk = { git = "https://github.com/NVIDIA/attestation-sdk", tag = "2026.03.02", optional = true }
 occlum_dcap = { git = "https://github.com/occlum/occlum", tag = "v0.29.7", optional = true }
 pem-rfc7468 = { version = "1", optional = true, features = ["alloc"] }
-pv = { version = "0.10.0", package = "s390_pv", optional = true }
+pv = { version = "0.12.0", package = "s390_pv", optional = true }
 scroll = { version = "0.13.0", default-features = false, features = [
     "derive",
     "std",

--- a/attestation-agent/attester/src/se/mod.rs
+++ b/attestation-agent/attester/src/se/mod.rs
@@ -12,10 +12,26 @@ use pv::{
 };
 use serde::{Deserialize, Serialize};
 use serde_with::{base64::Base64, serde_as};
-use std::fs;
 use tracing::debug;
 
-const DIGEST_FILE: &str = "/run/peerpod/initdata.digest";
+const RUNTIME_DIGEST_SIZE: usize = 48; // SHA-384 digest size in bytes
+
+/// Structured user data for IBM SEL attestation
+/// Currently, only contains runtime data digest bound to the attestation measurement
+/// This could be extended in the future to include additional fields
+#[serde_as]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UserData {
+    #[serde_as(as = "Base64")]
+    pub runtime_data_digest: Vec<u8>,
+}
+
+impl UserData {
+    /// Return runtime_data_digest as raw bytes for attestation command
+    pub fn to_bytes(&self) -> Vec<u8> {
+        self.runtime_data_digest.clone()
+    }
+}
 
 pub fn detect_platform() -> bool {
     misc::pv_guest_bit_set()
@@ -26,15 +42,20 @@ pub fn detect_platform() -> bool {
 #[derive(Debug, Serialize, Deserialize)]
 pub struct SeAttestationRequest {
     #[serde_as(as = "Base64")]
-    request_blob: Vec<u8>,
-    measurement_size: u32,
-    additional_size: u32,
+    pub request_blob: Vec<u8>,
+    pub measurement_size: u32,
+    pub additional_size: u32,
     #[serde_as(as = "Base64")]
-    encr_measurement_key: Vec<u8>,
+    pub encr_measurement_key: Vec<u8>,
     #[serde_as(as = "Base64")]
-    encr_request_nonce: Vec<u8>,
+    pub encr_request_nonce: Vec<u8>,
     #[serde_as(as = "Base64")]
-    image_hdr_tags: BootHdrTags,
+    pub image_hdr_tags: BootHdrTags,
+    /// Runtime data digest computed from the full JSON structure:
+    /// (tee-pubkey, nonce, additional-evidence)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde_as(as = "Option<Base64>")]
+    pub runtime_data_digest: Option<Vec<u8>>,
 }
 
 #[repr(C)]
@@ -71,14 +92,51 @@ impl Attester for SeAttester {
             encr_measurement_key,
             encr_request_nonce,
             image_hdr_tags,
+            runtime_data_digest,
         } = request;
-        let mut user_data = vec![0];
-        if fs::metadata(DIGEST_FILE).is_ok() {
-            user_data = fs::read(DIGEST_FILE)?;
-        }
+
+        // Construct user_data with runtime_data_digest
+        let runtime_digest =
+            runtime_data_digest.ok_or_else(|| anyhow!("runtime_data_digest not provided"))?;
+
+        debug!(
+            "Using runtime_data_digest, length: {}, content: {:?}",
+            runtime_digest.len(),
+            runtime_digest
+        );
+
+        let runtime_digest = match runtime_digest.len() {
+            len if len > RUNTIME_DIGEST_SIZE => {
+                bail!(
+                    "Invalid runtime_data_digest length: expected {} bytes (SHA-384), got {} (too large)",
+                    RUNTIME_DIGEST_SIZE,
+                    len
+                );
+            }
+            len if len < RUNTIME_DIGEST_SIZE => {
+                debug!(
+                    "Padding runtime_data_digest from {} to {} bytes with zeros",
+                    len, RUNTIME_DIGEST_SIZE
+                );
+                let mut padded = runtime_digest;
+                padded.resize(RUNTIME_DIGEST_SIZE, 0);
+                padded
+            }
+            _ => runtime_digest, // Exact match, use as-is
+        };
+
+        let user_data = UserData {
+            runtime_data_digest: runtime_digest,
+        };
+
+        let user_data_bytes = user_data.to_bytes();
+
+        // user_data is used to produce the measurement (HMAC),
+        // meaning if the data is different, the measurement will be different.
+        // See: https://www.ibm.com/docs/en/linux-on-systems?topic=commands-pvattest
         let mut uvc: AttestationCmd = AttestationCmd::new_request(
             request_blob.into(),
-            Some(user_data.to_vec()),
+            Some(user_data_bytes.clone()),
             measurement_size,
             additional_size,
         )?;
@@ -91,7 +149,7 @@ impl Attester for SeAttester {
         let response: SeAttestationResponse = SeAttestationResponse {
             measurement: uvc.measurement().to_vec(),
             additional_data,
-            user_data,
+            user_data: user_data_bytes,
             cuid: *cuid,
             encr_measurement_key,
             encr_request_nonce,
@@ -100,5 +158,187 @@ impl Attester for SeAttester {
 
         debug!("response json: {response:#?}");
         Ok(serde_json::to_value(&response)?)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Mock runtime digest (SHA-384 size: 48 bytes) for tests
+    // This simulates the digest computed from runtime data in production
+    const MOCK_RUNTIME_DIGEST: [u8; 48] = [0xBB; 48];
+
+    // Helper to create a dummy BootHdrTags for testing
+    fn create_dummy_boot_hdr_tags() -> BootHdrTags {
+        // BootHdrTags::new signature: (pld: [u8; 64], ald: [u8; 64], tld: [u8; 64], tag: [u8; 16])
+        let pld = [0u8; 64];
+        let ald = [0u8; 64];
+        let tld = [0u8; 64];
+        let tag = [0u8; 16];
+        BootHdrTags::new(pld, ald, tld, tag)
+    }
+
+    #[tokio::test]
+    async fn test_runtime_data_digest_serialization() {
+        // Test that runtime_data_digest is properly serialized and deserialized
+        let expected_digest = MOCK_RUNTIME_DIGEST.to_vec();
+
+        let request = SeAttestationRequest {
+            request_blob: vec![0; 32],
+            measurement_size: 64,
+            additional_size: 32,
+            encr_measurement_key: vec![0; 32],
+            encr_request_nonce: vec![0; 16],
+            image_hdr_tags: create_dummy_boot_hdr_tags(),
+            runtime_data_digest: Some(expected_digest.clone()),
+        };
+
+        // Serialize and deserialize (simulating the JSON flow in get_evidence)
+        let request_json = serde_json::to_vec(&request).unwrap();
+        let parsed: SeAttestationRequest = serde_json::from_slice(&request_json).unwrap();
+
+        // Verify the digest is preserved through serialization
+        assert!(parsed.runtime_data_digest.is_some());
+        assert_eq!(parsed.runtime_data_digest.unwrap(), expected_digest);
+    }
+
+    #[tokio::test]
+    async fn test_runtime_data_digest_none_when_not_provided() {
+        // Test that runtime_data_digest can be None and is properly handled
+        let request = SeAttestationRequest {
+            request_blob: vec![0; 32],
+            measurement_size: 64,
+            additional_size: 32,
+            encr_measurement_key: vec![0; 32],
+            encr_request_nonce: vec![0; 16],
+            image_hdr_tags: create_dummy_boot_hdr_tags(),
+            runtime_data_digest: None,
+        };
+
+        let request_json = serde_json::to_vec(&request).unwrap();
+        let parsed: SeAttestationRequest = serde_json::from_slice(&request_json).unwrap();
+
+        assert!(parsed.runtime_data_digest.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_runtime_data_digest_with_various_sizes() {
+        // Helper function that mimics the validation/padding logic from lines 110-129
+        fn process_runtime_digest(runtime_digest: Vec<u8>) -> Result<Vec<u8>> {
+            match runtime_digest.len() {
+                len if len > RUNTIME_DIGEST_SIZE => {
+                    bail!(
+                        "Invalid runtime_data_digest length: expected {} bytes (SHA-384), got {} (too large)",
+                        RUNTIME_DIGEST_SIZE,
+                        len
+                    )
+                }
+                len if len < RUNTIME_DIGEST_SIZE => {
+                    let mut padded = runtime_digest;
+                    padded.resize(RUNTIME_DIGEST_SIZE, 0);
+                    Ok(padded)
+                }
+                _ => Ok(runtime_digest), // Exact match, use as-is
+            }
+        }
+
+        // Case 1: Exact size (48 bytes) - should use as-is
+        let exact_digest = vec![0xAA; RUNTIME_DIGEST_SIZE];
+        let result = process_runtime_digest(exact_digest.clone()).unwrap();
+        assert_eq!(result.len(), RUNTIME_DIGEST_SIZE);
+        assert_eq!(result, exact_digest);
+
+        // Case 2: Too small (< 48 bytes) - should be padded with zeros
+        let small_test_cases = vec![
+            (vec![], 0),                       // Empty digest
+            (vec![0xAA], 1),                   // Single byte
+            (vec![0xAA, 0xBB, 0xCC, 0xDD], 4), // 4 bytes
+            (vec![0xFF; 32], 32),              // 32 bytes (SHA-256 size)
+            (vec![0x11; 47], 47),              // 47 bytes (just under limit)
+        ];
+
+        for (small_digest, original_len) in small_test_cases {
+            let result = process_runtime_digest(small_digest.clone()).unwrap();
+
+            // Verify result is padded to 48 bytes
+            assert_eq!(result.len(), RUNTIME_DIGEST_SIZE);
+
+            // Verify original data is preserved at the beginning
+            assert_eq!(&result[..original_len], &small_digest[..]);
+
+            // Verify zeros are padded at the end
+            for i in original_len..RUNTIME_DIGEST_SIZE {
+                assert_eq!(result[i], 0, "Byte at index {} should be 0 (padded)", i);
+            }
+        }
+
+        // Case 3: Too large (> 48 bytes) - should return error
+        let large_test_cases = vec![
+            (vec![0xFF; 49], 49),   // 49 bytes (just over limit)
+            (vec![0xFF; 64], 64),   // 64 bytes (SHA-512 size)
+            (vec![0xFF; 100], 100), // 100 bytes (way over limit)
+        ];
+
+        for (large_digest, len) in large_test_cases {
+            let result = process_runtime_digest(large_digest);
+
+            // Verify error is returned
+            assert!(
+                result.is_err(),
+                "Digest of size {} should produce an error",
+                len
+            );
+
+            let err_msg = result.unwrap_err().to_string();
+            assert!(
+                err_msg.contains("too large"),
+                "Error should mention 'too large'"
+            );
+            assert!(
+                err_msg.contains(&len.to_string()),
+                "Error should mention length {}",
+                len
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn test_runtime_data_digest_base64_serialization() {
+        // Verify that the digest is properly base64 encoded in JSON
+        let digest = MOCK_RUNTIME_DIGEST.to_vec();
+
+        let request = SeAttestationRequest {
+            request_blob: vec![0; 32],
+            measurement_size: 64,
+            additional_size: 32,
+            encr_measurement_key: vec![0; 32],
+            encr_request_nonce: vec![0; 16],
+            image_hdr_tags: create_dummy_boot_hdr_tags(),
+            runtime_data_digest: Some(digest.clone()),
+        };
+
+        let request_json = serde_json::to_string(&request).unwrap();
+
+        // Verify JSON contains base64-encoded digest
+        assert!(request_json.contains("runtime_data_digest"));
+
+        // Verify round-trip preserves the data
+        let parsed: SeAttestationRequest = serde_json::from_str(&request_json).unwrap();
+        assert_eq!(parsed.runtime_data_digest, Some(digest));
+    }
+
+    #[tokio::test]
+    async fn test_user_data_to_bytes() {
+        // Test that UserData correctly returns runtime_data_digest as raw bytes
+        let runtime_digest = MOCK_RUNTIME_DIGEST.to_vec();
+        let user_data = UserData {
+            runtime_data_digest: runtime_digest.clone(),
+        };
+
+        let bytes = user_data.to_bytes();
+
+        // Verify it returns raw bytes directly
+        assert_eq!(bytes, runtime_digest);
     }
 }

--- a/attestation-agent/kbs_protocol/src/client/rcar_client.rs
+++ b/attestation-agent/kbs_protocol/src/client/rcar_client.rs
@@ -168,25 +168,49 @@ impl KbsClient<Box<dyn EvidenceProvider>> {
 
         // Calculate the runtime data for the primary attester, which includes
         // the device evidence retrieved above.
+        let primary_runtime_data_json = json!({
+            "tee-pubkey": runtime_data.tee_pubkey,
+            "nonce": runtime_data.nonce,
+            "additional-evidence": additional_evidence,
+        });
+        let primary_runtime_data_serialized =
+            serialize_json_canonically(&primary_runtime_data_json)
+                .context("serialize runtime data failed")?;
+        let primary_runtime_digest = hash_algorithm.digest(&primary_runtime_data_serialized);
+
         let primary_runtime_data = match tee {
-            // SE handles the report data differently. As such, it does not support
-            // multi-device attestation.
+            // SE handles the report data differently. It:
+            // - does not support multi-device attestation.
+            // - injects runtime_data_digest into the request
+            // The injected data will be used in SE attester's get_evidence method.
             Tee::Se => {
                 if !additional_evidence.is_empty() {
                     bail!("Cannot attest multiple devices on s390x platform.")
                 }
-                runtime_data.nonce.into_bytes()
+
+                #[cfg(feature = "se-attester")]
+                {
+                    use attester::se::SeAttestationRequest;
+
+                    // Deserialize the nonce as SeAttestationRequest
+                    let mut request: SeAttestationRequest =
+                        serde_json::from_str(&runtime_data.nonce)
+                            .context("Failed to deserialize SeAttestationRequest from nonce")?;
+
+                    // Inject runtime_data_digest
+                    request.runtime_data_digest = Some(primary_runtime_digest);
+                    debug!("Injected runtime_data_digest into SE attestation request");
+
+                    // Serialize the modified request to pass to the attester
+                    serde_json::to_vec(&request)
+                        .context("Failed to serialize modified SeAttestationRequest")?
+                }
+                #[cfg(not(feature = "se-attester"))]
+                {
+                    bail!("Tee::Se requires se-attester feature to be enabled")
+                }
             }
-            _ => {
-                let primary_runtime_data = json!({
-                    "tee-pubkey": runtime_data.tee_pubkey,
-                    "nonce": runtime_data.nonce,
-                    "additional-evidence": additional_evidence,
-                });
-                let primary_runtime_data = serialize_json_canonically(&primary_runtime_data)
-                    .context("serialize runtime data failed")?;
-                hash_algorithm.digest(&primary_runtime_data)
-            }
+            _ => primary_runtime_digest,
         };
 
         let primary_evidence = self.provider.primary_evidence(primary_runtime_data).await?;


### PR DESCRIPTION
This PR makes the following changes:
- Deserialize SeAttestationRequest from the nonce in AttestationRequest
- Inject runtime_data_digest directly into the request
- Serialize SeAttestationRequest again as primary_runtime_data
- Construct user_data from runtime_data_digest

This binds user_data to the measurement in the attestation evidence.

Depends-on: https://github.com/confidential-containers/trustee/pull/1284

Assisted-by: IBM Bob
Signed-off-by: Hyounggyu Choi <Hyounggyu.Choi@ibm.com>