### PR TITLE
ci: release AA on TDX with musl

### DIFF
--- a/.github/workflows/publish-artifacts.yml
+++ b/.github/workflows/publish-artifacts.yml
@@ -23,7 +23,7 @@ jobs:
           { tee: none,        arch: aarch64, libc: gnu, runner: ubuntu-24.04 },
           { tee: amd,         arch: x86_64,  libc: musl, runner: ubuntu-24.04 },
           { tee: az-cvm-vtpm, arch: x86_64,  libc: gnu, runner: ubuntu-24.04 },
-          { tee: tdx,         arch: x86_64,  libc: gnu, runner: ubuntu-24.04 },
+          { tee: tdx,         arch: x86_64,  libc: musl, runner: ubuntu-24.04 },
           { tee: cca,         arch: x86_64,  libc: musl, runner: ubuntu-24.04 },
           { tee: cca,         arch: aarch64, libc: gnu, runner: ubuntu-24.04 },
           { tee: se,          arch: s390x,   libc: gnu, runner: ubuntu-24.04-s390x },


### PR DESCRIPTION
Currently the TDX attester can be built with musl. Thus we change the published AA binary with musl to run on different distros.