### PR TITLE
chore(deps): update openssl to 0.10.78 to fix vulnerabilities

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ jwt-simple = { version = "0.12", default-features = false, features = [
 ] }
 kbs-types = "0.15.0"
 nix = "0.31"
-openssl = "0.10"
+openssl = "0.10.78"
 prost = "0.14"
 protobuf = "3.7.2"
 rand = "0.10.0"


### PR DESCRIPTION
Pin workspace [`openssl`](Cargo.toml:43) to [`0.10.78`](Cargo.toml:43) to avoid resolving vulnerable `rust-openssl` versions.
