### PR TITLE
protos: Add missing license to crate

### DIFF
--- a/protos/Cargo.toml
+++ b/protos/Cargo.toml
@@ -2,6 +2,7 @@
 name = "protos"
 version = "0.1.0"
 edition = "2021"
+license = "Apache-2.0"
 
 [dependencies]
 async-trait = { workspace = true, optional = true }


### PR DESCRIPTION
protos is missing a license, so causes cargo deny to fail on it's license check if image-rs is in a dependency.