### PR TITLE
deps: Remediate two CVEs by updating astral-tokio-tar to 0.6.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -250,9 +250,9 @@ dependencies = [
 
 [[package]]
 name = "astral-tokio-tar"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c23f3af104b40a3430ccb90ed5f7bd877a8dc5c26fc92fde51a22b40890dcf9"
+checksum = "4ce73b17c62717c4b6a9af10b43e87c578b0cac27e00666d48304d3b7d2c0693"
 dependencies = [
  "filetime",
  "futures-core",


### PR DESCRIPTION
Another security vuln, which dependabot doesn't track, but the OpenSSF tool does:

Update astral-tokio-tar from 0.6.0 to 0.6.1, remediating
- RUSTSEC-2026-0112
- RUSTSEC-2026-0113

Assisted-by: IBM Bob