### PR TITLE
image-rs: introduce pathrs (incrementally)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -634,7 +634,7 @@ dependencies = [
  "bitflags 2.11.0",
  "cexpr",
  "clang-sys",
- "itertools 0.10.5",
+ "itertools 0.13.0",
  "log",
  "prettyplease",
  "proc-macro2",
@@ -654,7 +654,7 @@ dependencies = [
  "bitflags 2.11.0",
  "cexpr",
  "clang-sys",
- "itertools 0.10.5",
+ "itertools 0.13.0",
  "log",
  "prettyplease",
  "proc-macro2",
@@ -3377,6 +3377,7 @@ dependencies = [
  "oci-client 0.16.1",
  "oci-spec 0.9.0",
  "ocicrypt-rs",
+ "pathrs",
  "protos",
  "reqwest 0.13.2",
  "resource_uri",
@@ -4947,6 +4948,24 @@ name = "pathdiff"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
+
+[[package]]
+name = "pathrs"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fb2311801201fc6fd2e8a9f4841b41eee565e992fbe713731e29e367b8e3f17"
+dependencies = [
+ "bitflags 2.11.0",
+ "itertools 0.14.0",
+ "libc",
+ "memchr",
+ "once_cell",
+ "rustix 1.1.4",
+ "rustversion",
+ "static_assertions",
+ "tempfile",
+ "thiserror 2.0.18",
+]
 
 [[package]]
 name = "pbkdf2"
@@ -6566,7 +6585,7 @@ dependencies = [
  "sha1collisiondetection",
  "sha2 0.10.9",
  "sha3 0.10.8",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
  "twofish",
  "typenum",
  "x25519-dalek",

--- a/image-rs/Cargo.toml
+++ b/image-rs/Cargo.toml
@@ -33,6 +33,7 @@ oci-spec = "0.9.0"
 ocicrypt-rs = { path = "../ocicrypt-rs", default-features = false, features = [
     "async-io",
 ], optional = true }
+pathrs = "0.2.4"
 protos = { path = "../protos", optional = true, default-features = false }
 reqwest = { workspace = true, features = ["json"], optional = true }
 resource_uri = { path = "../attestation-agent/deps/resource_uri", optional = true }

--- a/image-rs/src/stream/unpack.rs
+++ b/image-rs/src/stream/unpack.rs
@@ -7,6 +7,7 @@ use filetime::FileTime;
 use futures::StreamExt;
 use nix::libc::timeval;
 use nix::sys::stat::{mknod, Mode, SFlag};
+use pathrs::InodeType;
 use thiserror::Error;
 use tracing::{debug, warn};
 
@@ -93,6 +94,12 @@ pub enum UnpackError {
         #[source]
         source: anyhow::Error,
         path: String,
+    },
+
+    #[error("pathrs error: {source}")]
+    PathRsFailed {
+        #[source]
+        source: pathrs::error::Error,
     },
 }
 
@@ -185,7 +192,7 @@ async fn convert_whiteout(
 pub async fn unpack<R: AsyncRead + Unpin>(input: R, destination: &Path) -> UnpackResult<()> {
     if destination.exists() {
         warn!(
-            "unpack destination {destination:?} already exists, will delete and rerwrite the layer",
+            "unpack destination {destination:?} already exists, will delete and rewrite the layer",
         );
         fs::remove_dir_all(destination)
             .await
@@ -255,9 +262,8 @@ pub async fn unpack<R: AsyncRead + Unpin>(input: R, destination: &Path) -> Unpac
             continue;
         }
 
-        match file.unpack_in(destination).await {
-            Ok(_) => {}
-            Err(e) => match try_hardlink_fallback(&kind, &mut file, destination).await {
+        if let Err(e) = file.unpack_in(destination).await {
+            match try_hardlink_fallback(&kind, &mut file, destination).await {
                 Ok(true) => {}
                 Ok(false) => return Err(UnpackError::UnpackFailed { source: e }),
                 Err(f) => {
@@ -267,7 +273,7 @@ pub async fn unpack<R: AsyncRead + Unpin>(input: R, destination: &Path) -> Unpac
                         )),
                     })
                 }
-            },
+            }
         }
 
         let path = format!(
@@ -403,63 +409,51 @@ async fn set_perms_ownerships(
     Ok(())
 }
 
-// Fallback for hard links whose linkname is absolute. Returns true if it handled the entry.
+/// Try creating a hardlink with an absolute link name/target.
+/// Returns Ok(True) if the hardlink is created.
 async fn try_hardlink_fallback<R: AsyncRead + Unpin>(
     kind: &tokio_tar::EntryType,
     file: &mut tokio_tar::Entry<R>,
-    destination: &Path,
+    layer_dir: &Path,
 ) -> UnpackResult<bool> {
     if !kind.is_hard_link() {
         return Ok(false);
     }
 
-    let linkname = match file
+    // With tar archives, the link name refers to the file that
+    // the hard link is pointing to.
+    // This is the opposite of how the term is used with ln.
+    let link_target = match file
         .link_name()
         .map_err(|source| UnpackError::ReadTarEntriesFailed { source })?
     {
         Some(cow) => cow.into_owned(),
         None => return Ok(false),
     };
-    if !linkname.is_absolute() {
+    if !link_target.is_absolute() {
         return Ok(false);
     }
 
-    let entry_rel = file
+    // Hardlinks may not exit the layer dir.
+    let layer_dir =
+        pathrs::Root::open(layer_dir).map_err(|source| UnpackError::PathRsFailed { source })?;
+
+    let link_path = file
         .path()
         .map_err(|source| UnpackError::ReadTarEntriesFailed { source })?;
 
-    // Resolve the final destination path for this entry and ensure parent exists.
-    let dst_entry_abs = destination.join(&entry_rel);
-    if let Some(parent) = dst_entry_abs.parent() {
-        fs::create_dir_all(parent)
-            .await
-            .map_err(|source| UnpackError::UnpackFailed { source })?;
+    // Create parent directories for the link path (link target must already exist)
+    if let Some(parent) = link_path.parent() {
+        layer_dir
+            .mkdir_all(parent, &Permissions::from_mode(0o755))
+            .map_err(|source| UnpackError::PathRsFailed { source })?;
     }
 
-    // Drop the leading root from linkname
-    let stripped = linkname
-        .strip_prefix(Path::new("/"))
-        .unwrap_or(linkname.as_path());
-    let anchored_src = destination.join(stripped);
+    layer_dir
+        .create(&link_path, &InodeType::Hardlink(link_target.to_path_buf()))
+        .map_err(|source| UnpackError::PathRsFailed { source })?;
 
-    // Resolve symlinks according to the actual FS
-    let dst_canon = fs::canonicalize(destination)
-        .await
-        .map_err(|source| UnpackError::UnpackFailed { source })?;
-    let src_canon = fs::canonicalize(&anchored_src)
-        .await
-        .map_err(|source| UnpackError::UnpackFailed { source })?;
-
-    if !src_canon.starts_with(&dst_canon) {
-        return Err(UnpackError::UnpackFailed {
-            source: std::io::Error::other("hardlink target escapes destination"),
-        });
-    }
-
-    match fs::hard_link(&src_canon, &dst_entry_abs).await {
-        Ok(()) => Ok(true),
-        Err(e) => Err(UnpackError::UnpackFailed { source: e }),
-    }
+    Ok(true)
 }
 
 #[cfg(test)]
@@ -472,6 +466,8 @@ mod tests {
         io::{empty, AsyncWriteExt},
     };
     use tokio_tar::{Builder, EntryType, Header};
+
+    use rstest::rstest;
 
     use super::*;
 
@@ -619,21 +615,33 @@ mod tests {
         assert!(unpack(data.as_slice(), destination).await.is_ok());
     }
 
+    #[rstest]
+    #[case::absolute_link_target("/etc/os-release", true)]
+    #[case::relative_escape_link_target("../../etc/os-release", false)]
     #[tokio::test]
-    async fn test_unpack_rejects_escaping_absolute_hardlink() {
+    async fn test_unpack_hardlink_tar_cases(#[case] link_name: &str, #[case] expect_ok: bool) {
         let td = tempfile::tempdir().unwrap();
-        let outside_file = td.path().join("outside_file");
-        let mut f = File::create(&outside_file).await.unwrap();
-        f.write_all(b"outside-data").await.unwrap();
-        f.flush().await.unwrap();
-
-        // linkname = "/../outside_file" will be anchored in fallback mode as
-        // destination/../outside_file, which points to the parent directory of the destination.
         let mut ar = Builder::new(Vec::new());
+
+        // 1. Create a file, write content, add it to the archive as the link target.
+        let source_file = td.path().join("os-release");
+        let mut f = File::create(&source_file).await.unwrap();
+        f.write_all(b"test-data\n").await.unwrap();
+        f.flush().await.unwrap();
+        ar.append_file(
+            "etc/os-release",
+            &mut File::open(&source_file).await.unwrap(),
+        )
+        .await
+        .unwrap();
+
+        // 2. Append a hardlink entry with case-provided link target.
+        let link_entry_path = "etc/os-release.hardlink";
+
         let mut hdr = Header::new_gnu();
         hdr.set_entry_type(EntryType::Link);
-        hdr.set_link_name("/../outside_file").unwrap();
-        hdr.set_path("subdir/evil_hardlink").unwrap();
+        hdr.set_link_name(link_name).unwrap();
+        hdr.set_path(link_entry_path).unwrap();
         hdr.set_size(0);
         hdr.set_mode(0o644);
         hdr.set_uid(0);
@@ -643,26 +651,27 @@ mod tests {
         ar.append(&hdr, empty()).await.unwrap();
 
         let data = ar.into_inner().await.unwrap();
-
         let destination = td.path().join("dest");
         let res = unpack(data.as_slice(), &destination).await;
 
-        // Expectation: unpacking should fail due to anti-escape check
-        match res {
-            Err(UnpackError::UnpackFailed { source }) => {
-                assert!(
-                    source
-                        .to_string()
-                        .contains("hardlink target escapes destination"),
-                    "unexpected error: {source}"
-                );
-            }
-            Ok(_) => panic!("unpack unexpectedly succeeded; anti-escape check failed"),
-            Err(e) => panic!("unexpected error variant: {e:?}"),
+        // 3. Assert unpack outcome and resulting paths under destination.
+        let hardlink_path = destination.join(link_entry_path);
+        if expect_ok {
+            res.unwrap();
+            let target = destination.join("etc/os-release");
+            let target_meta = fs::metadata(&target).await.unwrap();
+            let hardlink_meta = fs::metadata(&hardlink_path).await.unwrap();
+            assert!(target_meta.is_file() && hardlink_meta.is_file());
+            assert_eq!(target_meta.ino(), hardlink_meta.ino());
+        } else {
+            assert!(
+                res.is_err(),
+                "unpack should fail when hardlink target resolves outside the layer root: {res:?}"
+            );
+            assert!(
+                fs::metadata(&hardlink_path).await.is_err(),
+                "hardlink entry must not be created under destination"
+            );
         }
-
-        // Confirm that the escaping hardlink was not created
-        let evil_path = destination.join("subdir/evil_hardlink");
-        assert!(fs::metadata(&evil_path).await.is_err());
     }
 }


### PR DESCRIPTION
Pathrs is a handy crate that allows you to perform fs operations atomically and constrain them to a particular directory. We should probably use this crate in many places in image-rs, but let's start small.

The hardlink fallback method is a great fit for pathrs. Previously we were anchoring and canonicalizing the paths, but pathrs will do both of those things automatically. Since pathrs behaves like chroot, it handles absolute paths elegantly without needing any additional anchoring logic.

We are constraining hardlinks to the layer dir. This means that hard links cannot be created between layers. The image spec is slightly ambiguous about this (it says that this kind of link "may" fail). This should be fine.