### PR TITLE
attestation-agent: improve build info

### DIFF
--- a/attestation-agent/attestation-agent/build.rs
+++ b/attestation-agent/attestation-agent/build.rs
@@ -14,24 +14,37 @@ fn main() -> std::io::Result<()> {
         use std::path::Path;
 
         // generate an `intro` file that includes the feature information of the build
-        fn feature_list(features: Vec<&str>) -> String {
-            let enabled_features: Vec<&str> = features
+        fn feature_list(always_enabled: Vec<&str>, features: Vec<&str>) -> String {
+            let enabled_features: Vec<&str> = always_enabled
                 .into_iter()
-                .filter(|&feature| env::var(format!("CARGO_FEATURE_{feature}")).is_ok())
+                .chain(
+                    features
+                        .into_iter()
+                        .filter(|&feature| env::var(format!("CARGO_FEATURE_{feature}")).is_ok()),
+                )
+                .map(|f| f.strip_suffix("_ATTESTER").unwrap_or(f))
                 .collect();
 
             enabled_features.join(", ")
         }
 
-        let token_plugins = feature_list(vec!["KBS", "COCO_AS"]);
-        let attester = feature_list(vec![
-            "TDX_ATTESTER",
-            "SGX_ATTESTER",
-            "AZ_SNP_VTPM_ATTESTER",
-            "AZ_TDX_VTPM_ATTESTER",
-            "SNP_ATTESTER",
-            "SE_ATTESTER",
-        ]);
+        let token_plugins = feature_list(vec![], vec!["KBS", "COCO_AS"]);
+        let attester = feature_list(
+            vec!["SAMPLE_ATTESTER", "SAMPLE_DEVICE_ATTESTER"],
+            vec![
+                "TDX_ATTESTER",
+                "SGX_ATTESTER",
+                "AZ_SNP_VTPM_ATTESTER",
+                "AZ_TDX_VTPM_ATTESTER",
+                "SNP_ATTESTER",
+                "SE_ATTESTER",
+                "CCA_ATTESTER",
+                "CSV_ATTESTER",
+                "HYGON_DCU_ATTESTER",
+                "TPM_ATTESTER",
+                "NVIDIA_ATTESTER",
+            ],
+        );
 
         let out_dir = env::var("OUT_DIR").unwrap();
         let dest_path = Path::new(&out_dir).join("version");


### PR DESCRIPTION
The attestation-agent reports supported features when it starts up, but our logic for calculating these features is out of date.

Add the additional attester features and add another list of attesters that are always supported (e.g. the sample attester).