### PR TITLE
deps/kms: replace p12, yasna and ring with openssl

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -32,13 +32,13 @@ dependencies = [
 
 [[package]]
 name = "aes"
-version = "0.9.0-rc.4"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04097e08a47d9ad181c2e1f4a5fabc9ae06ce8839a333ba9a949bcb0d31fd2a3"
+checksum = "66bd29a732b644c0431c6140f370d097879203d79b80c94a6747ba0872adaef8"
 dependencies = [
  "cipher 0.5.1",
  "cpubits",
- "cpufeatures 0.2.17",
+ "cpufeatures 0.3.0",
 ]
 
 [[package]]
@@ -61,7 +61,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10b6f24a1f796bc46415a1d0d18dc0a8203ccba088acf5def3291c4f61225522"
 dependencies = [
- "aes 0.9.0-rc.4",
+ "aes 0.9.0",
  "byteorder",
 ]
 
@@ -2462,7 +2462,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee93edf3c501f0035bbeffeccfed0b79e14c311f12195ec0e661e114a0f60da4"
 dependencies = [
  "portable-atomic",
- "rand 0.10.0",
+ "rand 0.10.1",
  "web-time",
 ]
 
@@ -3705,7 +3705,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 1.0.69",
- "yasna 0.4.0",
+ "yasna",
  "zeroize",
 ]
 
@@ -3897,13 +3897,12 @@ dependencies = [
  "ehsm_client",
  "hex",
  "kbs_protocol",
- "p12",
+ "openssl",
  "prost 0.14.3",
  "protos",
  "rand 0.10.1",
  "reqwest 0.13.2",
  "resource_uri",
- "ring",
  "rstest",
  "serde",
  "serde_json",
@@ -3918,7 +3917,6 @@ dependencies = [
  "tracing",
  "url",
  "uuid",
- "yasna 0.5.2",
  "zeroize",
 ]
 
@@ -4816,23 +4814,6 @@ checksum = "49203cdcae0030493bad186b28da2fa25645fa276a51b6fec8010d281e02ef79"
 dependencies = [
  "dlv-list",
  "hashbrown 0.14.5",
-]
-
-[[package]]
-name = "p12"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4873306de53fe82e7e484df31e1e947d61514b6ea2ed6cd7b45d63006fd9224"
-dependencies = [
- "cbc",
- "cipher 0.4.4",
- "des",
- "getrandom 0.2.17",
- "hmac 0.12.1",
- "lazy_static",
- "rc2",
- "sha1",
- "yasna 0.5.2",
 ]
 
 [[package]]
@@ -5854,15 +5835,6 @@ checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
-]
-
-[[package]]
-name = "rc2"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62c64daa8e9438b84aaae55010a93f396f8e60e3911590fcba770d04643fc1dd"
-dependencies = [
- "cipher 0.4.4",
 ]
 
 [[package]]
@@ -8974,12 +8946,6 @@ checksum = "e262a29d0e61ccf2b6190d7050d4b237535fc76ce4c1210d9caa316f71dffa75"
 dependencies = [
  "num-bigint",
 ]
-
-[[package]]
-name = "yasna"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e17bb3549cc1321ae1296b9cdc2698e2b6cb1992adfa19a8c72e5b7a738f44cd"
 
 [[package]]
 name = "yoke"

--- a/confidential-data-hub/kms/Cargo.toml
+++ b/confidential-data-hub/kms/Cargo.toml
@@ -21,13 +21,12 @@ kbs_protocol = { path = "../../attestation-agent/kbs_protocol", default-features
     "aa_ttrpc",
     "openssl",
 ], optional = true }
-p12 = { version = "0.6.3", optional = true }
+openssl = { workspace = true, optional = true }
 prost = { workspace = true, optional = true }
 protos = { path = "../../protos", default-features = false, optional = true }
 rand = { workspace = true, optional = true }
 reqwest = { workspace = true, optional = true }
 resource_uri = { path = "../../attestation-agent/deps/resource_uri" }
-ring = "0.17"
 sha2 = { workspace = true, optional = true }
 serde.workspace = true
 serde_json.workspace = true
@@ -40,7 +39,6 @@ tonic = { workspace = true, optional = true }
 tracing.workspace = true
 url = { workspace = true, optional = true }
 uuid = { workspace = true, features = ["serde", "v4"], optional = true }
-yasna = { version = "0.5.2", optional = true }
 zeroize = { workspace = true, optional = true }
 
 [dev-dependencies]
@@ -56,14 +54,13 @@ default = ["aliyun", "kbs"]
 
 aliyun = [
     "chrono",
+    "dep:openssl",
     "hex",
-    "p12",
     "rand",
     "reqwest/rustls",
     "sha2",
     "tonic",
     "url",
-    "yasna",
     "protos/grpc",
     "prost",
 ]

--- a/confidential-data-hub/kms/src/plugins/aliyun/client/client_key_client/credential.rs
+++ b/confidential-data-hub/kms/src/plugins/aliyun/client/client_key_client/credential.rs
@@ -7,11 +7,12 @@
 
 use anyhow::*;
 use base64::{engine::general_purpose::STANDARD, Engine};
-use p12::{CertBag, ContentInfo, MacData, SafeBagKind, PFX};
-use ring::{rand::SystemRandom, rsa::KeyPair, signature::RSA_PKCS1_SHA256};
+use openssl::hash::MessageDigest;
+use openssl::pkcs12::Pkcs12;
+use openssl::pkey::PKey;
+use openssl::provider::Provider;
+use openssl::sign::Signer;
 use serde::Deserialize;
-use tracing::debug;
-use yasna::ASN1Result;
 
 #[derive(Clone, Debug)]
 pub(crate) struct CredentialClientKey {
@@ -42,72 +43,30 @@ impl CredentialClientKey {
     }
 
     pub(crate) fn sign(&self, str_to_sign: &str) -> Result<String> {
-        let mut signature = Vec::new();
-        let private_key = KeyPair::from_pkcs8(&self.private_key)
+        let pkey = PKey::private_key_from_pkcs8(&self.private_key)
             .map_err(|_| anyhow!("read RSA private key failed"))?;
-        signature.resize(private_key.public().modulus_len(), 0);
-        private_key
-            .sign(
-                &RSA_PKCS1_SHA256,
-                &SystemRandom::new(),
-                str_to_sign.as_bytes(),
-                &mut signature,
-            )
+        let mut signer =
+            Signer::new(MessageDigest::sha256(), &pkey).map_err(|_| anyhow!("create signer"))?;
+        let signature = signer
+            .sign_oneshot_to_vec(str_to_sign.as_bytes())
             .map_err(|_| anyhow!("signing failed"))?;
 
         Ok(STANDARD.encode(signature))
     }
 
     pub(crate) fn parse_private_key(private_key_data: String, password: String) -> Result<Vec<u8>> {
-        let private_key_der = STANDARD.decode(private_key_data.as_bytes())?;
-        let pfx = yasna::parse_der(&private_key_der, |r| -> ASN1Result<PFX> {
-            r.read_sequence(|r| {
-                let version = r.next().read_u8()?;
-                let auth_safe = ContentInfo::parse(r.next())?;
-                let mac_data = r.read_optional(MacData::parse).ok().flatten();
-                std::result::Result::Ok(PFX {
-                    version,
-                    auth_safe,
-                    mac_data,
-                })
-            })
-        })?;
+        let pkcs12_der = STANDARD.decode(private_key_data.as_bytes())?;
+        let pkcs12 = Pkcs12::from_der(&pkcs12_der).context("parse PKCS#12 DER failed")?;
+        let _legacy_provider = Provider::try_load(None, "legacy", true).ok();
+        let parsed = pkcs12
+            .parse2(&password)
+            .context("decrypt PKCS#12 with password failed")?;
+        let pkey = parsed
+            .pkey
+            .ok_or_else(|| anyhow!("missing private key in PKCS#12"))?;
 
-        let bags = pfx.bags(&password)?;
-        for bag in &bags {
-            match &bag.bag {
-                SafeBagKind::Pkcs8ShroudedKeyBag(k) => {
-                    let pass = Self::bmp_string(&password);
-                    let private_key = k
-                        .encryption_algorithm
-                        .decrypt_pbe(&k.encrypted_data, &pass)
-                        .ok_or(anyhow!("decrypt pbe failed"))?;
-                    return Ok(private_key);
-                }
-                SafeBagKind::CertBag(e) => match e {
-                    CertBag::X509(x) => {
-                        debug!("parse aliyun pkcs12 credential X509: {}", hex::encode(x))
-                    }
-                    CertBag::SDSI(s) => debug!("parse aliyun pkcs12 credential SDSI: {s:?}"),
-                },
-                _ => continue,
-            }
-        }
-
-        Err(anyhow!("no private key found!"))
-    }
-
-    fn bmp_string(s: &str) -> Vec<u8> {
-        let utf16: Vec<u16> = s.encode_utf16().collect();
-
-        let mut bytes = Vec::with_capacity(utf16.len() * 2 + 2);
-        for c in utf16 {
-            bytes.push((c / 256) as u8);
-            bytes.push((c % 256) as u8);
-        }
-        bytes.push(0x00);
-        bytes.push(0x00);
-        bytes
+        pkey.private_key_to_pkcs8()
+            .context("export PKCS#8 private key failed")
     }
 }
 

--- a/confidential-data-hub/kms/src/plugins/aliyun/client/sts_token_client/credential.rs
+++ b/confidential-data-hub/kms/src/plugins/aliyun/client/sts_token_client/credential.rs
@@ -7,7 +7,9 @@
 
 use anyhow::*;
 use base64::{engine::general_purpose::STANDARD, Engine};
-use ring::hmac::{self, Key, HMAC_SHA1_FOR_LEGACY_USE_ONLY};
+use openssl::hash::MessageDigest;
+use openssl::pkey::PKey;
+use openssl::sign::Signer;
 use serde::Deserialize;
 use url::form_urlencoded::byte_serialize;
 
@@ -24,8 +26,12 @@ pub struct StsCredential {
 }
 
 pub(crate) fn sign(str_to_sign: &str, secret: &str) -> Result<String> {
-    let pkey = Key::new(HMAC_SHA1_FOR_LEGACY_USE_ONLY, secret.as_bytes());
-    let signature = hmac::sign(&pkey, str_to_sign.as_bytes());
+    let pkey = PKey::hmac(secret.as_bytes()).map_err(|e| anyhow!("HMAC key: {e}"))?;
+    let mut signer =
+        Signer::new(MessageDigest::sha1(), &pkey).map_err(|e| anyhow!("HMAC signer: {e}"))?;
+    let signature = signer
+        .sign_oneshot_to_vec(str_to_sign.as_bytes())
+        .map_err(|e| anyhow!("HMAC sign: {e}"))?;
     Ok(STANDARD.encode(signature))
 }
 


### PR DESCRIPTION
In history, we use ring dependency for static building, but now openssl supports static building. Thus we replace ring, yasna and p12 crate with openssl.

Another benefit is that p12 is a very old crate that lacks maintaince. Switching to openssl would provide security and fixes.

close #1446 