### PR TITLE
cdh: fix ext4 formatting for integrity-protected LUKS2 devices

### DIFF
--- a/confidential-data-hub/docs/SECURE_STORAGE.md
+++ b/confidential-data-hub/docs/SECURE_STORAGE.md
@@ -83,7 +83,10 @@ In both modes, the cleartext device or filesystem is only exposed inside the TEE
 - **LUKS2 mode**:
   - Uses `targetType` to decide whether to expose a cleartext **device** (`"device"`) or a cleartext **filesystem** (`"fileSystem"`).
   - Can optionally enable dm-integrity via `dataIntegrity`.
-  - Uses a `/dev/mapper/<name>` device created by `libcryptsetup` as the cleartext device.
+  - Uses a `/dev/mapper/<name>` device created by `cryptsetup` as the cleartext device.
+  - When formatting an empty ext4 filesystem with dm-integrity enabled, CDH
+    defaults `lazy_itable_init` to `0` unless the caller explicitly provides a
+    `lazy_itable_init` setting in `mkfsOpts`.
 - **ZFS mode**:
   - Always provides a filesystem mount at the given `mount_point`; `targetType` is currently ignored but should be set to `"fileSystem"` for clarity.
   - Adds ZFS-specific options: `pool` (zpool name, defaults to `zpool`) and `dataset` (dataset name, defaults to `zdataset`).
@@ -100,7 +103,7 @@ flowchart LR
     A[Local/Network] -- mount --> B[Block Device]
     subgraph TEE Guest
         B -- Check if encrypted --> F{Is Encrypted?}
-        F -- No --> G[Encrypt by libcryptsetup]
+        F -- No --> G[Encrypt by cryptsetup]
         G -- encrypt --> C[LUKS Encrypted Block Device]
         F -- Yes --> C[LUKS Encrypted Block Device]
         C -- open and mapping --> D[Mapped Device]

--- a/confidential-data-hub/docs/use-cases/secure-mount-with-block-device.md
+++ b/confidential-data-hub/docs/use-cases/secure-mount-with-block-device.md
@@ -50,6 +50,12 @@ In addition to the common fields above, LUKS2 mode understands the following opt
 | `options.dataIntegrity`    | Boolean (`true` / `false`)                   | No (default `false`) | Enable (`true`) to turn on dm-integrity for stronger integrity guarantees; expect >30% IO performance overhead. Keep `false` for performance‑sensitive ephemeral storage. |
 | `options.mapperName`       | String (e.g. `"my-mapped-device"`)           | No       | Set when you need a stable `/dev/mapper/<name>` for monitoring or debugging. When omitted, CDH generates a UUID-based name. |
 
+When `encryptionType` is `"luks2"`, `targetType` is `"fileSystem"`,
+`filesystemType` is `"ext4"`, and `dataIntegrity` is `true`, CDH formats ext4
+with `lazy_itable_init=0` unless the caller explicitly provides a
+`lazy_itable_init` setting in `mkfsOpts`. This avoids later I/O errors from
+lazy inode table initialization on no-wipe dm-integrity devices.
+
 ### ZFS-specific options
 
 In addition to the common fields above, ZFS mode understands the following options:
@@ -359,4 +365,3 @@ secret
 > - For ZFS, CDH always creates a filesystem-style mount.
 > - `pool` and `dataset` must match what was used when the device was first formatted (`sourceType: "empty"`); otherwise import or mount may fail.
 > - After unmount, the device can be moved to another machine; use the same `pool`, `dataset`, and key to re-mount there.
-

--- a/confidential-data-hub/hub/src/storage/drivers/filesystem.rs
+++ b/confidential-data-hub/hub/src/storage/drivers/filesystem.rs
@@ -114,13 +114,20 @@ impl FsFormatter {
             )?;
         }
 
-        // then do original format command
-        self.format(device_path)?;
+        // then do original format command with integrity-compatible defaults
+        let format_args = match self.fs_type {
+            FsType::Ext4 => disable_lazy_itable_init(&self.args),
+        };
+        self.format_with_args(device_path, &format_args)?;
 
         Ok(())
     }
 
     pub fn format(&self, device_path: &str) -> Result<()> {
+        self.format_with_args(device_path, &self.args)
+    }
+
+    fn format_with_args(&self, device_path: &str, format_args: &[String]) -> Result<()> {
         let command = match self.fs_type {
             FsType::Ext4 => {
                 if !is_ext4_installed() {
@@ -134,7 +141,7 @@ impl FsFormatter {
         if self.force {
             args.push("-F");
         }
-        for arg in &self.args {
+        for arg in format_args {
             args.push(arg);
         }
 
@@ -142,6 +149,37 @@ impl FsFormatter {
 
         Ok(())
     }
+}
+
+// Keep explicit caller choices, but default ext4 to eager inode table initialization.
+fn disable_lazy_itable_init(args: &[String]) -> Vec<String> {
+    let mut args = args.to_vec();
+    if args.iter().any(|arg| arg.contains("lazy_itable_init")) {
+        return args;
+    }
+
+    warn!(
+        "defaulting ext4 lazy_itable_init=0 for LUKS2 dm-integrity; set it explicitly in mkfsOpts to override"
+    );
+
+    if let Some(index) = args.iter().rposition(|arg| arg == "-E") {
+        if let Some(options) = args.get_mut(index + 1) {
+            options.push_str(",lazy_itable_init=0");
+            return args;
+        }
+    }
+
+    if let Some(options) = args
+        .iter_mut()
+        .rfind(|arg| arg.starts_with("-E") && arg.len() > 2)
+    {
+        options.push_str(",lazy_itable_init=0");
+        return args;
+    }
+
+    args.push("-E".to_string());
+    args.push("lazy_itable_init=0".to_string());
+    args
 }
 
 fn is_ext4_installed() -> bool {
@@ -158,4 +196,47 @@ fn is_dd_installed() -> bool {
         warn!("dd is not installed. Consider installing `coreutils` (ubuntu).");
     }
     installed
+}
+
+#[cfg(test)]
+mod tests {
+    use super::disable_lazy_itable_init;
+
+    #[test]
+    fn ext4_args_add_lazy_itable_init_when_missing() {
+        let args = vec!["-m".to_string(), "0".to_string()];
+        assert_eq!(
+            disable_lazy_itable_init(&args),
+            vec![
+                "-m".to_string(),
+                "0".to_string(),
+                "-E".to_string(),
+                "lazy_itable_init=0".to_string()
+            ]
+        );
+    }
+
+    #[test]
+    fn ext4_args_merge_lazy_itable_init_into_separate_extended_options() {
+        let args = vec!["-E".to_string(), "nodiscard".to_string()];
+        assert_eq!(
+            disable_lazy_itable_init(&args),
+            vec!["-E".to_string(), "nodiscard,lazy_itable_init=0".to_string()]
+        );
+    }
+
+    #[test]
+    fn ext4_args_merge_lazy_itable_init_into_combined_extended_options() {
+        let args = vec!["-Enodiscard".to_string()];
+        assert_eq!(
+            disable_lazy_itable_init(&args),
+            vec!["-Enodiscard,lazy_itable_init=0".to_string()]
+        );
+    }
+
+    #[test]
+    fn ext4_args_keep_caller_lazy_itable_init() {
+        let args = vec!["-E".to_string(), "lazy_itable_init=1".to_string()];
+        assert_eq!(disable_lazy_itable_init(&args), args);
+    }
 }

--- a/confidential-data-hub/hub/src/storage/drivers/luks2.rs
+++ b/confidential-data-hub/hub/src/storage/drivers/luks2.rs
@@ -79,6 +79,12 @@ pub enum TargetType {
         filesystem_type: FsType,
 
         /// Extra options passed verbatim to mkfs.<fs> when it is needed.
+        ///
+        /// For LUKS2 + dm-integrity + ext4 on an empty device, CDH adds
+        /// integrity-compatible ext4 defaults when the caller has not provided
+        /// an explicit setting. In particular, CDH defaults lazy_itable_init to
+        /// 0 to avoid lazy inode table writes against no-wipe dm-integrity
+        /// devices.
         #[serde(default, skip_serializing_if = "Option::is_none")]
         #[serde(rename = "mkfsOpts")]
         mkfs_opts: Option<String>,
@@ -180,6 +186,11 @@ fn run_cryptsetup(args: &[&str]) -> anyhow::Result<()> {
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
 pub struct Luks2MountParameters {
     /// Indicates whether to enable dm-integrity.
+    ///
+    /// When this is true and CDH formats an empty ext4 filesystem, CDH uses
+    /// integrity-compatible formatting and applies ext4 safety defaults such as
+    /// lazy_itable_init=0 unless the caller explicitly provides that option in
+    /// mkfsOpts.
     #[serde(rename = "dataIntegrity")]
     #[serde(default)]
     pub data_integrity: Option<String>,
@@ -307,14 +318,17 @@ impl Luks2MountParameters {
                     args,
                 };
 
-                fs_formatter
-                    .format_integrity_compatible(&dev_path)
-                    .with_context(|| {
-                        format!(
-                            "Failed to make filesystem {:?} of device {}",
-                            filesystem_type, dev_path
-                        )
-                    })?;
+                let format_result = if data_integrity {
+                    fs_formatter.format_integrity_compatible(&dev_path)
+                } else {
+                    fs_formatter.format(&dev_path)
+                };
+                format_result.with_context(|| {
+                    format!(
+                        "Failed to make filesystem {:?} of device {}",
+                        filesystem_type, dev_path
+                    )
+                })?;
 
                 debug!(device_path = dev_path, "mounting device");
                 mount(

--- a/confidential-data-hub/hub/src/storage/volume_type/blockdevice/mod.rs
+++ b/confidential-data-hub/hub/src/storage/volume_type/blockdevice/mod.rs
@@ -283,15 +283,53 @@ async fn get_device_path(major: u32, minor: u32) -> Result<String> {
 #[cfg(test)]
 mod tests {
     use serial_test::serial;
+    use std::path::Path;
     use tempfile::TempDir;
     use tracing::warn;
 
+    use crate::storage::drivers::luks2::{luks_header_path, Luks2Formatter};
     use crate::storage::{
         drivers::{zfs::is_zfs_installed, TempFileLoopDevice},
         tests::init_tracing,
     };
 
     use super::*;
+
+    const EXT4_INTEGRITY_MKFS_OPTS: &str = "-O ^has_journal -m 0 -i 163840 -I 128";
+
+    fn close_luks_device(name: &str) {
+        let path = format!("/dev/mapper/{name}");
+        if Path::new(&path).exists() {
+            let _ = Luks2Formatter::default().close_device(name);
+        }
+    }
+
+    async fn close_luks_device_after_unmount(name: &str) {
+        tokio::time::sleep(std::time::Duration::from_millis(250)).await;
+        close_luks_device(name);
+    }
+
+    struct CloseDeviceOnDrop(String);
+
+    impl Drop for CloseDeviceOnDrop {
+        fn drop(&mut self) {
+            close_luks_device(&self.0);
+        }
+    }
+
+    struct RemoveFileOnDrop(String);
+
+    impl Drop for RemoveFileOnDrop {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_file(&self.0);
+        }
+    }
+
+    fn remove_luks_header_on_drop(device_path: &str) -> RemoveFileOnDrop {
+        let header_path = luks_header_path(device_path);
+        let _ = std::fs::remove_file(&header_path);
+        RemoveFileOnDrop(header_path)
+    }
 
     #[test]
     fn test_parse_device_id() {
@@ -401,6 +439,49 @@ mod tests {
             .unwrap();
 
         bd.umount().await.unwrap();
+    }
+
+    #[tokio::test]
+    #[cfg_attr(target_arch = "s390x", ignore)]
+    #[serial]
+    async fn encrypt_a_loop_device_with_integrity_and_mkfs_opts_using_luks2() {
+        let temp_device = TempFileLoopDevice::new(512 * 1024 * 1024).unwrap();
+        let device_path = temp_device.dev_path().to_string();
+        let _header_guard = remove_luks_header_on_drop(&device_path);
+        let mapper_name = format!("luks2-loop-integrity-test-{}", std::process::id());
+        let _mapper_guard = CloseDeviceOnDrop(mapper_name.clone());
+        let mut bd = BlockDevice::default();
+
+        let options = HashMap::from([
+            ("sourceType".to_string(), "empty".to_string()),
+            ("targetType".to_string(), "fileSystem".to_string()),
+            ("devicePath".to_string(), device_path),
+            ("encryptionType".to_string(), "luks2".to_string()),
+            (
+                "key".to_string(),
+                "file://./test_files/luks2-disk-passphrase".to_string(),
+            ),
+            ("mapperName".to_string(), mapper_name.clone()),
+            ("dataIntegrity".to_string(), "true".to_string()),
+            ("filesystemType".to_string(), "ext4".to_string()),
+            ("mkfsOpts".to_string(), EXT4_INTEGRITY_MKFS_OPTS.to_string()),
+        ]);
+
+        let tempdir = TempDir::new().unwrap();
+        let result = bd
+            .real_mount(&options, &[], tempdir.path().to_str().unwrap())
+            .await;
+        if result.is_err() {
+            close_luks_device(&mapper_name);
+        }
+        result.unwrap();
+
+        tokio::fs::write(tempdir.path().join("test-file"), b"some data")
+            .await
+            .unwrap();
+
+        bd.umount().await.unwrap();
+        close_luks_device_after_unmount(&mapper_name).await;
     }
 
     #[tokio::test]

--- a/confidential-data-hub/hub/src/storage/volume_type/blockdevice/mod.rs
+++ b/confidential-data-hub/hub/src/storage/volume_type/blockdevice/mod.rs
@@ -297,6 +297,24 @@ mod tests {
 
     const EXT4_INTEGRITY_MKFS_OPTS: &str = "-O ^has_journal -m 0 -i 163840 -I 128";
 
+    struct Ext4StressConfig {
+        workers: usize,
+        data_files_per_worker: usize,
+        tree_dirs_per_worker: usize,
+    }
+
+    const SINGLE_WORKER_EXT4_STRESS: Ext4StressConfig = Ext4StressConfig {
+        workers: 1,
+        data_files_per_worker: 128,
+        tree_dirs_per_worker: 256,
+    };
+
+    const PARALLEL_EXT4_STRESS: Ext4StressConfig = Ext4StressConfig {
+        workers: 16,
+        data_files_per_worker: 128,
+        tree_dirs_per_worker: 256,
+    };
+
     fn close_luks_device(name: &str) {
         let path = format!("/dev/mapper/{name}");
         if Path::new(&path).exists() {
@@ -329,6 +347,72 @@ mod tests {
         let header_path = luks_header_path(device_path);
         let _ = std::fs::remove_file(&header_path);
         RemoveFileOnDrop(header_path)
+    }
+
+    async fn run_ext4_stress(root: &Path, config: Ext4StressConfig) -> anyhow::Result<()> {
+        let data = vec![0u8; 1024 * 1024];
+        let mut tasks = Vec::with_capacity(config.workers);
+        for worker in 0..config.workers {
+            let worker_dir = root.join(format!("w{worker}"));
+            let data = data.clone();
+            let data_files_per_worker = config.data_files_per_worker;
+            tasks.push(tokio::spawn(async move {
+                tokio::fs::create_dir_all(&worker_dir).await?;
+                for file in 0..data_files_per_worker {
+                    tokio::fs::write(worker_dir.join(format!("f{file}")), &data).await?;
+                }
+                std::io::Result::Ok(())
+            }));
+        }
+
+        let mut stress_error = None;
+        for task in tasks {
+            match task.await {
+                Ok(Ok(())) => {}
+                Ok(Err(err)) => {
+                    stress_error.get_or_insert_with(|| anyhow::Error::new(err));
+                }
+                Err(err) => {
+                    stress_error.get_or_insert_with(|| anyhow::Error::new(err));
+                }
+            }
+        }
+        if let Some(err) = stress_error {
+            return Err(err);
+        }
+
+        let mut tasks = Vec::with_capacity(config.workers);
+        for worker in 0..config.workers {
+            let worker_tree = root.join("trees").join(format!("w{worker}"));
+            let tree_dirs_per_worker = config.tree_dirs_per_worker;
+            tasks.push(tokio::spawn(async move {
+                tokio::fs::create_dir_all(&worker_tree).await?;
+                for dir in 0..tree_dirs_per_worker {
+                    let dir_path = worker_tree.join(format!("d{dir}"));
+                    tokio::fs::create_dir_all(&dir_path).await?;
+                    tokio::fs::write(dir_path.join("file"), format!("w{worker}-{dir}")).await?;
+                }
+                std::io::Result::Ok(())
+            }));
+        }
+
+        let mut stress_error = None;
+        for task in tasks {
+            match task.await {
+                Ok(Ok(())) => {}
+                Ok(Err(err)) => {
+                    stress_error.get_or_insert_with(|| anyhow::Error::new(err));
+                }
+                Err(err) => {
+                    stress_error.get_or_insert_with(|| anyhow::Error::new(err));
+                }
+            }
+        }
+        if let Some(err) = stress_error {
+            return Err(err);
+        }
+
+        Ok(())
     }
 
     #[test]
@@ -482,6 +566,95 @@ mod tests {
 
         bd.umount().await.unwrap();
         close_luks_device_after_unmount(&mapper_name).await;
+    }
+
+    #[tokio::test]
+    #[cfg_attr(target_arch = "s390x", ignore)]
+    #[serial]
+    async fn encrypt_a_loop_device_with_integrity_and_parallel_ext4_stress_using_luks2() {
+        let temp_device = TempFileLoopDevice::new(56 * 1024 * 1024 * 1024).unwrap();
+        let device_path = temp_device.dev_path().to_string();
+        let _header_guard = remove_luks_header_on_drop(&device_path);
+        let mapper_name = format!("luks2-loop-stress-test-{}", std::process::id());
+        let _mapper_guard = CloseDeviceOnDrop(mapper_name.clone());
+        let mut bd = BlockDevice::default();
+
+        let options = HashMap::from([
+            ("sourceType".to_string(), "empty".to_string()),
+            ("targetType".to_string(), "fileSystem".to_string()),
+            ("devicePath".to_string(), device_path),
+            ("encryptionType".to_string(), "luks2".to_string()),
+            (
+                "key".to_string(),
+                "file://./test_files/luks2-disk-passphrase".to_string(),
+            ),
+            ("mapperName".to_string(), mapper_name.clone()),
+            ("dataIntegrity".to_string(), "true".to_string()),
+            ("filesystemType".to_string(), "ext4".to_string()),
+            ("mkfsOpts".to_string(), EXT4_INTEGRITY_MKFS_OPTS.to_string()),
+        ]);
+
+        let tempdir = TempDir::new().unwrap();
+        let result = bd
+            .real_mount(&options, &[], tempdir.path().to_str().unwrap())
+            .await;
+        if result.is_err() {
+            close_luks_device(&mapper_name);
+        }
+        result.unwrap();
+
+        let stress_result = run_ext4_stress(tempdir.path(), PARALLEL_EXT4_STRESS).await;
+        let umount_result = bd.umount().await;
+        close_luks_device_after_unmount(&mapper_name).await;
+
+        umount_result.unwrap();
+        stress_result.unwrap();
+    }
+
+    #[tokio::test]
+    #[cfg_attr(target_arch = "s390x", ignore)]
+    #[serial]
+    async fn encrypt_a_loop_device_with_integrity_and_single_worker_ext4_stress_using_luks2() {
+        let temp_device = TempFileLoopDevice::new(56 * 1024 * 1024 * 1024).unwrap();
+        let device_path = temp_device.dev_path().to_string();
+        let _header_guard = remove_luks_header_on_drop(&device_path);
+        let mapper_name = format!(
+            "luks2-loop-single-worker-stress-test-{}",
+            std::process::id()
+        );
+        let _mapper_guard = CloseDeviceOnDrop(mapper_name.clone());
+        let mut bd = BlockDevice::default();
+
+        let options = HashMap::from([
+            ("sourceType".to_string(), "empty".to_string()),
+            ("targetType".to_string(), "fileSystem".to_string()),
+            ("devicePath".to_string(), device_path),
+            ("encryptionType".to_string(), "luks2".to_string()),
+            (
+                "key".to_string(),
+                "file://./test_files/luks2-disk-passphrase".to_string(),
+            ),
+            ("mapperName".to_string(), mapper_name.clone()),
+            ("dataIntegrity".to_string(), "true".to_string()),
+            ("filesystemType".to_string(), "ext4".to_string()),
+            ("mkfsOpts".to_string(), EXT4_INTEGRITY_MKFS_OPTS.to_string()),
+        ]);
+
+        let tempdir = TempDir::new().unwrap();
+        let result = bd
+            .real_mount(&options, &[], tempdir.path().to_str().unwrap())
+            .await;
+        if result.is_err() {
+            close_luks_device(&mapper_name);
+        }
+        result.unwrap();
+
+        let stress_result = run_ext4_stress(tempdir.path(), SINGLE_WORKER_EXT4_STRESS).await;
+        let umount_result = bd.umount().await;
+        close_luks_device_after_unmount(&mapper_name).await;
+
+        umount_result.unwrap();
+        stress_result.unwrap();
     }
 
     #[tokio::test]


### PR DESCRIPTION
CDH formats LUKS2 devices with dm-integrity enabled and no full integrity wipe. In that mode, blocks only receive valid integrity tags after they have been written.

The existing tests covered the LUKS2 integrity formatting path through a temporary-file backed device, but not through the loop/block-device path that is closer to CDH secure_mount usage. This PR adds loop-device coverage and ext4 stress tests. The parallel stress test reproduces I/O errors from ext4 inode table metadata activity on a freshly formatted integrity-protected device.

The fix defaults ext4 formatting to `lazy_itable_init=0`, so inode table blocks are initialized during `mkfs.ext4`. Explicit caller-provided `lazy_itable_init` settings are preserved.

This follows the investigation from kata-containers/kata-containers#12721 and aligns with the temporary Kata-side validation in kata-containers/kata-containers#12953.

Solves: #1433