### PR TITLE
CDH/luks2: add `--integrity-no-journal` flag when integrity is enabled

### DIFF
--- a/confidential-data-hub/hub/src/storage/drivers/luks2.rs
+++ b/confidential-data-hub/hub/src/storage/drivers/luks2.rs
@@ -125,6 +125,7 @@ impl Luks2Formatter {
             args.push("--integrity");
             args.push(HMAC_SHA256);
             args.push("--integrity-no-wipe");
+            args.push("--integrity-no-journal");
         }
 
         args.push(device_path);


### PR DESCRIPTION
Before #1380 we use CryptActivate::NO_JOURNAL to promote the performance when integrity protection is enabled. But #1380 ignored this flag. This patch brings back the flag to cryptsetup cmdline.

Let's get everything equal back.

cc @manuelh-dev 