### PR TITLE
tests: fix kbs config

### DIFF
--- a/attestation-agent/kbs_protocol/test/kbs-config.toml
+++ b/attestation-agent/kbs_protocol/test/kbs-config.toml
@@ -21,7 +21,7 @@ type = "InsecureAllowAll"
 
 [[plugins]]
 name = "resource"
-type = "kvstorage"
+storage_backend_type = "kvstorage"
 
 [storage_backend]
 storage_type = "local_fs"


### PR DESCRIPTION
We udpated the KBS config again, so we gotta tweak the config in the kbs protocol test. Fortunately the new debugging output there makes this pretty easy to diagnose.