### PR TITLE
kbs_protocol: support composite attestation for IBM SE

### DIFF
--- a/attestation-agent/kbs_protocol/src/client/rcar_client.rs
+++ b/attestation-agent/kbs_protocol/src/client/rcar_client.rs
@@ -180,10 +180,6 @@ impl KbsClient<Box<dyn EvidenceProvider>> {
             // - injects runtime_data_digest into the request
             // The injected data will be used in SE attester's get_evidence method.
             Tee::Se => {
-                if !additional_evidence.is_empty() {
-                    bail!("Cannot attest multiple devices on s390x platform.")
-                }
-
                 #[cfg(feature = "se-attester")]
                 {
                     use attester::se::SeAttestationRequest;


### PR DESCRIPTION
Now in the kbs protocol level, the report_data/runtime_data digest could be set, thus the binding between device evidences and CPU evidence can be acieved for IBM SE.

Based on #1469 