### PR TITLE
image-rs: add conformance test for image pulling

### DIFF
--- a/image-rs/scripts/add_conformance_image.sh
+++ b/image-rs/scripts/add_conformance_image.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+# Copyright (c) 2026 NVIDIA Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CONFORMANCE_DIR="${SCRIPT_DIR}/../test_data/conformance-images"
+
+usage() {
+    cat <<EOF
+Usage: $(basename "$0") <image-ref> <local-name>
+
+Download a container image and save it as an OCI tar archive for conformance testing.
+
+Arguments:
+    image-ref   Full image reference (e.g., docker.io/library/busybox:latest)
+    local-name  Name for the local tar file (without .tar extension)
+
+The image will be saved to: test_data/conformance-images/<local-name>.tar
+EOF
+    exit 1
+}
+
+if [[ $# -ne 2 ]]; then
+    usage
+fi
+
+IMAGE_REF="$1"
+LOCAL_NAME="$2"
+OUTPUT_FILE="${CONFORMANCE_DIR}/${LOCAL_NAME}.tar"
+
+if ! command -v skopeo &> /dev/null; then
+    echo "Error: skopeo is not installed" >&2
+    exit 1
+fi
+
+if [[ -f "$OUTPUT_FILE" ]]; then
+    echo "Warning: ${OUTPUT_FILE} already exists, overwriting..."
+fi
+
+echo "Downloading ${IMAGE_REF} to ${OUTPUT_FILE}..."
+skopeo copy "docker://${IMAGE_REF}" "oci-archive:${OUTPUT_FILE}"
+
+echo "Done. Image saved to: ${OUTPUT_FILE}"
+echo "Size: $(du -h "${OUTPUT_FILE}" | cut -f1)"

--- a/image-rs/tests/conformance/mod.rs
+++ b/image-rs/tests/conformance/mod.rs
@@ -1,0 +1,93 @@
+// Copyright (c) 2026 NVIDIA Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::{bail, Context, Result};
+use image_rs::config::ImageConfig;
+use image_rs::registry::{Config as RegistryConfig, Registry};
+use std::path::{Path, PathBuf};
+use testcontainers::{
+    core::{IntoContainerPort, WaitFor},
+    runners::AsyncRunner,
+    ContainerAsync, GenericImage, ImageExt,
+};
+use tokio::process::Command;
+
+pub fn conformance_images_dir() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("test_data/conformance-images")
+}
+
+pub fn image_config_for_registry(work_dir: PathBuf, registry_url: &str) -> ImageConfig {
+    ImageConfig {
+        work_dir,
+        registry_config: Some(RegistryConfig {
+            unqualified_search_registries: vec![],
+            registry: vec![Registry {
+                location: registry_url.to_string(),
+                insecure: true,
+                prefix: String::new(),
+                blocked: false,
+                mirror: vec![],
+            }],
+        }),
+        ..Default::default()
+    }
+}
+
+pub struct LocalRegistry {
+    _container: ContainerAsync<GenericImage>,
+    port: u16,
+}
+
+impl LocalRegistry {
+    pub async fn start(port: u16) -> Result<Self> {
+        let container = GenericImage::new("registry", "2")
+            .with_wait_for(WaitFor::message_on_stderr("listening on [::]:5000"))
+            .with_mapped_port(port, 5000.tcp())
+            .start()
+            .await
+            .context("Failed to start registry container")?;
+
+        Ok(Self {
+            _container: container,
+            port,
+        })
+    }
+
+    pub fn url(&self) -> String {
+        format!("127.0.0.1:{}", self.port)
+    }
+
+    pub fn image_ref(&self, name: &str) -> String {
+        format!("{}/{}:latest", self.url(), name)
+    }
+
+    pub async fn load_image(&self, tar_path: &Path) -> Result<String> {
+        let name = tar_path
+            .file_stem()
+            .and_then(|s| s.to_str())
+            .ok_or_else(|| anyhow::anyhow!("Invalid tar filename"))?;
+
+        let dest_ref = self.image_ref(name);
+
+        let output = Command::new("skopeo")
+            .args([
+                "copy",
+                &format!("oci-archive:{}", tar_path.display()),
+                &format!("docker://{}", dest_ref),
+                "--dest-tls-verify=false",
+            ])
+            .output()
+            .await
+            .context("Failed to execute skopeo")?;
+
+        if !output.status.success() {
+            bail!(
+                "skopeo copy failed: {}",
+                String::from_utf8_lossy(&output.stderr)
+            );
+        }
+
+        Ok(dest_ref)
+    }
+}

--- a/image-rs/tests/unpack_conformance.rs
+++ b/image-rs/tests/unpack_conformance.rs
@@ -1,0 +1,198 @@
+// Copyright (c) 2026 NVIDIA Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+
+mod conformance;
+
+use conformance::{conformance_images_dir, image_config_for_registry, LocalRegistry};
+use std::path::PathBuf;
+use tempfile::TempDir;
+
+const REGISTRY_PORT: u16 = 5000;
+
+fn keep_artifacts() -> bool {
+    std::env::var("IMAGE_RS_KEEP_TEST_ARTIFACTS").is_ok()
+}
+
+struct PulledImage {
+    _work_dir: TempDir,
+    bundle_dir: TempDir,
+}
+
+impl PulledImage {
+    fn rootfs(&self) -> PathBuf {
+        self.bundle_dir.path().join("rootfs")
+    }
+
+    fn cleanup(self) {
+        if !keep_artifacts() {
+            let _ = nix::mount::umount(&self.rootfs());
+        }
+    }
+}
+
+async fn pull_image_rs(image_ref: &str, registry_url: &str) -> PulledImage {
+    let work_dir = tempfile::tempdir().unwrap();
+    let bundle_dir = tempfile::tempdir().unwrap();
+
+    let config = image_config_for_registry(work_dir.path().to_path_buf(), registry_url);
+    let mut client = image_rs::builder::ClientBuilder::from(config)
+        .build()
+        .await
+        .expect("Failed to build image client");
+    client
+        .pull_image(image_ref, bundle_dir.path(), &None, &None)
+        .await
+        .expect("image-rs pull failed");
+
+    PulledImage {
+        _work_dir: work_dir,
+        bundle_dir,
+    }
+}
+
+async fn pull_umoci(image_ref: &str) -> PulledImage {
+    use tokio::process::Command;
+
+    let work_dir = tempfile::tempdir().unwrap();
+    let bundle_dir = tempfile::tempdir().unwrap();
+    let oci_layout = work_dir.path().join("oci");
+
+    let output = Command::new("skopeo")
+        .args([
+            "copy",
+            &format!("docker://{}", image_ref),
+            &format!("oci:{}:latest", oci_layout.display()),
+            "--src-tls-verify=false",
+        ])
+        .output()
+        .await
+        .expect("Failed to execute skopeo");
+    assert!(
+        output.status.success(),
+        "skopeo copy failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let output = Command::new("umoci")
+        .args([
+            "unpack",
+            "--image",
+            &format!("{}:latest", oci_layout.display()),
+            bundle_dir.path().to_string_lossy().as_ref(),
+        ])
+        .output()
+        .await
+        .expect("Failed to execute umoci");
+    assert!(
+        output.status.success(),
+        "umoci unpack failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    PulledImage {
+        _work_dir: work_dir,
+        bundle_dir,
+    }
+}
+
+fn compare_rootfs(
+    image_name: &str,
+    image_rs_rootfs: &std::path::Path,
+    umoci_rootfs: &std::path::Path,
+) {
+    use std::io::Write;
+    use std::process::Command;
+
+    let spec_output = Command::new("gomtree")
+        .args([
+            "-c",
+            "-k",
+            "size,type,uid,gid,mode,link,time,sha256digest,xattr,xattrs",
+            "-p",
+        ])
+        .arg(umoci_rootfs)
+        .output()
+        .expect("Failed to execute gomtree");
+    assert!(
+        spec_output.status.success(),
+        "gomtree spec generation failed: {}",
+        String::from_utf8_lossy(&spec_output.stderr)
+    );
+
+    let mut spec_file = tempfile::NamedTempFile::new().unwrap();
+    spec_file.write_all(&spec_output.stdout).unwrap();
+
+    let verify_output = Command::new("gomtree")
+        .args(["-f"])
+        .arg(spec_file.path())
+        .args(["-p"])
+        .arg(image_rs_rootfs)
+        .output()
+        .expect("Failed to execute gomtree verify");
+
+    if !verify_output.status.success() {
+        let stderr = String::from_utf8_lossy(&verify_output.stderr);
+        let stdout = String::from_utf8_lossy(&verify_output.stdout);
+        println!(
+            "Rootfs mismatch for {} (image-rs vs umoci):\n{}{}",
+            image_name, stdout, stderr
+        );
+    }
+}
+
+#[tokio::test]
+#[serial_test::serial]
+async fn test_unpack_conformance() {
+    assert!(
+        nix::unistd::Uid::effective().is_root(),
+        "This test requires root privileges"
+    );
+
+    let images: Vec<_> = std::fs::read_dir(conformance_images_dir())
+        .expect("Failed to read conformance-images directory")
+        .filter_map(|e| e.ok())
+        .map(|e| e.path())
+        .filter(|p| p.extension().is_some_and(|ext| ext == "tar"))
+        .collect();
+
+    if images.is_empty() {
+        eprintln!("No test images found, skipping");
+        return;
+    }
+
+    let registry = LocalRegistry::start(REGISTRY_PORT)
+        .await
+        .expect("Failed to start local registry");
+
+    for tar_path in &images {
+        let image_name = tar_path.file_stem().unwrap().to_str().unwrap();
+        let image_ref = registry
+            .load_image(tar_path)
+            .await
+            .expect("Failed to load image");
+
+        let image_rs_pulled = pull_image_rs(&image_ref, &registry.url()).await;
+        println!(
+            "image-rs: {} -> {}",
+            image_name,
+            image_rs_pulled.rootfs().display()
+        );
+
+        let umoci_pulled = pull_umoci(&image_ref).await;
+        println!(
+            "umoci: {} -> {}",
+            image_name,
+            umoci_pulled.rootfs().display()
+        );
+
+        compare_rootfs(
+            image_name,
+            &image_rs_pulled.rootfs(),
+            &umoci_pulled.rootfs(),
+        );
+
+        image_rs_pulled.cleanup();
+        umoci_pulled.cleanup();
+    }
+}


### PR DESCRIPTION
Add a test that pulls an image with umoci and with image-rs and then compares them gomtree.

To avoid issues with the network, the test spins up a local registry and loads images from test_data/conformance_images into it. This PR does not add any test images (thus the test doesn't do anything). We can add images to the repo (pending some license discussion) or you can just run the test locally with your own test images. This also adds a script to pull a test image and put it in the directory with the right format.

I think we may want to generalize this local registry approach and use it for some of the other tests too. This could be handy for performance tests, for instance, which we should probably add. Anecdotally image-rs seems significantly slower than umoci.

While umoci is a good reference implementation to compare to, it differs from image-rs in that it unpacks an image directly to the filesystem (while image-rs uses overlayfs). This leads to some differences even when the image is unpacked correctly.

For example, overlayfs does not correctly report hardlink counts. Thus, we don't include nlink in our comparison. Overlayfs can also have some discrepancies in terms of size. For now, this is included in the comparison and these differences are reported.

Further, it's not yet clear if the mtime of the root dir will be correct with overlayfs. This is also reported.

This test is not yet ready to be required, but it's pretty handy. 