### PR TITLE
ocicrypt-rs: add warning when OCICRYPT_KEYPROVIDER_CONFIG is not set

### DIFF
--- a/ocicrypt-rs/Cargo.toml
+++ b/ocicrypt-rs/Cargo.toml
@@ -30,6 +30,7 @@ serde_json.workspace = true
 sha2 = { workspace = true, optional = true }
 tokio = { workspace = true, features = ["rt-multi-thread"], optional = true }
 tonic = { workspace = true, optional = true }
+tracing = { workspace = true }
 ttrpc = { workspace = true, features = ["async"], optional = true }
 zeroize = { workspace = true, optional = true }
 

--- a/ocicrypt-rs/src/config.rs
+++ b/ocicrypt-rs/src/config.rs
@@ -287,13 +287,18 @@ impl OcicryptConfig {
             .map_err(|e| anyhow!("Error reading file {:?}", e.to_string()))
     }
 
-    /// from_env tries to read the configuration file at the following locations
-    /// ${OCICRYPT_KEYPROVIDER_CONFIG} == "/etc/ocicrypt_keyprovider.json"
-    /// If no configuration file could be found or read a null pointer is returned
+    /// from_env reads the configuration file pointed at by the given environment
+    /// variable. If the variable is not set, `Ok(None)` is returned and a warning
+    /// is emitted, since no keyproviders will be registered.
     pub fn from_env(env: &str) -> Result<Option<OcicryptConfig>> {
-        // find file name from environment variable, ignore error if environment variable is not set.
         match std::env::var(env) {
-            Err(_e) => Ok(None),
+            Err(_e) => {
+                tracing::warn!(
+                    env_var = env,
+                    "ocicrypt keyprovider config env var is not set; no keyproviders will be registered"
+                );
+                Ok(None)
+            }
             Ok(filename) => OcicryptConfig::from_file(filename.as_str()).map(Some),
         }
     }


### PR DESCRIPTION
 ## Summary

  Adds a `tracing::warn!` to `OcicryptConfig::from_env` when the `OCICRYPT_KEYPROVIDER_CONFIG` env var is unset. Today the function returns `Ok(None)` silently — downstream callers then fail with a generic decrypt error that gives no
  hint that the env var was the real cause. Behavior is unchanged: `Ok(None)` is still returned, only an observability log is added.

  `tracing` is already a workspace dependency (used by `image-rs`, `attestation-agent`, `confidential-data-hub`, `api-server-rest`); this PR adds it to `ocicrypt-rs/Cargo.toml` to match.

  Similar in spirit to #630 (don't swallow `pre_unwrap_key()` error) — surfacing a previously-silent failure mode at the boundary where the operator can act, without changing the API contract.

  ## Test plan

  - [x] No change to `from_env` return signature or semantics
  - [x] No change to any other code path
  - [x] Existing `test_ocicrypt_config` continues to exercise the `Ok(filename)` branch
  - [ ] CI: builds across `block-cipher-openssl`, `block-cipher-ring`, `keywrap-keyprovider-*` feature matrices on this PR