### PR TITLE
asr: support base64 URL-safe-nopad runtime_data on evidence API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -174,6 +174,7 @@ dependencies = [
  "form_urlencoded",
  "hyper 0.14.32",
  "protos",
+ "rstest",
  "serde",
  "serde_json",
  "shadow-rs",

--- a/api-server-rest/Cargo.toml
+++ b/api-server-rest/Cargo.toml
@@ -21,6 +21,9 @@ tracing-subscriber.workspace = true
 ttrpc = { workspace = true, features = ["async"] }
 protos = { path = "../protos", default-features = false, features = ["ttrpc"] }
 
+[dev-dependencies]
+rstest.workspace = true
+
 [build-dependencies]
 serde_json = { workspace = true }
 shadow-rs.workspace = true

--- a/api-server-rest/README.md
+++ b/api-server-rest/README.md
@@ -13,6 +13,10 @@ $ curl http://127.0.0.1:8006/cdh/resource/default/key/1
 $ curl http://127.0.0.1:8006/aa/evidence\?runtime_data\=xxxx
 {"svn":"1","report_data":"eHh4eA=="}
 
+# When runtime_data is URL-safe base64, pass encoding=base64
+$ curl "http://127.0.0.1:8006/aa/evidence?runtime_data=eHh4eA&encoding=base64"
+{"svn":"1","report_data":"eHh4eA=="}
+
 $ curl http://127.0.0.1:8006/aa/token\?token_type\=kbs
 {"token":"eyJhbGciOiJFi...","tee_keypair":"-----BEGIN... "}
 

--- a/api-server-rest/build.rs
+++ b/api-server-rest/build.rs
@@ -31,7 +31,8 @@ fn _token() {}
     get,
     path = "/aa/evidence",
     params(
-        ("runtime_data" = String, Query, description = "Runtime Data")
+        ("runtime_data" = String, Query, description = "Runtime Data"),
+        ("encoding" = Option<String>, Query, description = "Runtime data encoding; use `base64` for URL-safe base64 (no padding)")
     ),
     responses(
         (status = 200, description = "success response",

--- a/api-server-rest/openapi/api.json
+++ b/api-server-rest/openapi/api.json
@@ -62,6 +62,15 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "name": "encoding",
+            "in": "query",
+            "description": "Runtime data encoding; use `base64` for URL-safe base64 (no padding)",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {

--- a/api-server-rest/src/router.rs
+++ b/api-server-rest/src/router.rs
@@ -15,7 +15,7 @@ use crate::client::{
     aa::{AAClient, AaelEvent, AA_AAEL_URL, AA_EVIDENCE_URL, AA_ROOT, AA_TOKEN_URL},
     cdh::{CDHClient, CDH_RESOURCE_URL, CDH_ROOT},
 };
-use crate::utils::split_nth_slash;
+use crate::utils::{decode_runtime_data, split_nth_slash};
 use crate::VERSION;
 
 pub struct Router {
@@ -168,10 +168,14 @@ impl Router {
                             info!("Get evidence");
                             match params.get("runtime_data") {
                                 Some(runtime_data) => {
-                                    match client
-                                        .get_evidence(&runtime_data.clone().into_bytes())
-                                        .await
-                                    {
+                                    let runtime_data = match decode_runtime_data(
+                                        runtime_data,
+                                        params.get("encoding").map(String::as_str),
+                                    ) {
+                                        std::result::Result::Ok(data) => data,
+                                        std::result::Result::Err(_) => return self.bad_request(),
+                                    };
+                                    match client.get_evidence(&runtime_data).await {
                                         std::result::Result::Ok(results) => {
                                             return self.octet_stream_response(results)
                                         }

--- a/api-server-rest/src/utils.rs
+++ b/api-server-rest/src/utils.rs
@@ -3,6 +3,23 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+use anyhow::{anyhow, Context, Result};
+use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
+
+/// Parse `runtime_data` from the evidence query string.
+///
+/// When `encoding` is `base64`, `runtime_data` is decoded as URL-safe base64 (no padding).
+/// Otherwise the raw UTF-8 bytes of the query value are used (legacy behavior).
+pub fn decode_runtime_data(runtime_data: &str, encoding: Option<&str>) -> Result<Vec<u8>> {
+    match encoding {
+        None => Ok(runtime_data.as_bytes().to_vec()),
+        Some("base64") => URL_SAFE_NO_PAD
+            .decode(runtime_data)
+            .context("invalid base64 URL-safe runtime_data"),
+        Some(other) => Err(anyhow!("unsupported runtime_data encoding: {other}")),
+    }
+}
+
 pub fn split_nth_slash(url: &str, n: usize) -> Option<(&str, &str)> {
     let mut split_pos = None;
     let mut splits = url.match_indices('/');
@@ -17,6 +34,26 @@ pub fn split_nth_slash(url: &str, n: usize) -> Option<(&str, &str)> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use rstest::rstest;
+
+    #[rstest]
+    #[case("hello", None, true, Some(b"hello".as_slice()))]
+    #[case("cmVwb3J0", Some("base64"), true, Some(b"report".as_slice()))]
+    #[case("data", Some("hex"), false, None)]
+    #[case("!!!", Some("base64"), false, None)]
+    fn test_decode_runtime_data(
+        #[case] runtime_data: &str,
+        #[case] encoding: Option<&str>,
+        #[case] expect_ok: bool,
+        #[case] expected: Option<&[u8]>,
+    ) {
+        let result = decode_runtime_data(runtime_data, encoding);
+        if expect_ok {
+            assert_eq!(result.unwrap(), expected.unwrap());
+        } else {
+            assert!(result.is_err());
+        }
+    }
 
     #[test]
     fn test_split_nth_slash() {


### PR DESCRIPTION
Add an optional `encoding=base64` query parameter to `/aa/evidence`. When set, decode `runtime_data` with URL-safe base64 (no padding) before forwarding to the attestation agent. Preserve the existing behavior when `encoding` is omitted.

Close #1434