### PR TITLE
asr: expose AA get_additional_evidence via REST API

### DIFF
--- a/api-server-rest/README.md
+++ b/api-server-rest/README.md
@@ -17,6 +17,12 @@ $ curl http://127.0.0.1:8006/aa/evidence\?runtime_data\=xxxx
 $ curl "http://127.0.0.1:8006/aa/evidence?runtime_data=eHh4eA&encoding=base64"
 {"svn":"1","report_data":"eHh4eA=="}
 
+$ curl http://127.0.0.1:8006/aa/additional-evidence\?runtime_data\=xxxx
+{"nvidia":"..."}
+
+$ curl "http://127.0.0.1:8006/aa/additional-evidence?runtime_data=eHh4eA&encoding=base64"
+{"nvidia":"..."}
+
 $ curl http://127.0.0.1:8006/aa/token\?token_type\=kbs
 {"token":"eyJhbGciOiJFi...","tee_keypair":"-----BEGIN... "}
 

--- a/api-server-rest/build.rs
+++ b/api-server-rest/build.rs
@@ -47,6 +47,26 @@ fn _token() {}
 )]
 fn _evidence() {}
 
+#[utoipa::path(
+    get,
+    path = "/aa/additional-evidence",
+    params(
+        ("runtime_data" = String, Query, description = "Runtime Data"),
+        ("encoding" = Option<String>, Query, description = "Runtime data encoding; use `base64` for URL-safe base64 (no padding)")
+    ),
+    responses(
+        (status = 200, description = "success response",
+                content_type = "application/octet-stream",
+                body = String,
+                example = json!({"sev-snp":"..."})),
+        (status = 400, description = "bad request for invalid query param"),
+        (status = 403, description = "forbid external access"),
+        (status = 404, description = "resource not found"),
+        (status = 405, description = "only Get method allowed")
+    )
+)]
+fn _additional_evidence() {}
+
 #[derive(ToSchema)]
 pub struct AaelEvent {
     /// Attestation Agent Event Log Domain
@@ -128,7 +148,7 @@ fn generate_openapi_document() -> std::io::Result<()> {
         (url = "http://127.0.0.1:8006", description = "CoCo RESTful API")
      ),
 
-    paths(_token, _evidence, _aael, _resource, _version)
+    paths(_token, _evidence, _additional_evidence, _aael, _resource, _version)
  )]
     struct ApiDoc;
     let mut file = File::create("openapi/api.json")?;

--- a/api-server-rest/openapi/api.json
+++ b/api-server-rest/openapi/api.json
@@ -49,6 +49,59 @@
         }
       }
     },
+    "/aa/additional-evidence": {
+      "get": {
+        "tags": [],
+        "operationId": "_additional_evidence",
+        "parameters": [
+          {
+            "name": "runtime_data",
+            "in": "query",
+            "description": "Runtime Data",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "encoding",
+            "in": "query",
+            "description": "Runtime data encoding; use `base64` for URL-safe base64 (no padding)",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "success response",
+            "content": {
+              "application/octet-stream": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": {
+                  "sev-snp": "..."
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "bad request for invalid query param"
+          },
+          "403": {
+            "description": "forbid external access"
+          },
+          "404": {
+            "description": "resource not found"
+          },
+          "405": {
+            "description": "only Get method allowed"
+          }
+        }
+      }
+    },
     "/aa/evidence": {
       "get": {
         "tags": [],

--- a/api-server-rest/src/client/aa.rs
+++ b/api-server-rest/src/client/aa.rs
@@ -5,8 +5,8 @@
 
 use anyhow::*;
 use protos::ttrpc::aa::attestation_agent::{
-    ExtendRuntimeMeasurementRequest, GetAdditionalTeesRequest, GetEvidenceRequest,
-    GetTeeTypeRequest, GetTokenRequest,
+    ExtendRuntimeMeasurementRequest, GetAdditionalEvidenceRequest, GetAdditionalTeesRequest,
+    GetEvidenceRequest, GetTeeTypeRequest, GetTokenRequest,
 };
 use protos::ttrpc::aa::attestation_agent_ttrpc::AttestationAgentServiceClient;
 use serde::Deserialize;
@@ -19,6 +19,7 @@ pub const AA_ROOT: &str = "/aa";
 /// URL for querying CDH get resource API
 pub const AA_TOKEN_URL: &str = "/token";
 pub const AA_EVIDENCE_URL: &str = "/evidence";
+pub const AA_ADDITIONAL_EVIDENCE_URL: &str = "/additional-evidence";
 pub const AA_AAEL_URL: &str = "/aael";
 
 pub struct AAClient {
@@ -62,6 +63,18 @@ impl AAClient {
         let res = self
             .client
             .get_evidence(ttrpc::context::with_timeout(TTRPC_TIMEOUT), &req)
+            .await?;
+        Ok(res.Evidence)
+    }
+
+    pub async fn get_additional_evidence(&self, runtime_data: &[u8]) -> Result<Vec<u8>> {
+        let req = GetAdditionalEvidenceRequest {
+            RuntimeData: runtime_data.to_vec(),
+            ..Default::default()
+        };
+        let res = self
+            .client
+            .get_additional_evidence(ttrpc::context::with_timeout(TTRPC_TIMEOUT), &req)
             .await?;
         Ok(res.Evidence)
     }

--- a/api-server-rest/src/router.rs
+++ b/api-server-rest/src/router.rs
@@ -12,7 +12,10 @@ use std::net::SocketAddr;
 use tracing::{debug, info};
 
 use crate::client::{
-    aa::{AAClient, AaelEvent, AA_AAEL_URL, AA_EVIDENCE_URL, AA_ROOT, AA_TOKEN_URL},
+    aa::{
+        AAClient, AaelEvent, AA_AAEL_URL, AA_ADDITIONAL_EVIDENCE_URL, AA_EVIDENCE_URL, AA_ROOT,
+        AA_TOKEN_URL,
+    },
     cdh::{CDHClient, CDH_RESOURCE_URL, CDH_ROOT},
 };
 use crate::utils::{decode_runtime_data, split_nth_slash};
@@ -176,6 +179,27 @@ impl Router {
                                         std::result::Result::Err(_) => return self.bad_request(),
                                     };
                                     match client.get_evidence(&runtime_data).await {
+                                        std::result::Result::Ok(results) => {
+                                            return self.octet_stream_response(results)
+                                        }
+                                        Err(e) => return self.internal_error(e.to_string()),
+                                    }
+                                }
+                                None => return self.bad_request(),
+                            }
+                        }
+                        (AA_ADDITIONAL_EVIDENCE_URL, &Method::GET) => {
+                            info!("Get additional evidence");
+                            match params.get("runtime_data") {
+                                Some(runtime_data) => {
+                                    let runtime_data = match decode_runtime_data(
+                                        runtime_data,
+                                        params.get("encoding").map(String::as_str),
+                                    ) {
+                                        std::result::Result::Ok(data) => data,
+                                        std::result::Result::Err(_) => return self.bad_request(),
+                                    };
+                                    match client.get_additional_evidence(&runtime_data).await {
                                         std::result::Result::Ok(results) => {
                                             return self.octet_stream_response(results)
                                         }


### PR DESCRIPTION
Add GET /aa/additional-evidence so containers can obtain additional TEE evidence through api-server-rest. Reuse the same runtime_data query handling as /aa/evidence, including optional base64 encoding.

Assisted-by: Cursor