### PR TITLE
ci: fix AA release version information

### DIFF
--- a/.github/workflows/publish-artifacts.yml
+++ b/.github/workflows/publish-artifacts.yml
@@ -54,6 +54,9 @@ jobs:
         version: 1.2.0
 
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        fetch-depth: 0
+        fetch-tags: true
 
     - uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1.16.1
       with:


### PR DESCRIPTION
Attestation Agent's -V command, relies on "build::LAST_TAG" macro. This macro calls `git describe --tags --abbrev=0 HEAD` underlying. But the current AA release CI uses shalow clone, thus no tags is downloaded.

The published AA now will have -V info like

```
attestation-agent -af4deffc
supported attesters: SAMPLE, SAMPLE_DEVICE, TDX
token plugins: KBS, COCO_AS
```

This fix will help to get proper tag before '-'