### PR TITLE
KBS Protocol | Add PQC algorithm support

### DIFF
--- a/.github/workflows/aa_basic.yml
+++ b/.github/workflows/aa_basic.yml
@@ -97,6 +97,11 @@ jobs:
         run: |
           sudo -E PATH=$PATH -s cargo test ${{ matrix.cargo_test_opts }} -p attestation-agent -p attester -p coco_keyprovider -p kbc -p kbs_protocol -p crypto -p resource_uri
 
+      - name: Build and test kbs_protocol pqc-experimental feature
+        run: |
+          sudo -E PATH=$PATH -s cargo test -p kbs_protocol --features pqc-experimental -- pqc
+        if: matrix.instance == 'ubuntu-24.04'
+
       - name: Run cargo fmt check
         run: cargo fmt --all -- --check
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16,7 +16,7 @@ checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
 dependencies = [
  "bytes",
  "crypto-common 0.1.7",
- "generic-array",
+ "generic-array 0.14.7",
 ]
 
 [[package]]
@@ -1167,7 +1167,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.7",
 ]
 
 [[package]]
@@ -1176,7 +1176,7 @@ version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.7",
 ]
 
 [[package]]
@@ -1194,7 +1194,7 @@ version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.7",
 ]
 
 [[package]]
@@ -2058,7 +2058,7 @@ version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.7",
  "rand_core 0.6.4",
  "subtle",
  "zeroize",
@@ -2070,7 +2070,7 @@ version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.7",
  "rand_core 0.6.4",
  "typenum",
 ]
@@ -2092,7 +2092,7 @@ version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "58bcd97a54c7ca5ce2f6eb16f6bede5b0ab5f0055fedc17d2f0b4466e21671ca"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.7",
  "subtle",
 ]
 
@@ -2104,7 +2104,7 @@ checksum = "b9d6cf87adf719ddf43a805e92c6870a531aedda35ff640442cbaf8674e141e1"
 dependencies = [
  "aead 0.5.2",
  "cipher 0.4.4",
- "generic-array",
+ "generic-array 0.14.7",
  "poly1305",
  "salsa20",
  "subtle",
@@ -2340,7 +2340,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd2735a791158376708f9347fe8faba9667589d82427ef3aed6794a8981de3d9"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.7",
 ]
 
 [[package]]
@@ -2501,7 +2501,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.7",
 ]
 
 [[package]]
@@ -2769,7 +2769,7 @@ dependencies = [
  "crypto-bigint",
  "digest 0.10.7",
  "ff",
- "generic-array",
+ "generic-array 0.14.7",
  "group",
  "hkdf",
  "pem-rfc7468 0.7.0",
@@ -3141,6 +3141,16 @@ dependencies = [
  "typenum",
  "version_check",
  "zeroize",
+]
+
+[[package]]
+name = "generic-array"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dab9e9188e97a93276e1fe7b56401b851e2b45a46d045ca658100c1303ada649"
+dependencies = [
+ "rustversion",
+ "typenum",
 ]
 
 [[package]]
@@ -3915,7 +3925,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
 dependencies = [
  "block-padding",
- "generic-array",
+ "generic-array 0.14.7",
 ]
 
 [[package]]
@@ -4198,7 +4208,7 @@ checksum = "c57c852b14147e2bd58c14fde40398864453403ef632b1101db130282ee6e2cc"
 dependencies = [
  "base64 0.13.1",
  "bitflags 1.3.2",
- "generic-array",
+ "generic-array 0.14.7",
  "num-bigint",
  "serde",
  "serde_json",
@@ -4330,6 +4340,7 @@ dependencies = [
 name = "kbs_protocol"
 version = "0.1.0"
 dependencies = [
+ "aes-kw 0.3.1",
  "anyhow",
  "async-trait",
  "attester",
@@ -4338,6 +4349,7 @@ dependencies = [
  "crypto",
  "jwt-simple",
  "kbs-types",
+ "ml-kem",
  "protobuf",
  "protos",
  "reqwest 0.13.4",
@@ -4348,6 +4360,7 @@ dependencies = [
  "serde_json_canonicalizer",
  "serial_test",
  "sha2 0.11.0",
+ "sha3-kmac",
  "shadow-rs",
  "tempfile",
  "testcontainers",
@@ -4377,6 +4390,16 @@ checksum = "9e24a010dd405bd7ed803e5253182815b41bf2e6a80cc3bfc066658e03a198aa"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
+]
+
+[[package]]
+name = "kem"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01737161ba802849cfd486b5bd209d38ba4943494c249a8126005170c7621edd"
+dependencies = [
+ "crypto-common 0.2.2",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -4687,6 +4710,20 @@ dependencies = [
  "pkcs8 0.11.0",
  "sha3 0.11.0",
  "signature 3.0.0",
+]
+
+[[package]]
+name = "ml-kem"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e15f3e5b957493873e396a66914e83e616b6afe335cdef7efe5c6e1216aba66"
+dependencies = [
+ "hybrid-array",
+ "kem",
+ "module-lattice",
+ "pkcs8 0.11.0",
+ "rand_core 0.10.1",
+ "sha3 0.11.0",
 ]
 
 [[package]]
@@ -5568,7 +5605,7 @@ dependencies = [
  "ed25519-dalek",
  "elliptic-curve",
  "flate2",
- "generic-array",
+ "generic-array 0.14.7",
  "hex",
  "hkdf",
  "idea",
@@ -6946,7 +6983,7 @@ checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
 dependencies = [
  "base16ct",
  "der 0.7.10",
- "generic-array",
+ "generic-array 0.14.7",
  "pkcs8 0.10.2",
  "serdect 0.2.0",
  "subtle",
@@ -7352,6 +7389,26 @@ checksum = "be176f1a57ce4e3d31c1a166222d9768de5954f811601fb7ca06fc8203905ce1"
 dependencies = [
  "digest 0.11.3",
  "keccak 0.2.0",
+]
+
+[[package]]
+name = "sha3-kmac"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b6b86fb906e40929519c1a38dc349a7f5595778cc00cc20b55eec34fddeb9ec"
+dependencies = [
+ "generic-array 1.4.1",
+ "sha3 0.10.9",
+ "sha3-utils",
+]
+
+[[package]]
+name = "sha3-utils"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08e0bf98cc082cbe077f06a707c94ca15796d046cc4cd2593167b5730a6727be"
+dependencies = [
+ "zerocopy",
 ]
 
 [[package]]

--- a/attestation-agent/kbs_protocol/Cargo.toml
+++ b/attestation-agent/kbs_protocol/Cargo.toml
@@ -27,6 +27,10 @@ resource_uri.path = "../deps/resource_uri"
 serde.workspace = true
 serde_json.workspace = true
 sha2.workspace = true
+# Post-Quantum KEM deps (gated by `pqc-experimental`).
+aes-kw = { version = "0.3.1", optional = true, features = ["zeroize"] }
+ml-kem = { version = "0.3.2", features = ["getrandom"], optional = true }
+sha3-kmac = { version = "0.3.0", optional = true }
 shadow-rs = { version = "2.0.0", default-features = false }
 thiserror.workspace = true
 tokio.workspace = true
@@ -77,5 +81,10 @@ nvidia-attester = ["attester/nvidia-attester"]
 
 rust-crypto = ["reqwest/rustls", "crypto/rust-crypto"]
 openssl = ["reqwest/native-tls-vendored", "crypto/openssl"]
+
+# Experimental Post-Quantum KEM support (ML-KEM-768+A192KW per
+# [draft-ietf-jose-pqc-kem-05](https://datatracker.ietf.org/doc/html/draft-ietf-jose-pqc-kem-05)). 
+# Default off.
+pqc-experimental = ["dep:aes-kw", "dep:ml-kem", "dep:sha3-kmac"]
 
 bin = ["tokio/rt", "tokio/macros", "clap", "tracing-subscriber"]

--- a/attestation-agent/kbs_protocol/src/akp.rs
+++ b/attestation-agent/kbs_protocol/src/akp.rs
@@ -1,0 +1,207 @@
+// Copyright (c) 2026 Arqit / guest-components contributors.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Experimental Post-Quantum KEM support for the KBS resource-response JWE
+//! path, client side.
+//!
+//! Implements the decryption half of `ML-KEM-768+A192KW` per
+//! draft-ietf-jose-pqc-kem-05. Counterpart of the server-side
+//! `kbs/src/akp.rs` in the trustee repo.
+//!
+//! Wire format is not finalized — the IETF draft is WG-adopted Standards
+//! Track but not yet RFC. The KDF FixedInfo encoding (X input to KMAC256)
+//! is underspecified by the draft; we follow the RFC 7518 §4.6.2 ConcatKDF
+//! precedent, omitting PartyUInfo/PartyVInfo as the PQ draft directs. This
+//! MUST stay byte-identical to the server's `kmac256_kdf` or AES-KW unwrap
+//! will fail. Re-validate against reference implementations and test
+//! vectors when those emerge.
+
+use aes_kw::{KeyInit, KwAes192};
+use anyhow::{anyhow, Result};
+use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
+use kbs_types::TeePubKey;
+use ml_kem::{kem::KeyExport, Decapsulate, DecapsulationKey, EncapsulationKey, Kem, MlKem768};
+use sha3_kmac::Kmac256;
+
+/// `kty` value for the Algorithm Key Pair (AKP) key type per
+/// draft-ietf-jose-pqc-kem-05 §10.
+pub const AKP_KTY: &str = "AKP";
+
+/// Algorithm identifier for ML-KEM-768 with AES-192 key wrap.
+pub const ML_KEM_768_A192KW_ALGORITHM: &str = "ML-KEM-768+A192KW";
+
+/// AES-192 wrap-key length in bytes (= 192 bits ÷ 8). Per
+/// draft-ietf-jose-pqc-kem-05 §8 the wrap variant for ML-KEM-768 is A192KW.
+const A192KW_KEY_LEN: usize = 24;
+
+/// AES-256 content-encryption-key length in bytes. Matches the existing
+/// classical paths' `A256GCM`.
+const A256_CEK_LEN: usize = 32;
+
+/// ML-KEM-768 keypair held by the TEE for the resource-response JWE path.
+///
+/// `Clone` is required because `TeeKey` and `TeeKeyPair` derive `Clone`.
+/// `Debug` is implemented manually to avoid leaking the decapsulation key.
+#[derive(Clone)]
+pub struct AkpKeyPair {
+    encap_key: EncapsulationKey<MlKem768>,
+    decap_key: DecapsulationKey<MlKem768>,
+}
+
+impl std::fmt::Debug for AkpKeyPair {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("AkpKeyPair").finish_non_exhaustive()
+    }
+}
+
+impl AkpKeyPair {
+    /// Generate a fresh ML-KEM-768 keypair. Uses OS RNG internally via
+    /// `ml-kem`'s `getrandom` feature.
+    pub fn generate() -> Self {
+        let (decap_key, encap_key) = MlKem768::generate_keypair();
+        Self {
+            encap_key,
+            decap_key,
+        }
+    }
+
+    /// Raw encapsulation-key bytes (1184 bytes for ML-KEM-768) suitable for
+    /// base64url encoding in the JWK `pub` field.
+    pub fn public_key_bytes(&self) -> Vec<u8> {
+        self.encap_key.to_bytes().to_vec()
+    }
+
+    /// Build the JWK wire representation of this keypair's public key.
+    pub fn to_pub_jwk(&self) -> TeePubKey {
+        TeePubKey::AKP {
+            alg: ML_KEM_768_A192KW_ALGORITHM.to_string(),
+            public_key: URL_SAFE_NO_PAD.encode(self.public_key_bytes()),
+        }
+    }
+
+    /// Decapsulate the KEM ciphertext (`ek` JOSE header) and AES-KW-unwrap
+    /// the content-encryption key.
+    ///
+    /// `kem_ciphertext`: raw bytes from the JWE `ek` header
+    /// (already base64url-decoded).
+    /// `wrapped_cek`: bytes from the JWE `encrypted_key` field.
+    ///
+    /// Returns the 32-byte CEK ready for AES-256-GCM payload decryption.
+    pub fn decapsulate_and_unwrap(
+        &self,
+        kem_ciphertext: &[u8],
+        wrapped_cek: &[u8],
+    ) -> Result<Vec<u8>> {
+        let shared_secret = self
+            .decap_key
+            .decapsulate_slice(kem_ciphertext)
+            .map_err(|e| anyhow!("ML-KEM-768 decapsulate failed: {e:?}"))?;
+
+        let kwk = kmac256_kdf(
+            shared_secret.as_slice(),
+            ML_KEM_768_A192KW_ALGORITHM,
+            A192KW_KEY_LEN,
+        )?;
+        let kwk: [u8; A192KW_KEY_LEN] = kwk
+            .try_into()
+            .map_err(|_| anyhow!("KDF output not {A192KW_KEY_LEN} bytes"))?;
+
+        let unwrapper =
+            KwAes192::new_from_slice(&kwk).map_err(|e| anyhow!("AES-KW key init failed: {e:?}"))?;
+        let mut cek = vec![0u8; A256_CEK_LEN];
+        unwrapper
+            .unwrap_key(wrapped_cek, &mut cek)
+            .map_err(|e| anyhow!("AES-KW unwrap failed: {e:?}"))?;
+        Ok(cek)
+    }
+}
+
+/// KMAC256-based KDF per draft-ietf-jose-pqc-kem-05 §5.1.
+///
+/// `KMAC256(K = shared_secret, X = AlgorithmID || SuppPubInfo,
+///          L = out_len_bytes·8 bits, S = "")`
+///
+/// AlgorithmID = 4-byte BE length(alg) || alg.
+/// SuppPubInfo = 4-byte BE keydatalen-in-bits.
+/// PartyUInfo / PartyVInfo are intentionally excluded per the draft.
+///
+/// MUST stay byte-identical to the server's `kbs/src/akp.rs::kmac256_kdf`.
+///
+/// Visible to the rest of the crate to support unwrap-path testing in
+/// `keypair.rs` without re-implementing the encoding.
+pub(crate) fn kmac256_kdf(
+    shared_secret: &[u8],
+    alg: &str,
+    out_len_bytes: usize,
+) -> Result<Vec<u8>> {
+    let alg_bytes = alg.as_bytes();
+    let alg_len = (alg_bytes.len() as u32).to_be_bytes();
+    let keydatalen_bits = ((out_len_bytes * 8) as u32).to_be_bytes();
+
+    let mut x = Vec::with_capacity(4 + alg_bytes.len() + 4);
+    x.extend_from_slice(&alg_len);
+    x.extend_from_slice(alg_bytes);
+    x.extend_from_slice(&keydatalen_bits);
+
+    let mut kmac =
+        Kmac256::new(shared_secret, b"").map_err(|e| anyhow!("KMAC256 init failed: {e:?}"))?;
+    kmac.update(&x);
+    let mut out = vec![0u8; out_len_bytes];
+    kmac.finalize_into(&mut out);
+    Ok(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ml_kem::Encapsulate;
+
+    /// End-to-end roundtrip: encapsulate to the keypair's own public key,
+    /// derive the KWK via the same KDF, wrap a known CEK, then exercise
+    /// the client-side `decapsulate_and_unwrap` and confirm the CEK
+    /// matches. This verifies the KDF + AES-KW + ML-KEM decapsulation
+    /// codepath end-to-end without depending on the server.
+    #[test]
+    fn decapsulate_and_unwrap_roundtrip() {
+        let keypair = AkpKeyPair::generate();
+
+        let (kem_ciphertext, shared_secret) = keypair.encap_key.encapsulate();
+
+        let kwk =
+            kmac256_kdf(shared_secret.as_slice(), ML_KEM_768_A192KW_ALGORITHM, 24).expect("kdf");
+        let kwk: [u8; 24] = kwk.try_into().unwrap();
+
+        let cek_orig: [u8; 32] = [7u8; 32];
+        let wrapper = KwAes192::new_from_slice(&kwk).expect("init KWK");
+        let mut wrapped_cek = vec![0u8; 40]; // 32-byte CEK + 8-byte AES-KW integrity check
+        wrapper
+            .wrap_key(&cek_orig, &mut wrapped_cek)
+            .expect("wrap CEK");
+
+        let cek_recovered = keypair
+            .decapsulate_and_unwrap(kem_ciphertext.as_slice(), &wrapped_cek)
+            .expect("decapsulate_and_unwrap");
+
+        assert_eq!(cek_recovered.as_slice(), &cek_orig[..]);
+    }
+
+    #[test]
+    fn pub_jwk_has_correct_fields_and_length() {
+        let kp = AkpKeyPair::generate();
+        let TeePubKey::AKP { alg, public_key } = kp.to_pub_jwk() else {
+            panic!("expected AKP variant");
+        };
+        assert_eq!(alg, ML_KEM_768_A192KW_ALGORITHM);
+        let bytes = URL_SAFE_NO_PAD.decode(&public_key).expect("base64");
+        assert_eq!(bytes.len(), 1184); // ML-KEM-768 encap-key length per FIPS 203.
+    }
+
+    #[test]
+    fn kdf_is_deterministic_and_correct_length() {
+        let secret = [0u8; 32];
+        let out = kmac256_kdf(&secret, ML_KEM_768_A192KW_ALGORITHM, 24).expect("kdf");
+        assert_eq!(out.len(), 24);
+        let out2 = kmac256_kdf(&secret, ML_KEM_768_A192KW_ALGORITHM, 24).expect("kdf again");
+        assert_eq!(out, out2);
+    }
+}

--- a/attestation-agent/kbs_protocol/src/bin/trustee-attester/main.rs
+++ b/attestation-agent/kbs_protocol/src/bin/trustee-attester/main.rs
@@ -79,6 +79,10 @@ async fn main() -> Result<()> {
     // a kbs_protocol client with evidence_provider
     let mut client_builder = KbsClientBuilder::with_evidence_provider(evidence_provider, &url);
 
+    // Sets TeeKeyAlgorithm to ML-KEM if pqc-experimental feature enabled.
+    #[cfg(feature = "pqc-experimental")]
+    client_builder.set_tee_key_algorithm(TeeKeyAlgorithm::MlKem768A192Kw);
+
     // if a certificate is given, use it
     if let Some(cf) = cert_file {
         debug!("Reading certificate from cert_file {}", cf.display());

--- a/attestation-agent/kbs_protocol/src/keypair.rs
+++ b/attestation-agent/kbs_protocol/src/keypair.rs
@@ -5,6 +5,8 @@
 
 use anyhow::{anyhow, bail, Context, Result};
 
+#[cfg(feature = "pqc-experimental")]
+use crate::akp::{AkpKeyPair, ML_KEM_768_A192KW_ALGORITHM};
 use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
 use crypto::{
     ec::{EcKeyPair, KeyWrapAlgorithm, P256EcKeyPair, P521EcKeyPair},
@@ -24,6 +26,8 @@ pub struct TeeKeyPair {
 pub enum TeeKey {
     Rsa(Box<RSAKeyPair>),
     Ec(Box<EcKeyPair>),
+    #[cfg(feature = "pqc-experimental")]
+    Akp(Box<AkpKeyPair>),
 }
 
 #[derive(Clone, Copy, Debug, Default, Deserialize, Eq, PartialEq)]
@@ -35,6 +39,12 @@ pub enum TeeKeyAlgorithm {
     EcdhEsA256KwP521,
     #[serde(rename = "RSA-OAEP-256")]
     RsaOaep256,
+    /// ML-KEM-768 with AES-192 key wrap per draft-ietf-jose-pqc-kem-05.
+    /// Gated behind `pqc-experimental`; default-build configs cannot select
+    /// this variant.
+    #[cfg(feature = "pqc-experimental")]
+    #[serde(rename = "ML-KEM-768+A192KW")]
+    MlKem768A192Kw,
 }
 
 impl TeeKeyPair {
@@ -52,11 +62,31 @@ impl TeeKeyPair {
                 TeeKey::Ec(Box::new(EcKeyPair::P521(P521EcKeyPair::default())))
             }
             TeeKeyAlgorithm::RsaOaep256 => TeeKey::Rsa(Box::new(RSAKeyPair::new()?)),
+            #[cfg(feature = "pqc-experimental")]
+            TeeKeyAlgorithm::MlKem768A192Kw => TeeKey::Akp(Box::new(AkpKeyPair::generate())),
         };
         Ok(Self { key })
     }
 
-    /// Export TEE public key as specific structure.
+    /// Whether this keypair uses the experimental AKP (ML-KEM-768) algorithm.
+    ///
+    /// Always `false` when the `pqc-experimental` Cargo feature is off, so
+    /// callers can use this unconditionally without their own feature gate.
+    pub fn is_akp(&self) -> bool {
+        #[cfg(feature = "pqc-experimental")]
+        {
+            matches!(&self.key, TeeKey::Akp(_))
+        }
+        #[cfg(not(feature = "pqc-experimental"))]
+        {
+            false
+        }
+    }
+
+    /// Export TEE public key as a typed `kbs_types::TeePubKey`.
+    ///
+    /// Covers all key types, including the experimental AKP (ML-KEM-768)
+    /// variant, which maps to `TeePubKey::AKP`.
     pub fn export_pubkey(&self) -> Result<TeePubKey> {
         match &self.key {
             TeeKey::Rsa(key) => {
@@ -80,6 +110,8 @@ impl TeeKeyPair {
                     y,
                 })
             }
+            #[cfg(feature = "pqc-experimental")]
+            TeeKey::Akp(key) => Ok(key.to_pub_jwk()),
         }
     }
 
@@ -141,6 +173,26 @@ impl TeeKeyPair {
             let cek = key.unwrap_key(wrapped_cek, x, y, KeyWrapAlgorithm::EcdhEsA256Kw)?;
             Ok(cek)
         } else {
+            #[cfg(feature = "pqc-experimental")]
+            if header.alg == ML_KEM_768_A192KW_ALGORITHM {
+                let ek_b64 = header
+                    .other_fields
+                    .get("ek")
+                    .ok_or(anyhow!("Invalid JWE ProtectedHeader. Without `ek`"))?
+                    .as_str()
+                    .ok_or(anyhow!("Invalid JWE ProtectedHeader. `ek` is not a string"))?;
+
+                let kem_ciphertext = URL_SAFE_NO_PAD
+                    .decode(ek_b64)
+                    .context("base64url decode `ek` failed")?;
+
+                let TeeKey::Akp(key) = &self.key else {
+                    bail!("Unmatched key. Must be AKP key");
+                };
+
+                return key.decapsulate_and_unwrap(&kem_ciphertext, &wrapped_cek);
+            }
+
             bail!("Unsupported algorithm: {}", header.alg)
         }
     }
@@ -165,6 +217,8 @@ impl TeeKeyPair {
         match &self.key {
             TeeKey::Rsa(keypair) => keypair.to_pkcs1_pem(),
             TeeKey::Ec(keypair) => keypair.to_pkcs8_pem(),
+            #[cfg(feature = "pqc-experimental")]
+            TeeKey::Akp(_) => bail!("PEM serialization is not supported for AKP keys"),
         }
     }
 
@@ -232,5 +286,90 @@ mod tests {
         let rsa_oaep256: TeeKeyAlgorithm =
             serde_json::from_str("\"RSA-OAEP-256\"").expect("RSA-OAEP-256 algorithm should parse");
         assert_eq!(rsa_oaep256, TeeKeyAlgorithm::RsaOaep256);
+    }
+}
+
+#[cfg(all(test, feature = "pqc-experimental"))]
+mod pqc_tests {
+    use super::*;
+    use crate::akp::{kmac256_kdf, ML_KEM_768_A192KW_ALGORITHM};
+    use aes_kw::{KeyInit, KwAes192};
+    use ml_kem::{Encapsulate, EncapsulationKey, Key, MlKem768};
+
+    #[test]
+    fn deserialize_ml_kem_algorithm() {
+        let algo: TeeKeyAlgorithm = serde_json::from_str("\"ML-KEM-768+A192KW\"")
+            .expect("ML-KEM-768+A192KW algorithm should parse");
+        assert_eq!(algo, TeeKeyAlgorithm::MlKem768A192Kw);
+    }
+
+    #[test]
+    fn new_with_akp_exports_akp_jwk() {
+        let keypair = TeeKeyPair::new_with_algorithm(TeeKeyAlgorithm::MlKem768A192Kw)
+            .expect("new AKP keypair");
+        let TeePubKey::AKP { alg, public_key } = keypair.export_pubkey().expect("export pubkey")
+        else {
+            panic!("expected AKP variant");
+        };
+        assert_eq!(alg, ML_KEM_768_A192KW_ALGORITHM);
+        // Encap key is 1184 bytes → base64url with no padding is 1579 chars.
+        assert_eq!(public_key.len(), 1579);
+    }
+
+    #[test]
+    fn to_pem_errors_for_akp() {
+        let keypair = TeeKeyPair::new_with_algorithm(TeeKeyAlgorithm::MlKem768A192Kw)
+            .expect("new AKP keypair");
+        let err = keypair
+            .to_pem()
+            .expect_err("AKP has no PEM format in phase 1");
+        assert!(err.to_string().contains("AKP"));
+    }
+
+    /// Build a `ProtectedHeader` + wrapped CEK as the server would emit
+    /// (encapsulate to our pubkey, derive KWK via the shared KDF, AES-KW
+    /// wrap a known CEK, base64url the KEM ciphertext into `ek`), then
+    /// confirm `TeeKeyPair::unwrap_cek` returns the same CEK. Exercises
+    /// the new AKP arm in `unwrap_cek` end-to-end.
+    #[test]
+    fn unwrap_cek_for_ml_kem_response() {
+        let keypair = TeeKeyPair::new_with_algorithm(TeeKeyAlgorithm::MlKem768A192Kw)
+            .expect("new AKP keypair");
+        let TeeKey::Akp(akp_keypair) = &keypair.key else {
+            panic!("expected AKP variant");
+        };
+
+        // Simulate the server: parse our own public key as an encap key.
+        let pub_bytes = akp_keypair.public_key_bytes();
+        let ek_typed: &Key<EncapsulationKey<MlKem768>> = pub_bytes.as_slice().try_into().unwrap();
+        let encap_key = EncapsulationKey::<MlKem768>::new(ek_typed).unwrap();
+        let (kem_ciphertext, shared_secret) = encap_key.encapsulate();
+
+        // Same KDF the client side uses on decrypt — guarantees the wrap
+        // key matches.
+        let kwk = kmac256_kdf(shared_secret.as_slice(), ML_KEM_768_A192KW_ALGORITHM, 24).unwrap();
+        let kwk: [u8; 24] = kwk.try_into().unwrap();
+
+        // Wrap a known CEK.
+        let cek_orig: [u8; 32] = [0xAB; 32];
+        let wrapper = KwAes192::new_from_slice(&kwk).unwrap();
+        let mut wrapped_cek = vec![0u8; 40];
+        wrapper.wrap_key(&cek_orig, &mut wrapped_cek).unwrap();
+
+        // Build the ProtectedHeader as the server emits.
+        let ek_b64 = URL_SAFE_NO_PAD.encode(kem_ciphertext.as_slice());
+        let header = ProtectedHeader {
+            alg: ML_KEM_768_A192KW_ALGORITHM.to_string(),
+            enc: "A256GCM".to_string(),
+            other_fields: serde_json::json!({ "ek": ek_b64 })
+                .as_object()
+                .unwrap()
+                .clone(),
+        };
+
+        let cek = keypair
+            .unwrap_cek(&header, wrapped_cek)
+            .expect("unwrap CEK");
+        assert_eq!(cek.as_slice(), &cek_orig[..]);
     }
 }

--- a/attestation-agent/kbs_protocol/src/lib.rs
+++ b/attestation-agent/kbs_protocol/src/lib.rs
@@ -70,6 +70,8 @@
 //! Note: everytime the token is found expired, the client will call the
 //! `token_provider` to retrieve a new token.
 
+#[cfg(feature = "pqc-experimental")]
+pub mod akp;
 pub mod api;
 pub mod builder;
 pub mod client;


### PR DESCRIPTION
This is the initial draft implementation to enable PQC algorithm support across CoCo and relates to [issue 1271](https://github.com/confidential-containers/trustee/issues/1271) raised on the Trustee repo.

These changes reflect those required on the guest side, and is enabled via a compile time feature flag.

A draft PR for the Trustee is in progress at [PR 1383](https://github.com/confidential-containers/trustee/pull/1383)

A test client is included at attestation-agent/kbs_protocol/examples/akp_get_resource. The following screen captures show the successful retrieval of a resource using new PQC workflows. Included with this can be seen a capture from Wireshark showing the PQC encapsulation public key in the request payload for attestation.

This is a proof of concept. Once this and the Trustee changes have been reviewed and accepted, further work can be undertaken to add the changes to the kbs-types and reflect the changes back into the type references in this and the Trustee repository so this can be introduced fully as an experimental feature.


<img width="1270" height="149" alt="test_client" src="https://github.com/user-attachments/assets/70bf07f9-ff95-4b7a-86a0-eaf95c8c81a1" />
<img width="549" height="272" alt="wireshark" src="https://github.com/user-attachments/assets/a46aca5d-7c32-4de3-8a96-0d9fe66b30b4" />
