### PR TITLE
evidence_getter: TPM report data size to 32 bytes

### DIFF
--- a/attestation-agent/attester/README.md
+++ b/attestation-agent/attester/README.md
@@ -26,6 +26,7 @@ echo $EVIDENCE_STRING | ../../target/release/evidence_getter stdio
 ```
 
 Here, `$EVIDENCE_STRING` is a string/bytes of up to 64 bytes.
+(Some platforms may impose platform-specific limits on evidence)
 
 ## Adding TPM quote to evidence
 

--- a/attestation-agent/attester/src/bin/evidence_getter.rs
+++ b/attestation-agent/attester/src/bin/evidence_getter.rs
@@ -25,6 +25,14 @@ enum Cli {
     File { path: String },
 }
 
+/// Some CPU TEE platforms may impose platform-specific limits on report_data.
+fn adjust_report_data(tee: Tee, report_data: &[u8]) -> Vec<u8> {
+    match tee {
+        Tee::AzSnpVtpm | Tee::AzTdxVtpm => report_data[..report_data.len().min(32)].to_vec(),
+        _ => report_data.to_vec(),
+    }
+}
+
 #[tokio::main(flavor = "current_thread")]
 async fn main() {
     let env_filter = match std::env::var_os("RUST_LOG") {
@@ -60,14 +68,10 @@ async fn main() {
         }
     }
 
-    // Some platforms may impose platform-specific limits on report_data.
-    if let Tee::AzSnpVtpm | Tee:AzTdxVtpm = detect_tee_type() {
-       report_data.truncate(32);
-    }
-
-    let evidence = TryInto::<BoxedAttester>::try_into(detect_tee_type())
+    let tee = detect_tee_type();
+    let evidence = TryInto::<BoxedAttester>::try_into(tee)
         .expect("Failed to initialize attester.")
-        .get_evidence(report_data.clone())
+        .get_evidence(adjust_report_data(tee, &report_data))
         .await
         .expect("get evidence failed");
     println!("{:?}:{evidence}", detect_tee_type());

--- a/attestation-agent/attester/src/bin/evidence_getter.rs
+++ b/attestation-agent/attester/src/bin/evidence_getter.rs
@@ -61,12 +61,9 @@ async fn main() {
     }
 
     // Some platforms may impose platform-specific limits on report_data.
-    report_data = match detect_tee_type() {
-        Tee::AzSnpVtpm => report_data[..32].to_vec(),
-        Tee::AzTdxVtpm => report_data[..32].to_vec(),
-        _ => report_data.clone(),
-    };
-
+    if let Tee::AzSnpVtpm | Tee:AzTdxVtpm = detect_tee_type() {
+       report_data.truncate(32);
+    }
 
     let evidence = TryInto::<BoxedAttester>::try_into(detect_tee_type())
         .expect("Failed to initialize attester.")

--- a/attestation-agent/attester/src/bin/evidence_getter.rs
+++ b/attestation-agent/attester/src/bin/evidence_getter.rs
@@ -5,6 +5,7 @@
 
 use attester::{detect_attestable_devices, detect_tee_type, BoxedAttester};
 use clap::Parser;
+use kbs_types::Tee;
 use std::io::Read;
 use tokio::fs;
 use tracing_subscriber::{fmt, EnvFilter};
@@ -36,7 +37,6 @@ async fn main() {
         .with_writer(std::io::stderr)
         .init();
 
-    // report_data on all platforms is 64 bytes length.
     let mut report_data = vec![0u8; 64];
 
     let cli = Cli::parse();
@@ -57,6 +57,14 @@ async fn main() {
             report_data[..len].copy_from_slice(&content[..len]);
         }
     }
+
+    // Some platforms may impose platform-specific limits on report_data.
+    report_data = match detect_tee_type() {
+        Tee::AzSnpVtpm => report_data[..32].to_vec(),
+        Tee::AzTdxVtpm => report_data[..32].to_vec(),
+        _ => report_data.clone(),
+    };
+
 
     let evidence = TryInto::<BoxedAttester>::try_into(detect_tee_type())
         .expect("Failed to initialize attester.")

--- a/attestation-agent/attester/src/bin/evidence_getter.rs
+++ b/attestation-agent/attester/src/bin/evidence_getter.rs
@@ -42,9 +42,11 @@ async fn main() {
     let cli = Cli::parse();
 
     match cli {
-        Cli::Stdio => std::io::stdin()
-            .read_exact(&mut report_data)
-            .expect("read input failed"),
+        Cli::Stdio => {
+            std::io::stdin()
+                .read(&mut report_data)
+                .expect("read input failed");
+        }
         Cli::Commandline { data } => {
             let len = data.len().min(64);
             report_data[..len].copy_from_slice(&data.as_bytes()[..len]);


### PR DESCRIPTION
Failed to execute `evidence_getter` in Azure CVM + SEV-SNP.(main branch. `499658b307c39040efc009563737987c47a1dd63`)

```
$ printf 'z%.zs' {1..64} | sudo ../../target/release/evidence_getter stdio
2026-06-01T04:51:06.557666Z  INFO tss_esapi::context: Closing context.
2026-06-01T04:51:06.557745Z  INFO tss_esapi::context: Context closed.
2026-06-01T04:51:06.559679Z  INFO tss_esapi::context: Closing context.
2026-06-01T04:51:06.559716Z  INFO tss_esapi::context: Context closed.
WARNING:esys:src/tss2-esys/api/Esys_Quote.c:317:Esys_Quote_Finish() Received TPM Error
ERROR:esys:src/tss2-esys/api/Esys_Quote.c:105:Esys_Quote() Esys Finish ErrorCode (0x000001d5)
2026-06-01T04:51:06.560832Z ERROR tss_esapi::context::tpm_commands::attestation_commands: Error in quoting PCR: structure is the wrong size (associated with parameter number 1)
2026-06-01T04:51:06.560849Z  INFO tss_esapi::context: Closing context.
2026-06-01T04:51:06.560856Z  INFO tss_esapi::context: Closing handle 1075766378
2026-06-01T04:51:06.560862Z  INFO tss_esapi::context: Context closed.

thread 'main' panicked at attestation-agent/attester/src/bin/evidence_getter.rs:65:10:
get evidence failed: tpm error

Caused by:
    0: structure is the wrong size (associated with parameter number 1)
    1: structure is the wrong size (associated with parameter number 1)
    2: Response code value: 0x1d5
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

Truncate to 32 bytes because az-snp-vtpm v0.8.1 only supports SHA-256. <https://github.com/kinvolk/azure-cvm-tooling/blob/v0.8.1/az-cvm-vtpm/src/vtpm/mod.rs#L348>

This patch seems to fix the issue.

```
$ cargo build --no-default-features --features bin,az-snp-vtpm-attester --bin evidence_getter --release
   Compiling attester v0.1.0 (/home/azureuser/guest-components/attestation-agent/attester)
    Finished `release` profile [optimized] target(s) in 5.25s
[azureuser@coco-test attester]$ printf 'z%.zs' {1..64} | sudo ../../target/release/evidence_getter stdio
...
AzSnpVtpm:{"hcl_report":"SENM...
```

See also 79554cf88d1d2e85f480de5aae91d2a26990b91b.
