### PR TITLE
chore(deps):update openssl to v0.10.81 to fix CVE-2026-45784

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4811,9 +4811,9 @@ dependencies = [
 
 [[package]]
 name = "openssl"
-version = "0.10.80"
+version = "0.10.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a45fa2aa886c42762255da344f0a0d313e254066c46aad76f300c3d3da62d967"
+checksum = "77823a27f0babb03091cb9ed9ef80af3b39dbc82f97e8fa530374b7dafd87a45"
 dependencies = [
  "bitflags 2.11.1",
  "cfg-if",
@@ -4857,9 +4857,9 @@ dependencies = [
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.116"
+version = "0.9.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f28a22dc7140cda5f096e5e7724a6962ca81a7f8bfd2979f9b18c11af56318c4"
+checksum = "b47e7e6bb2c38cd930d25a23b40fa52e068c10e85f3e03a7f5ba5aaca5713695"
 dependencies = [
  "cc",
  "libc",


### PR DESCRIPTION
Update openssl dependency from 0.10.x to 0.10.81 in workspace
Cargo.toml to address security vulnerability CVE-2026-45784.

This update applies to all workspace members that depend on openssl:
- ocicrypt-rs
- attestation-agent/deps/crypto
- confidential-data-hub/kms

The cargo update also upgraded openssl-sys from v0.9.116 to v0.9.117.