### PR TITLE
attester: nvidia: serialize Architecture UPPERCASE

### DIFF
--- a/attestation-agent/attester/src/nvidia/mod.rs
+++ b/attestation-agent/attester/src/nvidia/mod.rs
@@ -35,6 +35,7 @@ fn ensure_sdk_init() -> Result<()> {
 }
 
 #[derive(Debug, Deserialize, Display, EnumString, PartialEq, Serialize)]
+#[serde(rename_all(serialize = "UPPERCASE"))]
 #[strum(ascii_case_insensitive)]
 enum Architecture {
     #[serde(alias = "BLACKWELL")]


### PR DESCRIPTION
WDYT? I had a hiccup with Trustee/ITA since I only used test data that had UPPERCASE Arch. NRAS needs it so maybe use uppercase consistently (the same change could be made on nvidia-verifier side)? 

--- 
Trustee/ITA fails with nvidia-attester originated evidence because device architecture is not UPPERCASE.

While this could be fixed in Trustee/ITA by making everything case insensitive, the observation is that nvidia handles this UPPERCASE end to end. Therefore, keep Archicture UPPERCASE between nvidia-attester and Trustee as well.