### PR TITLE
Fix cdh not extend runtime measurement of PullImage

### DIFF
--- a/confidential-data-hub/hub/src/hub.rs
+++ b/confidential-data-hub/hub/src/hub.rs
@@ -185,13 +185,13 @@ async fn initialize_aa_client() -> Result<Option<AttestationAgentServiceClient>>
     use anyhow::anyhow;
 
     const AA_SOCKET_FILE: &str =
-        "unix:///run/confidential-containers/attestation-agent/attestation-agent.sock";
+        "/run/confidential-containers/attestation-agent/attestation-agent.sock";
 
     if !Path::new(AA_SOCKET_FILE).exists() {
         return Ok(None);
     }
 
-    let c = ttrpc::r#async::Client::connect(AA_SOCKET_FILE)
+    let c = ttrpc::r#async::Client::connect(&format!("unix://{AA_SOCKET_FILE}"))
         .await
         .map_err(|e| Error::AttestationAgentClientError {
             source: anyhow!("failed to connect to attestation agent: {e:?}"),


### PR DESCRIPTION
confidential-data-hub failed to extend runtime measurement while pulling image about image infomation. Because of wrong prefix in front of the aa socket file, cdh failed to initialize aa client.