### PR TITLE
deps: upgrade anyhow 1.0.102 → 1.0.103

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -195,9 +195,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "api-server-rest"


### PR DESCRIPTION
RUSTSEC-2026-0190 was reported against anyhow 1.0 and fixed in 1.0.103. Update Cargo.lock to resolve to the patched version.

Assisted-by: IBM Bob <noreply@ibm.com>