### PR TITLE
asr: bump hyper minimum version 0.14.27 → 0.14.32

### DIFF
--- a/api-server-rest/Cargo.toml
+++ b/api-server-rest/Cargo.toml
@@ -11,7 +11,7 @@ async-trait.workspace = true
 base64.workspace = true
 clap = { workspace = true, features = ["derive"] }
 form_urlencoded = "1.2.2"
-hyper = { version = "0.14.27", features = ["server", "http1", "runtime"] }
+hyper = { version = "0.14.32", features = ["server", "http1", "runtime"] }
 serde.workspace = true
 serde_json.workspace = true
 shadow-rs.workspace = true


### PR DESCRIPTION
CVE-2021-32714, CVE-2021-32715 and RUSTSEC-2022-0022 were fixed in hyper 0.14.10/0.14.12. Raise the lower bound to reflect the currently resolved version.

Assisted-by: IBM Bob <noreply@ibm.com>