### PR TITLE
coco-extension: build and ship the kata coco-extension image

### DIFF
--- a/.github/workflows/coco-extension-image.yml
+++ b/.github/workflows/coco-extension-image.yml
@@ -1,0 +1,289 @@
+name: Build and publish the CoCo guest extension image
+
+# Builds the "coco-extension" image (kata-containers-coco-extension.img) that
+# packages the guest components as a kata composable guest extension.
+#
+# Two artifacts are produced per architecture from the same assembled rootfs:
+#   * an OCI container image (scratch-based, rootfs + components.toml manifest)
+#   * an EROFS + dm-verity disk image (+ its dm-verity root hash), using the
+#     same layout as kata's rootfs-image-coco-extension asset.
+#
+# On pull requests everything is built and uploaded as workflow artifacts (no
+# registry push). On pushes to main the artifacts are published to ghcr.io
+# (tagged with the commit sha and "latest") and attested. On a published
+# release the same artifacts are published tagged with the release version, the
+# multi-arch manifests get the version tag, and the per-arch disk images and
+# their dm-verity root hashes are attached to the GitHub release so consumers
+# (e.g. kata-containers) can pin to a stable version.
+on:
+  pull_request:
+  push:
+    branches:
+    - main
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+env:
+  REGISTRY: ghcr.io
+  # OCI container image flavour.
+  CONTAINER_IMAGE: ghcr.io/${{ github.repository }}/coco-extension
+  # EROFS + dm-verity disk image flavour.
+  DISK_IMAGE: ghcr.io/${{ github.repository }}/coco-extension-disk
+  # Pause image bundled into the extension (kept in sync with kata versions.yaml).
+  # This is transitional: we still unpack registry.k8s.io/pause into pause_bundle/
+  # because kata's rootfs-image-coco-extension asset and components.toml contract
+  # expect the extension to ship the pause bundle (kata-agent resolves
+  # "pause-bundle" from /run/kata-extensions/coco). It will be dropped once kata
+  # stops baking pause into the coco extension.
+  PAUSE_IMAGE_REPO: docker://registry.k8s.io/pause
+  PAUSE_IMAGE_VERSION: "3.10"
+  NVAT_VERSION: "2026.03.02"
+  UMOCI_VERSION: v0.6.0
+
+jobs:
+  build:
+    name: build (${{ matrix.arch }})
+    permissions:
+      contents: write # needed to upload disk images to the GitHub release
+      packages: write
+      id-token: write
+      attestations: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+        - arch: x86_64
+          oci_arch: amd64
+          libc: musl
+          attester: snp-attester,tdx-attester
+          measured_rootfs: "yes"
+          runner: ubuntu-24.04
+        - arch: aarch64
+          oci_arch: arm64
+          libc: gnu
+          attester: cca-attester
+          measured_rootfs: "yes"
+          runner: ubuntu-24.04-arm
+        - arch: s390x
+          oci_arch: s390x
+          libc: gnu
+          attester: se-attester
+          measured_rootfs: "no"
+          runner: s390x
+    runs-on: ${{ matrix.runner }}
+    env:
+      ARCH: ${{ matrix.arch }}
+      LIBC: ${{ matrix.libc }}
+      ATTESTER: ${{ matrix.attester }}
+      # "kbs" enables cc_kbc, the KBS resource provider used on every arch.
+      RESOURCE_PROVIDER: kbs
+      MEASURED_ROOTFS: ${{ matrix.measured_rootfs }}
+      RUST_TARGET: ${{ matrix.arch }}-unknown-linux-${{ matrix.libc }}
+    steps:
+    - name: Harden the runner (Audit all outbound calls)
+      uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+      with:
+        egress-policy: audit
+
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+    - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
+      with:
+        target: ${{ env.RUST_TARGET }}
+        # This action injects RUSTFLAGS="-D warnings" by default, which leaks
+        # into every cargo invocation in the job — including third-party crates
+        # built from source by the NVIDIA Attestation SDK (its vendored regorus
+        # fails on the mismatched_lifetime_syntaxes lint) and our own component
+        # build. We only want to build here, not gate on warnings, so clear it.
+        rustflags: ""
+
+    - name: Install build tooling
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y --no-install-recommends \
+          build-essential clang cmake pkg-config protobuf-compiler \
+          libssl-dev libtss2-dev libdevmapper-dev musl-tools \
+          cryptsetup-bin erofs-utils libclang-dev libxml2-dev parted skopeo zlib1g-dev
+        # umoci is used to unpack the pause image into an OCI runtime bundle.
+        # Prebuilt binaries exist for every architecture in the matrix.
+        sudo curl -fsSL -o /usr/local/bin/umoci \
+          "https://github.com/opencontainers/umoci/releases/download/${UMOCI_VERSION}/umoci.linux.${{ matrix.oci_arch }}"
+        sudo chmod +x /usr/local/bin/umoci
+
+    - name: Install NVIDIA Attestation SDK
+      if: ${{ matrix.arch == 'x86_64' }}
+      run: |
+        tmpdir="$(mktemp -d)"
+        git clone https://github.com/NVIDIA/attestation-sdk "${tmpdir}/attestation-sdk"
+        git -C "${tmpdir}/attestation-sdk" fetch --depth=1 origin "${NVAT_VERSION}"
+        git -C "${tmpdir}/attestation-sdk" checkout FETCH_HEAD
+        cmake -S "${tmpdir}/attestation-sdk/nv-attestation-sdk-cpp" \
+          -B "${tmpdir}/attestation-sdk/nv-attestation-sdk-cpp/build" \
+          -DCMAKE_BUILD_TYPE=Release
+        cmake --build "${tmpdir}/attestation-sdk/nv-attestation-sdk-cpp/build" --parallel "$(nproc)"
+        sudo cmake --install "${tmpdir}/attestation-sdk/nv-attestation-sdk-cpp/build"
+        # The nv-attestation-sdk-sys build script looks for the C header at
+        # /usr/include/nvat.h, but cmake installs it under /usr/local/include.
+        # Symlink it (matches kata's coco-guest-components builder).
+        sudo mkdir -p /usr/include
+        sudo ln -sf /usr/local/include/nvat.h /usr/include/nvat.h
+        sudo ldconfig
+        rm -rf "${tmpdir}"
+
+    - name: Assemble extension rootfs
+      run: ./tools/coco-extension/assemble-rootfs.sh
+
+    - name: Build OCI container image
+      run: |
+        docker build \
+          -f tools/coco-extension/Dockerfile \
+          -t "${CONTAINER_IMAGE}:${{ github.sha }}-${{ matrix.oci_arch }}" \
+          build/coco-extension-rootfs
+
+    - name: Build EROFS + dm-verity disk image
+      run: ./tools/coco-extension/build-erofs-image.sh
+
+    # --- Pull request: build only, upload artifacts, no registry push ---------
+    - name: Save OCI image for artifact upload
+      if: ${{ github.event_name == 'pull_request' }}
+      run: |
+        mkdir -p build/artifacts
+        docker save "${CONTAINER_IMAGE}:${{ github.sha }}-${{ matrix.oci_arch }}" \
+          -o "build/artifacts/coco-extension-oci-${{ matrix.oci_arch }}.tar"
+        cp build/coco-extension-image/kata-containers-coco-extension.img \
+          "build/artifacts/kata-containers-coco-extension-${{ matrix.oci_arch }}.img"
+        if [ -f build/coco-extension-image/root_hash_coco-extension.txt ]; then
+          cp build/coco-extension-image/root_hash_coco-extension.txt \
+            "build/artifacts/root_hash_coco-extension-${{ matrix.oci_arch }}.txt"
+        fi
+
+    - name: Upload artifacts
+      if: ${{ github.event_name == 'pull_request' }}
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      with:
+        name: coco-extension-${{ matrix.oci_arch }}
+        path: build/artifacts/
+        retention-days: 15
+        if-no-files-found: error
+
+    # --- Push to main / release: publish to ghcr.io and attest ----------------
+    # The immutable per-arch reference is always "<sha>-<arch>"; the friendly
+    # tags (latest, or the release version) are assembled into multi-arch
+    # manifests in the publish-manifests job below.
+    - name: Log in to the Container registry
+      if: ${{ github.event_name != 'pull_request' }}
+      uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v3.6.0
+      with:
+        registry: ${{ env.REGISTRY }}
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - uses: oras-project/setup-oras@38de303aac69abb66f3e6255b7198bff35f323e3 # v2.0.0
+      if: ${{ github.event_name != 'pull_request' }}
+      with:
+        version: 1.2.0
+
+    - name: Publish OCI container image
+      id: publish-container
+      if: ${{ github.event_name != 'pull_request' }}
+      run: |
+        arch_tag="${{ github.sha }}-${{ matrix.oci_arch }}"
+        docker push "${CONTAINER_IMAGE}:${arch_tag}"
+        digest="$(docker inspect --format='{{index .RepoDigests 0}}' "${CONTAINER_IMAGE}:${arch_tag}" | cut -d'@' -f2)"
+        echo "image=${CONTAINER_IMAGE}" >> "$GITHUB_OUTPUT"
+        echo "digest=${digest}" >> "$GITHUB_OUTPUT"
+
+    - name: Publish disk image with ORAS
+      id: publish-disk
+      if: ${{ github.event_name != 'pull_request' }}
+      working-directory: build/coco-extension-image
+      run: |
+        arch_tag="${{ github.sha }}-${{ matrix.oci_arch }}"
+        files=(kata-containers-coco-extension.img)
+        if [ -f root_hash_coco-extension.txt ]; then
+          files+=(root_hash_coco-extension.txt)
+        fi
+        oras push "${DISK_IMAGE}:${arch_tag}" \
+          --artifact-type application/vnd.confidential-containers.coco-extension.disk \
+          "${files[@]}"
+        digest="$(oras manifest fetch "${DISK_IMAGE}:${arch_tag}" --descriptor | jq -r .digest)"
+        echo "image=${DISK_IMAGE}" >> "$GITHUB_OUTPUT"
+        echo "digest=${digest}" >> "$GITHUB_OUTPUT"
+
+    - name: Generate provenance for the OCI container image
+      if: ${{ github.event_name != 'pull_request' }}
+      uses: actions/attest@a1948c3f048ba23858d222213b7c278aabede763 # v4.1.1
+      with:
+        subject-name: ${{ steps.publish-container.outputs.image }}
+        subject-digest: ${{ steps.publish-container.outputs.digest }}
+        push-to-registry: true
+
+    - name: Generate provenance for the disk image
+      if: ${{ github.event_name != 'pull_request' }}
+      uses: actions/attest@a1948c3f048ba23858d222213b7c278aabede763 # v4.1.1
+      with:
+        subject-name: ${{ steps.publish-disk.outputs.image }}
+        subject-digest: ${{ steps.publish-disk.outputs.digest }}
+        push-to-registry: true
+
+    # --- Release only: attach the per-arch disk image and root hash -----------
+    - name: Attach disk image to the GitHub release
+      if: ${{ github.event_name == 'release' }}
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        RELEASE_TAG: ${{ github.event.release.tag_name }}
+      working-directory: build/coco-extension-image
+      run: |
+        cp kata-containers-coco-extension.img \
+          "kata-containers-coco-extension-${{ matrix.oci_arch }}.img"
+        assets=("kata-containers-coco-extension-${{ matrix.oci_arch }}.img")
+        if [ -f root_hash_coco-extension.txt ]; then
+          cp root_hash_coco-extension.txt \
+            "root_hash_coco-extension-${{ matrix.oci_arch }}.txt"
+          assets+=("root_hash_coco-extension-${{ matrix.oci_arch }}.txt")
+        fi
+        gh release upload "${RELEASE_TAG}" "${assets[@]}" --clobber
+
+  publish-manifests:
+    name: publish multi-arch manifests
+    if: ${{ github.event_name != 'pull_request' }}
+    needs: build
+    permissions:
+      contents: read
+      packages: write
+    runs-on: ubuntu-24.04
+    steps:
+    - name: Harden the runner (Audit all outbound calls)
+      uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+      with:
+        egress-policy: audit
+
+    - name: Log in to the Container registry
+      uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v3.6.0
+      with:
+        registry: ${{ env.REGISTRY }}
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Assemble multi-arch manifests
+      env:
+        # On push to main: the commit sha plus the rolling "latest" tag.
+        # On release: the commit sha plus the immutable release version, so
+        # consumers can pin to it.
+        EXTRA_TAG: ${{ github.event_name == 'release' && github.event.release.tag_name || 'latest' }}
+      run: |
+        for image in "${CONTAINER_IMAGE}" "${DISK_IMAGE}"; do
+          for tag in "${{ github.sha }}" "${EXTRA_TAG}"; do
+            docker manifest create "${image}:${tag}" \
+              --amend "${image}:${{ github.sha }}-amd64" \
+              --amend "${image}:${{ github.sha }}-arm64" \
+              --amend "${image}:${{ github.sha }}-s390x"
+            docker manifest annotate --arch amd64 --os linux "${image}:${tag}" "${image}:${{ github.sha }}-amd64"
+            docker manifest annotate --arch arm64 --os linux "${image}:${tag}" "${image}:${{ github.sha }}-arm64"
+            docker manifest annotate --arch s390x --os linux "${image}:${tag}" "${image}:${{ github.sha }}-s390x"
+            docker manifest push "${image}:${tag}"
+          done
+        done

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /target
+/build
 
 .DS_Store
 

--- a/tools/coco-extension/Dockerfile
+++ b/tools/coco-extension/Dockerfile
@@ -1,0 +1,27 @@
+# Copyright (c) 2026 Confidential Containers contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# OCI container image flavour of the CoCo guest extension.
+#
+# The build context MUST be the assembled extension rootfs produced by
+# assemble-rootfs.sh, e.g.:
+#
+#   ./assemble-rootfs.sh
+#   docker build \
+#     -f tools/coco-extension/Dockerfile \
+#     -t ghcr.io/confidential-containers/guest-components/coco-extension:dev \
+#     build/coco-extension-rootfs
+#
+# The image is intentionally scratch-based: it carries only the extension
+# payload (guest-component binaries, ocicrypt config, components.toml manifest
+# and the pause bundle) with no base OS. Consumers either use the layers
+# directly or convert the image into an EROFS + dm-verity extension disk image.
+FROM scratch
+
+LABEL org.opencontainers.image.title="CoCo guest extension" \
+      org.opencontainers.image.description="Confidential Containers guest components packaged as a kata composable guest extension" \
+      org.opencontainers.image.source="https://github.com/confidential-containers/guest-components" \
+      org.opencontainers.image.licenses="Apache-2.0"
+
+COPY . /

--- a/tools/coco-extension/assemble-rootfs.sh
+++ b/tools/coco-extension/assemble-rootfs.sh
@@ -1,0 +1,240 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2026 Confidential Containers contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Assemble the CoCo guest extension rootfs.
+#
+# The rootfs produced here is the payload of the "coco-extension" image
+# (kata-containers-coco-extension.img). It is consumed in two ways:
+#
+#   * packed into a "FROM scratch" OCI container image (see Dockerfile), and
+#   * turned into an EROFS + dm-verity disk image (see build-erofs-image.sh).
+#
+# The layout mirrors what kata-containers' kata-deploy-binaries.sh
+# (install_image_coco_extension) produces, so the resulting image is a drop-in
+# for kata's own rootfs-image-coco-extension asset:
+#
+#   usr/local/bin/attestation-agent
+#   usr/local/bin/confidential-data-hub
+#   usr/local/bin/api-server-rest
+#   usr/local/bin/attestation-agent-nv (x86_64, when NVIDIA SDK is available)
+#   usr/local/lib/libnvat.so*
+#   etc/ocicrypt_config.json
+#   etc/kata-extensions/components.toml
+#   usr/sbin/cryptsetup
+#   pause_bundle/...
+#
+set -o errexit
+set -o nounset
+set -o pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root_dir="$(cd "${script_dir}/../.." && pwd)"
+
+# Target selection. Defaults match a native x86_64 build; the CI workflow
+# overrides these per architecture.
+ARCH="${ARCH:-$(uname -m)}"
+LIBC="${LIBC:-musl}"
+
+# Attesters and resource providers compiled into the guest components. These are
+# architecture specific (e.g. tdx/snp attesters only build on x86_64, se-attester
+# only on s390x), so the caller is expected to set ATTESTER accordingly.
+ATTESTER="${ATTESTER:-none}"
+NV_ATTESTER="${NV_ATTESTER:-${ATTESTER},nvidia-attester}"
+RESOURCE_PROVIDER="${RESOURCE_PROVIDER:-kbs}"
+INCLUDE_NVIDIA_ATTESTER="${INCLUDE_NVIDIA_ATTESTER:-auto}"
+INCLUDE_CRYPTSETUP="${INCLUDE_CRYPTSETUP:-yes}"
+NVAT_LIB_DIR="${NVAT_LIB_DIR:-/usr/local/lib}"
+
+# TEE_PLATFORM is intentionally left empty so the top-level Makefile does not
+# override the ATTESTER/RESOURCE_PROVIDER values passed in the environment. This
+# mirrors kata's build-static-coco-guest-components.sh.
+TEE_PLATFORM="${TEE_PLATFORM:-}"
+
+# Pause image to bundle. Kept in sync with kata's versions.yaml (.externals.pause).
+PAUSE_IMAGE_REPO="${PAUSE_IMAGE_REPO:-docker://registry.k8s.io/pause}"
+PAUSE_IMAGE_VERSION="${PAUSE_IMAGE_VERSION:-3.10}"
+
+# Where to assemble the rootfs. Must be writable and is also used as the OCI
+# image build context.
+ROOTFS_DIR="${ROOTFS_DIR:-${repo_root_dir}/build/coco-extension-rootfs}"
+
+info() { echo "[assemble-rootfs] $*"; }
+die() { echo "[assemble-rootfs] ERROR: $*" >&2; exit 1; }
+
+# The top-level Makefile remaps ppc64le -> powerpc64le for the rust target
+# triple; mirror that so BUILD_DIR below points at the right place.
+rust_arch="${ARCH}"
+[[ "${rust_arch}" == "ppc64le" ]] && rust_arch="powerpc64le"
+
+build_dir="${repo_root_dir}/target/${rust_arch}-unknown-linux-${LIBC}/release"
+
+build_guest_components() {
+	info "Building guest components (ARCH=${ARCH} LIBC=${LIBC} ATTESTER=${ATTESTER})"
+
+	make -C "${repo_root_dir}" build \
+		TEE_PLATFORM="${TEE_PLATFORM}" \
+		ARCH="${ARCH}" \
+		LIBC="${LIBC}" \
+		ATTESTER="${ATTESTER}" \
+		RESOURCE_PROVIDER="${RESOURCE_PROVIDER}"
+
+	# Strip to keep the extension image small; the debug info is not shippable.
+	local strip_bin="strip"
+	command -v "${strip_bin}" >/dev/null 2>&1 || die "strip not found"
+	for bin in confidential-data-hub attestation-agent api-server-rest; do
+		"${strip_bin}" "${build_dir}/${bin}"
+	done
+}
+
+copy_non_glibc_library_closure() {
+	local lib="$1"
+	local dest_dir="${ROOTFS_DIR}/usr/local/lib"
+	local dep
+	local dep_path
+	local dep_name
+
+	mkdir -p "${dest_dir}"
+
+	while read -r dep; do
+		if [[ "${dep}" == *"=>"* ]]; then
+			dep_path="${dep#*=> }"
+			dep_path="${dep_path%% *}"
+		else
+			dep_path="${dep%% *}"
+		fi
+
+		[[ "${dep_path}" == /* ]] || continue
+		[[ -f "${dep_path}" ]] || continue
+
+		dep_name="$(basename "${dep_path}")"
+		case "${dep_name}" in
+			ld-linux-*|libc.so.*|libdl.so.*|libm.so.*|libpthread.so.*|librt.so.*)
+				continue
+				;;
+		esac
+
+		cp -a "${dep_path}" "${dest_dir}/"
+	done < <(ldd "${lib}")
+}
+
+build_nvidia_attestation_agent() {
+	case "${INCLUDE_NVIDIA_ATTESTER}" in
+		yes) ;;
+		no) return 0 ;;
+		auto)
+			if [[ "${ARCH}" != "x86_64" ]]; then
+				info "Skipping NVIDIA attester variant on ${ARCH}"
+				return 0
+			fi
+			;;
+		*) die "unsupported INCLUDE_NVIDIA_ATTESTER=${INCLUDE_NVIDIA_ATTESTER}" ;;
+	esac
+
+	[[ -e "${NVAT_LIB_DIR}/libnvat.so" || -e "${NVAT_LIB_DIR}/libnvat.so.1" ]] || \
+		die "NVIDIA SDK libnvat.so not found in ${NVAT_LIB_DIR}"
+
+	info "Building NVIDIA attester variant (ATTESTER=${NV_ATTESTER})"
+	rm -f "${build_dir}/attestation-agent"
+
+	NVAT_USE_SYSTEM_LIB=1 \
+		make -C "${repo_root_dir}/attestation-agent" \
+		ttrpc=true \
+		ARCH="${ARCH}" \
+		LIBC="${LIBC}" \
+		ATTESTER="${NV_ATTESTER}" \
+		RUSTFLAGS_ARGS="-L ${NVAT_LIB_DIR}"
+
+	strip "${build_dir}/attestation-agent"
+	install -D -m0755 \
+		"${build_dir}/attestation-agent" \
+		"${ROOTFS_DIR}/usr/local/bin/attestation-agent-nv"
+
+	info "Installing NVIDIA attestation libraries"
+	mkdir -p "${ROOTFS_DIR}/usr/local/lib"
+	cp -a "${NVAT_LIB_DIR}"/libnvat.so* "${ROOTFS_DIR}/usr/local/lib/"
+
+	local libnvat
+	libnvat="$(find "${NVAT_LIB_DIR}" -maxdepth 1 -name 'libnvat.so*' | sort | head -n 1)"
+	if [[ -n "${libnvat}" ]]; then
+		copy_non_glibc_library_closure "${libnvat}"
+	fi
+}
+
+install_cryptsetup() {
+	if [[ "${INCLUDE_CRYPTSETUP}" != "yes" ]]; then
+		return 0
+	fi
+
+	command -v cryptsetup >/dev/null 2>&1 || die "cryptsetup not found"
+	info "Installing cryptsetup"
+	install -D -m0755 \
+		"$(command -v cryptsetup)" \
+		"${ROOTFS_DIR}/usr/sbin/cryptsetup"
+}
+
+install_guest_components() {
+	info "Installing guest components into ${ROOTFS_DIR}"
+
+	make -C "${repo_root_dir}" install \
+		TEE_PLATFORM="${TEE_PLATFORM}" \
+		ARCH="${ARCH}" \
+		LIBC="${LIBC}" \
+		DESTDIR="${ROOTFS_DIR}/usr/local/bin"
+
+	# ocicrypt config used by CDH's keyprovider; referenced from components.toml.
+	install -D -m0644 \
+		"${repo_root_dir}/confidential-data-hub/hub/src/image/ocicrypt_config.json" \
+		"${ROOTFS_DIR}/etc/ocicrypt_config.json"
+
+	build_nvidia_attestation_agent
+	install_cryptsetup
+}
+
+install_pause_bundle() {
+	info "Pulling pause image ${PAUSE_IMAGE_REPO}:${PAUSE_IMAGE_VERSION}"
+	command -v skopeo >/dev/null 2>&1 || die "skopeo not found"
+	command -v umoci >/dev/null 2>&1 || die "umoci not found"
+
+	local workdir
+	workdir="$(mktemp -d)"
+	# shellcheck disable=SC2064
+	trap "rm -rf '${workdir}'" RETURN
+
+	skopeo copy "${PAUSE_IMAGE_REPO}:${PAUSE_IMAGE_VERSION}" \
+		"oci:${workdir}/pause:${PAUSE_IMAGE_VERSION}"
+
+	rm -rf "${ROOTFS_DIR}/pause_bundle"
+	umoci unpack --rootless \
+		--image "${workdir}/pause:${PAUSE_IMAGE_VERSION}" \
+		"${ROOTFS_DIR}/pause_bundle"
+	rm -f "${ROOTFS_DIR}/pause_bundle/umoci.json"
+}
+
+install_manifest() {
+	info "Writing extension component manifest"
+	# Always ship the same manifest kata uses, including the nvidia attester
+	# variant selector. attestation-agent-nv is only built on x86_64, but the
+	# manifest must stay identical so kata-agent and NVRC share one contract.
+	install -D -m0644 \
+		"${script_dir}/components.toml" \
+		"${ROOTFS_DIR}/etc/kata-extensions/components.toml"
+}
+
+main() {
+	info "Assembling CoCo extension rootfs at ${ROOTFS_DIR}"
+	rm -rf "${ROOTFS_DIR}"
+	mkdir -p "${ROOTFS_DIR}"
+
+	build_guest_components
+	install_guest_components
+	install_pause_bundle
+	install_manifest
+
+	info "Done. Rootfs contents:"
+	find "${ROOTFS_DIR}" -maxdepth 5 -printf '  %P\n' | sort
+}
+
+main "$@"

--- a/tools/coco-extension/build-erofs-image.sh
+++ b/tools/coco-extension/build-erofs-image.sh
@@ -1,0 +1,258 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2026 Confidential Containers contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Turn the assembled CoCo extension rootfs into the image layout consumed by
+# kata's guest extension mount path:
+#
+#   partition 1: EROFS payload
+#   partition 2: dm-verity hash device (only when MEASURED_ROOTFS=yes)
+#   root_hash_coco-extension.txt: kernel cmdline verity parameters
+#
+# This intentionally builds the small extension image locally instead of pulling
+# in kata-containers' osbuilder. The important compatibility points are the disk
+# layout, the EROFS options, and veritysetup's --no-superblock format.
+#
+# Requires root privileges for loop devices and dm-verity formatting.
+set -o errexit
+set -o nounset
+set -o pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root_dir="$(cd "${script_dir}/../.." && pwd)"
+
+ARCH="${ARCH:-$(uname -m)}"
+
+# Assembled rootfs (output of assemble-rootfs.sh).
+ROOTFS_DIR="${ROOTFS_DIR:-${repo_root_dir}/build/coco-extension-rootfs}"
+
+# Where the resulting image and root hash file are written.
+OUTPUT_DIR="${OUTPUT_DIR:-${repo_root_dir}/build/coco-extension-image}"
+
+# On s390x IBM Secure Execution measures the guest through a different mechanism,
+# so the extension is unmeasured (no dm-verity hash partition) there, mirroring
+# kata's base/confidential images. Everywhere else we build a measured rootfs.
+if [[ -z "${MEASURED_ROOTFS:-}" ]]; then
+	if [[ "${ARCH}" == "s390x" ]]; then
+		MEASURED_ROOTFS="no"
+	else
+		MEASURED_ROOTFS="yes"
+	fi
+fi
+
+BUILD_VARIANT="coco-extension"
+IMAGE_NAME="kata-containers-${BUILD_VARIANT}.img"
+ROOTFS_START_MB=1
+IMAGE_SIZE_ALIGNMENT_MB="${IMAGE_SIZE_ALIGNMENT_MB:-128}"
+
+info() { echo "[build-erofs-image] $*"; }
+die() { echo "[build-erofs-image] ERROR: $*" >&2; exit 1; }
+
+[[ -d "${ROOTFS_DIR}" ]] || die "rootfs not found at ${ROOTFS_DIR}; run assemble-rootfs.sh first"
+if [[ "${EUID}" -ne 0 ]]; then
+	command -v sudo >/dev/null 2>&1 || die "root privileges are required and sudo is not available"
+	exec sudo -E bash "$0" "$@"
+fi
+
+for cmd in cp dd losetup mkfs.erofs parted partprobe sed stat truncate veritysetup; do
+	command -v "${cmd}" >/dev/null 2>&1 || die "${cmd} is required"
+done
+
+cleanup_paths=()
+loop_device=""
+
+cleanup() {
+	if [[ -n "${loop_device}" ]]; then
+		losetup -d "${loop_device}" >/dev/null 2>&1 || true
+	fi
+
+	for path in "${cleanup_paths[@]}"; do
+		rm -rf "${path}"
+	done
+}
+trap cleanup EXIT
+
+make_temp_dir() {
+	local dir
+	dir="$(mktemp -p "${TMPDIR:-/tmp}" -d coco-extension-image.XXXXXX)"
+	cleanup_paths+=("${dir}")
+	echo "${dir}"
+}
+
+make_erofs_payload() {
+	local staging_dir="$1"
+	local fs_image="$2"
+
+	info "Copying extension rootfs into staging directory"
+	cp -a "${ROOTFS_DIR}"/. "${staging_dir}/"
+
+	# kata's osbuilder creates this whenever /etc exists. It is harmless for the
+	# extension and keeps this image layout compatible with the existing asset.
+	if [[ -d "${staging_dir}/etc" ]]; then
+		touch "${staging_dir}/etc/machine-id"
+	fi
+
+	info "Creating EROFS payload"
+	mkfs.erofs -zlz4hc -Enoinline_data "${fs_image}" "${staging_dir}"
+}
+
+calculate_image_size_mb() {
+	local fs_image="$1"
+	local fs_size_bytes
+	local image_size_mb
+	local remainder
+
+	fs_size_bytes="$(stat -c "%s" "${fs_image}")"
+	image_size_mb=$(( ((fs_size_bytes + 1048576) / 1048576) + 1 + ROOTFS_START_MB ))
+
+	if [[ "${MEASURED_ROOTFS}" == "yes" ]]; then
+		# Reserve the final ~1% of the disk for the dm-verity hash partition,
+		# matching kata's osbuilder layout.
+		image_size_mb=$(( (image_size_mb * 100 / 99) + 1 ))
+	fi
+
+	remainder=$(( image_size_mb % IMAGE_SIZE_ALIGNMENT_MB ))
+	if [[ "${remainder}" != "0" ]]; then
+		image_size_mb=$(( image_size_mb + IMAGE_SIZE_ALIGNMENT_MB - remainder ))
+	fi
+
+	echo "${image_size_mb}"
+}
+
+create_disk() {
+	local image="$1"
+	local image_size_mb="$2"
+	local hash_start_mb
+
+	info "Creating raw disk image (${image_size_mb} MiB)"
+	rm -f "${image}"
+	truncate -s "${image_size_mb}M" "${image}"
+
+	if [[ "${MEASURED_ROOTFS}" == "yes" ]]; then
+		hash_start_mb=$(( image_size_mb * 99 / 100 ))
+		if [[ "${hash_start_mb}" -le "${ROOTFS_START_MB}" ]]; then
+			die "image too small for measured rootfs layout"
+		fi
+
+		parted -s -a optimal "${image}" -- \
+			mklabel msdos \
+			mkpart primary ext4 "${ROOTFS_START_MB}MiB" "${hash_start_mb}MiB" \
+			mkpart primary ext4 "${hash_start_mb}MiB" 100% \
+			set 1 boot on
+	else
+		parted -s -a optimal "${image}" -- \
+			mklabel msdos \
+			mkpart primary ext4 "${ROOTFS_START_MB}MiB" 100%
+	fi
+}
+
+attach_loop_device() {
+	local image="$1"
+	local device
+
+	device="$(losetup -P -f --show "${image}")"
+	partprobe -s "${device}" >/dev/null
+
+	for _ in $(seq 1 5); do
+		if [[ -b "${device}p1" ]]; then
+			loop_device="${device}"
+			return
+		fi
+		sleep 1
+	done
+
+	die "partition ${device}p1 was not created"
+}
+
+build_kernel_verity_params() {
+	local output="$1"
+	local root_hash
+	local salt
+	local data_blocks
+	local data_block_size
+	local hash_block_size
+
+	read_verity_field() {
+		local label="$1"
+		local value
+
+		value="$(printf '%s\n' "${output}" | sed -n "s/^${label}:[[:space:]]*//p")"
+		value="${value// \[*/}"
+		[[ -n "${value}" ]] || die "Missing '${label}' in veritysetup output"
+		echo "${value}"
+	}
+
+	root_hash="$(read_verity_field "Root hash")"
+	salt="$(read_verity_field "Salt")"
+	data_blocks="$(read_verity_field "Data blocks")"
+	data_block_size="$(read_verity_field "Data block size")"
+	hash_block_size="$(read_verity_field "Hash block size")"
+
+	printf 'root_hash=%s,salt=%s,data_blocks=%s,data_block_size=%s,hash_block_size=%s' \
+		"${root_hash}" \
+		"${salt}" \
+		"${data_blocks}" \
+		"${data_block_size}" \
+		"${hash_block_size}"
+}
+
+setup_verity() {
+	local device="$1"
+	local root_hash_file="$2"
+	local verity_output
+	local kernel_verity_params
+
+	if [[ "${MEASURED_ROOTFS}" != "yes" ]]; then
+		rm -f "${root_hash_file}"
+		info "Unmeasured build; no root hash file expected"
+		return
+	fi
+
+	[[ -b "${device}p2" ]] || die "expected dm-verity hash partition ${device}p2"
+
+	info "Formatting dm-verity hash device"
+	verity_output="$(veritysetup format --no-superblock "${device}p1" "${device}p2" 2>&1)"
+	kernel_verity_params="$(build_kernel_verity_params "${verity_output}")"
+	printf '%s\n' "${kernel_verity_params}" > "${root_hash_file}"
+}
+
+build_image() {
+	local image="${OUTPUT_DIR}/${IMAGE_NAME}"
+	local root_hash_file="${OUTPUT_DIR}/root_hash_${BUILD_VARIANT}.txt"
+	local staging_dir
+	local fs_image
+	local image_size_mb
+	local device
+
+	mkdir -p "${OUTPUT_DIR}"
+	staging_dir="$(make_temp_dir)"
+	fs_image="$(mktemp -p "${TMPDIR:-/tmp}" coco-extension-erofs.XXXXXX)"
+	cleanup_paths+=("${fs_image}")
+
+	info "Building ${IMAGE_NAME} (ARCH=${ARCH} MEASURED_ROOTFS=${MEASURED_ROOTFS})"
+	make_erofs_payload "${staging_dir}" "${fs_image}"
+	image_size_mb="$(calculate_image_size_mb "${fs_image}")"
+	create_disk "${image}" "${image_size_mb}"
+	attach_loop_device "${image}"
+	device="${loop_device}"
+
+	info "Writing EROFS payload to ${device}p1"
+	dd if="${fs_image}" of="${device}p1" bs=4M conv=fsync status=none
+
+	setup_verity "${device}" "${root_hash_file}"
+
+	if [[ "${MEASURED_ROOTFS}" == "yes" ]]; then
+		info "Root hash / verity params:"
+		sed 's/^/  /' "${root_hash_file}"
+	fi
+
+	info "Image built: ${image}"
+}
+
+main() {
+	build_image
+}
+
+main "$@"

--- a/tools/coco-extension/components.toml
+++ b/tools/coco-extension/components.toml
@@ -1,0 +1,67 @@
+# Data-driven extension manifest consumed by kata-agent. It describes the
+# components shipped in this extension so the agent needs no per-bundle code
+# changes. All paths are relative to the extension mount point
+# (/run/kata-extensions/coco). The "${var}" tokens in the [[process]] entries are
+# substituted by kata-agent from its runtime context.
+#
+# This file is the cross-repo contract between the coco-extension image built
+# here and the kata-agent that consumes it. It must stay in sync with the schema
+# documented in kata-containers'
+# docs/design/proposals/composable-vm-images.md and with the agent's
+# src/agent/src/guest_extension_image.rs parser.
+schema_version = 1
+
+[paths]
+"ocicrypt-config" = "etc/ocicrypt_config.json"
+"pause-bundle"    = "pause_bundle"
+
+[[process]]
+id            = "attestation-agent"
+level         = 1
+args          = ["--attestation_sock", "${aa_attestation_uri}"]
+optional_args = [{ when = "initdata_toml_path", args = ["--initdata-toml", "${initdata_toml_path}"] }]
+config        = "${aa_config_path}"
+wait_socket   = "${aa_attestation_socket}"
+timeout_secs  = "${launch_process_timeout}"
+# The extension ships both the stock attestation-agent and the NVIDIA-attester
+# build; the consumer selects one via the "attester_variant" context value
+# (kata-agent uses "default", NVRC uses "nvidia").
+select        = "${attester_variant}"
+
+  [process.variants.default]
+  path = "usr/local/bin/attestation-agent"
+
+  [process.variants.nvidia]
+  path = "usr/local/bin/attestation-agent-nv"
+  # attestation-agent-nv links libnvat.so (bundled in this CoCo extension under
+  # usr/local/lib), which dlopens libnvidia-ml.so.1 at runtime to collect GPU
+  # attestation evidence. NVML ships in the GPU extension, mounted by NVRC at the
+  # well-known /run/kata-extensions/gpu with its driver libraries under usr/lib, so
+  # both dirs must be on the loader path. The nvidia variant only runs when the
+  # GPU extension is present, so referencing its mount path here is safe; without
+  # the GPU lib dir NVML init fails ("NVAT Error 500: NVML Initialization
+  # Failed") and the RCAR handshake never produces GPU evidence.
+  env  = { LD_LIBRARY_PATH = "${extension_root}/usr/local/lib:/run/kata-extensions/gpu/usr/lib" }
+
+[[process]]
+id           = "confidential-data-hub"
+level        = 2
+path         = "usr/local/bin/confidential-data-hub"
+config       = "${cdh_config_path}"
+# CDH's secure_mount shells out (by PATH lookup) to cryptsetup for encrypted
+# storage and to mke2fs/mkfs.ext4/dd for the filesystem. cryptsetup is CoCo-only
+# and ships in this extension under usr/sbin (see
+# build-static-coco-guest-components.sh); the plain mkfs/dd tooling lives in the
+# base-nvidia image's /sbin and /bin. The agent launches CDH with
+# PATH=/bin:/sbin:/usr/bin:/usr/sbin, but setting any env here overrides it
+# wholesale, so prepend the extension's usr/sbin and restore the base dirs.
+env          = { OCICRYPT_KEYPROVIDER_CONFIG = "${ocicrypt_config_path}", PATH = "${extension_root}/usr/sbin:/bin:/sbin:/usr/bin:/usr/sbin" }
+wait_socket  = "${cdh_socket}"
+timeout_secs = "${launch_process_timeout}"
+
+[[process]]
+id           = "api-server-rest"
+level        = 3
+path         = "usr/local/bin/api-server-rest"
+args         = ["--features", "${rest_api_features}"]
+timeout_secs = "0"


### PR DESCRIPTION
Kata Containers' composable VM image work splits the CoCo guest components out of the monolithic confidential rootfs into a separate guest extension image (kata's rootfs-image-coco-extension asset). Today that image is assembled in the kata-containers repo from this repo's binaries, which means any change to the extension layout or manifest requires coordinating across two repos and cannot be vetted until the kata side runs.

Build the extension image here instead. From a single assembled rootfs we emit two flavours: a scratch-based OCI container image and an EROFS + dm-verity disk image (with its dm-verity root hash), matching the layout kata expects.

The rootfs mirrors kata's install_image_coco_extension(): the guest component binaries, ocicrypt config, pause bundle, cryptsetup, and the data-driven components.toml manifest (kata-agent contract). On x86_64 it also builds the NVIDIA attester variant (attestation-agent-nv) plus its libnvat closure. The EROFS image is built locally (mkfs.erofs + parted + veritysetup) rather than pulling in kata's osbuilder.

Builds cover x86_64, aarch64, and s390x. Pull requests only build and upload workflow artifacts; pushes to main publish to ghcr.io (tagged with the commit sha and "latest") with build attestations; and published releases publish the images tagged with the release version and attach the per-arch disk images and dm-verity root hashes to the GitHub release so consumers can pin to a stable version.

Refs: https://github.com/confidential-containers/guest-components/issues/1537