### PR TITLE
feat(cdh/kms): add AWS KMS and Secrets Manager provider

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -222,6 +222,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "arc-swap"
+version = "1.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c049c0be4daef0b145cb3555416b3b8ef5b7888a38aea1a3a155801fe7b0810b"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "argon2"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -431,6 +440,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "aws-credential-types"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e93964ffdaf57857f544be3666a5f57570bb699e934700f11b49708f61bb556e"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "zeroize",
+]
+
+[[package]]
 name = "aws-lc-fips-sys"
 version = "0.13.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -467,6 +488,288 @@ dependencies = [
  "cmake",
  "dunce",
  "fs_extra",
+]
+
+[[package]]
+name = "aws-runtime"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7816e98ee912159f45d307e5ee6bfea4a335a55aee15f7f3e32f81a6f3000f1d"
+dependencies = [
+ "aws-credential-types",
+ "aws-sigv4",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "bytes-utils",
+ "fastrand",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "percent-encoding",
+ "pin-project-lite",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
+name = "aws-sdk-kms"
+version = "1.112.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12409cfb265576c245cf86640c4090634959459f2537a428174ca6aba5ec9456"
+dependencies = [
+ "arc-swap",
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-observability",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-schema",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "http 0.2.12",
+ "http 1.4.0",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-secretsmanager"
+version = "1.109.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "661ce910a6ed895c6bde66aa78040272628b127714fe0e9bb799f07ab4db407b"
+dependencies = [
+ "arc-swap",
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-observability",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-schema",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "http 0.2.12",
+ "http 1.4.0",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sigv4"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "723c2234ad7511ceef63eab016b7ba6ff7c55590fefb96fa8467af014a07309f"
+dependencies = [
+ "aws-credential-types",
+ "aws-smithy-http",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "bytes",
+ "form_urlencoded",
+ "hex",
+ "hmac 0.13.0",
+ "http 0.2.12",
+ "http 1.4.0",
+ "percent-encoding",
+ "sha2 0.11.0",
+ "time",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-async"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f02e407fb3b54891734224b9ffac8a71fdd35f542500fa1af95754a6b2beb316"
+dependencies = [
+ "futures-util",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "aws-smithy-http"
+version = "0.64.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37843d9add67c3aff5856f409c6dc315d3cdff60f9c0cb5b670dab1e9920306d"
+dependencies = [
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "bytes",
+ "bytes-utils",
+ "futures-core",
+ "futures-util",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "percent-encoding",
+ "pin-project-lite",
+ "pin-utils",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-http-client"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "635d23afda0a6ab48d666c4d447c4873e8d1e83518a2be2093122397e50b838e"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "h2 0.4.14",
+ "http 1.4.0",
+ "hyper 1.9.0",
+ "hyper-rustls",
+ "hyper-util",
+ "pin-project-lite",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tower",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-json"
+version = "0.63.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3dc65a121adb4b33729919fcfa14fa36fb33c1555a8f06bb0e2188dbfdc1d9ef"
+dependencies = [
+ "aws-smithy-runtime-api",
+ "aws-smithy-schema",
+ "aws-smithy-types",
+]
+
+[[package]]
+name = "aws-smithy-observability"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e86338c869539a581bf161247762a6e87f92c5c075060057b5ed6d06632ed0c"
+dependencies = [
+ "aws-smithy-runtime-api",
+]
+
+[[package]]
+name = "aws-smithy-runtime"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bea94a9ff8464016338c851e24b472d7131c388c88898a502e781815b2ee6045"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-http-client",
+ "aws-smithy-observability",
+ "aws-smithy-runtime-api",
+ "aws-smithy-schema",
+ "aws-smithy-types",
+ "bytes",
+ "fastrand",
+ "http 0.2.12",
+ "http 1.4.0",
+ "http-body 0.4.6",
+ "http-body 1.0.1",
+ "http-body-util",
+ "pin-project-lite",
+ "pin-utils",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-runtime-api"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22ed1ebe6e0a95ea84570225f5a8208dec4b8f77e61a9b0d6f51773fcb4612f0"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-runtime-api-macros",
+ "aws-smithy-types",
+ "bytes",
+ "http 0.2.12",
+ "http 1.4.0",
+ "pin-project-lite",
+ "tokio",
+ "tracing",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-smithy-runtime-api-macros"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "221eaa237ddf1ca79b60d1372aad77e47f9c0ea5b3ce5099da8c61d027dc77b3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "aws-smithy-schema"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d56e0a4e53127a632224e43633b0fe045fa9e1e3cfc68b9830f1115e103f910"
+dependencies = [
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "http 1.4.0",
+]
+
+[[package]]
+name = "aws-smithy-types"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6dc683efb34b9e755675b37fedbe0103141e5b6df7bdc9eb6967756a8c167d8"
+dependencies = [
+ "base64-simd",
+ "bytes",
+ "bytes-utils",
+ "futures-core",
+ "http 0.2.12",
+ "http 1.4.0",
+ "http-body 0.4.6",
+ "http-body 1.0.1",
+ "http-body-util",
+ "itoa",
+ "num-integer",
+ "pin-project-lite",
+ "pin-utils",
+ "ryu",
+ "serde",
+ "time",
+ "tokio",
+ "tokio-util",
+]
+
+[[package]]
+name = "aws-types"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e957a6c6dbce82b7a91f44231c09273159703769f447cbe85e854dfe9cf67f86"
+dependencies = [
+ "aws-credential-types",
+ "aws-smithy-async",
+ "aws-smithy-runtime-api",
+ "aws-smithy-schema",
+ "aws-smithy-types",
+ "rustc_version",
+ "tracing",
 ]
 
 [[package]]
@@ -589,6 +892,16 @@ name = "base64-serde"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77c6d128af408d8ebd08331f0331cf2cf20d19e6c44a7aec58791641ecc8c0b5"
+
+[[package]]
+name = "base64-simd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "339abbe78e73178762e23bea9dfd08e697eb3f3301cd4be981c0f78ba5859195"
+dependencies = [
+ "outref",
+ "vsimd",
+]
 
 [[package]]
 name = "base64-url"
@@ -969,6 +1282,16 @@ name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+
+[[package]]
+name = "bytes-utils"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dafe3a8757b027e2be6e4e5601ed563c55989fcf1546e933c66c8eb3a058d35"
+dependencies = [
+ "bytes",
+ "either",
+]
 
 [[package]]
 name = "bzip2"
@@ -4000,6 +4323,8 @@ dependencies = [
  "anyhow",
  "async-trait",
  "attestation-agent",
+ "aws-sdk-kms",
+ "aws-sdk-secretsmanager",
  "base64 0.22.1",
  "bincode 2.0.1",
  "chrono",
@@ -4892,6 +5217,12 @@ dependencies = [
  "dlv-list",
  "hashbrown 0.14.5",
 ]
+
+[[package]]
+name = "outref"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
 
 [[package]]
 name = "p256"
@@ -6024,6 +6355,12 @@ dependencies = [
  "memchr",
  "regex-syntax",
 ]
+
+[[package]]
+name = "regex-lite"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab834c73d247e67f4fae452806d17d3c7501756d98c8808d7c9c7aa7d18f973"
 
 [[package]]
 name = "regex-syntax"
@@ -8214,6 +8551,12 @@ name = "virtue"
 version = "0.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "051eb1abcf10076295e815102942cc58f9d5e3b4560e46e53c21e8ff6f3af7b1"
+
+[[package]]
+name = "vsimd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 
 [[package]]
 name = "vsock"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,8 @@ anyhow = "1.0"
 assert-json-diff = "2.0"
 assert_cmd = "2"
 async-trait = "0.1.89"
+aws-sdk-kms = { version = "1.109", default-features = false, features = ["behavior-version-latest", "default-https-client", "rt-tokio"] }
+aws-sdk-secretsmanager = { version = "1.109", default-features = false, features = ["behavior-version-latest", "default-https-client", "rt-tokio"] }
 base64 = "0.22.1"
 base64-serde = "0.8"
 bincode = "2.0.1"

--- a/confidential-data-hub/Makefile
+++ b/confidential-data-hub/Makefile
@@ -118,5 +118,5 @@ clean:
 
 help:
 	@echo "==========================Help========================================="
-	@echo "build: make [DEBUG=1] [LIBC=(musl)] [ARCH=(x86_64/s390x/ppc64le)] [RESOURCE_PROVIDER=(kbs/sev)] [KMS_PROVIDER=aliyun/ehsm] [RPC=(ttrpc/grpc)]"
+	@echo "build: make [DEBUG=1] [LIBC=(musl)] [ARCH=(x86_64/s390x/ppc64le)] [RESOURCE_PROVIDER=(kbs/sev)] [KMS_PROVIDER=aliyun/aws/ehsm] [RPC=(ttrpc/grpc)]"
 	@echo "install: make install [DESTDIR=/path/to/target] [LIBC=(musl)]"

--- a/confidential-data-hub/docs/SEALED_SECRET.md
+++ b/confidential-data-hub/docs/SEALED_SECRET.md
@@ -201,6 +201,7 @@ Your secret will be provisioned to the `PROTECTED_SECRET` environment variable.
 | Provider Name      | README                                                      			| Maintainer                |
 | ------------------ | -------------------------------------------------------------------- | ------------------------- |
 | aliyun       	     |  [aliyun](kms-providers/alibaba.md)                               	| Alibaba                   |
+| aws       	     |  [aws](kms-providers/aws.md)                                     	| CoCo                      |
 | ehsm       	     |  [ehsm](kms-providers/ehsm-kms.md)                              		| Unmaintained                   	|
 | kbs                |                                                                          | CoCo                  |
 

--- a/confidential-data-hub/docs/kms-providers/aws.md
+++ b/confidential-data-hub/docs/kms-providers/aws.md
@@ -1,0 +1,182 @@
+# KMS Driver for AWS
+
+This driver backs two kinds of sealed secrets:
+
+- **Envelope secrets** via [AWS KMS](https://aws.amazon.com/kms/). The
+  data-encryption-key (DEK) is wrapped/unwrapped with the KMS `Encrypt`/`Decrypt`
+  operations.
+- **Vault secrets** via [AWS Secrets Manager](https://aws.amazon.com/secrets-manager/).
+  The pointed-to value is fetched with `GetSecretValue`.
+
+Both are served by a single client (`AwsKmsClient`) authenticated with one set of
+static IAM credentials.
+
+## Spec
+
+### Consts & Layouts
+
+| Name         | Value   |
+| ------------ | ------- |
+| `provider`   | `aws`   |
+
+The `provider_settings` and `annotations` defined in [Sealed Secret](../SEALED_SECRET.md#format)
+are as follows:
+
+#### provider_settings
+
+| Name       | Usage                                                     |
+| ---------- | --------------------------------------------------------- |
+| `region`   | AWS region of the KMS key / secret, e.g. `us-east-1`.     |
+
+The KMS key identifier (key id, ARN, or `alias/...`) is carried in the sealed
+secret's `key_id` field for envelope secrets. The Secrets Manager secret id
+(name or ARN) is carried in the `name` field for vault secrets.
+
+#### annotations
+
+##### encryption/decryption (envelope)
+
+| Name                 | Usage                                                                                              |
+| -------------------- | ------------------------------------------------------------------------------------------------- |
+| `encryption_context` | (Optional) AWS KMS encryption context (AAD). If set at seal time it must match at unseal time.     |
+
+By default this is empty. When an `encryption_context` is provided it is passed
+to KMS `Encrypt` at seal time and bound into the ciphertext; the identical
+context must then be supplied to `Decrypt` at unseal time or the operation
+fails. AWS KMS embeds the IV/nonce in the ciphertext blob, so no `iv` annotation
+is used.
+
+##### get_secret (vault)
+
+| Name             | Usage                                                                       |
+| ---------------- | --------------------------------------------------------------------------- |
+| `version_id`     | (Optional) Fetch a specific version of the secret. Empty = current version. |
+| `version_stage`  | (Optional) Staging label to fetch. Empty = `AWSCURRENT`.                     |
+
+### Credential files
+
+To connect to AWS a credential file is needed. It is a JSON document with static
+IAM credentials:
+
+```json
+{
+  "access_key_id": "AKIA...",
+  "secret_access_key": "...",
+  "session_token": null
+}
+```
+
+`session_token` is optional and only used for temporary (STS) credentials.
+
+When in a TEE, the credential file is supposed to be placed at
+`/run/confidential-containers/cdh/kbs/kms-credential/aws/credential.json`.
+The location can be overridden with the `AWS_IN_GUEST_KEY_PATH` environment
+variable (the file name inside that directory is always `credential.json`).
+
+The recommended way to provision the file is the CDH credential interface: add a
+`[[credentials]]` entry to the CDH config so the file is fetched from the KBS,
+attestation-gated, when CDH starts. Store the JSON credential document shown
+above as a KBS resource, then reference it:
+
+```toml
+[[credentials]]
+path = "/run/confidential-containers/cdh/kbs/kms-credential/aws/credential.json"
+resource_uri = "kbs:///default/aws/credential"
+```
+
+`path` must be under `/run/confidential-containers/cdh/kbs`, and it must match
+the directory the driver reads (the default above, or whatever
+`AWS_IN_GUEST_KEY_PATH` points at).
+
+> [!IMPORTANT]
+> Static IAM keys do not rotate on their own; prefer scoping them tightly (a
+> dedicated IAM principal allowed only `kms:Decrypt` on the specific key and/or
+> `secretsmanager:GetSecretValue` on the specific secret) and rotating them out
+> of band.
+
+## Behavior
+
+`AwsKmsClient` implements `Encrypter`, `Decrypter`, `Getter`, and `Setter`.
+`Encrypter`/`Setter` are used on the user side (sealing/provisioning), while
+`Decrypter`/`Getter` are used in-guest (unsealing).
+
+The client is constructed directly from the region and static credentials; it
+does **not** perform ambient AWS credential discovery (no environment/instance
+metadata scanning), which keeps the in-guest attack surface minimal.
+
+## Sealed Secrets
+
+### Envelope
+
+Suppose we are on a machine that can reach AWS with an IAM principal allowed to
+`kms:Encrypt` on the target key.
+
+Prepare:
+- `kms-key-id.txt`: the KMS key id/ARN/alias, e.g. `alias/my-coco-key`
+- `aws-region.txt`: e.g. `us-east-1`
+- `aws-credential.json`: the credential file shown above
+- `plaintext`: the file whose content will be sealed
+
+```bash
+KEY_ID=$(cat kms-key-id.txt)
+REGION=$(cat aws-region.txt)
+CREDENTIAL_FILE_PATH=$(pwd)/aws-credential.json
+
+git clone https://github.com/confidential-containers/guest-components.git && cd guest-components
+
+cargo build -p confidential-data-hub --bin secret --features aws
+
+target/debug/secret seal \
+    --signing-kid kbs://signing/key/uri --signing-jwk-path ./path/to/jwk \
+    envelope --key-id "$KEY_ID" --file-path ../plaintext \
+    aws \
+    --region "$REGION" \
+    --credential-file-path "$CREDENTIAL_FILE_PATH" \
+    > sealed_secret.json
+```
+
+The resulting `sealed_secret.json` looks like:
+
+```json
+{
+    "version": "0.1.0",
+    "type": "envelope",
+    "key_id": "alias/my-coco-key",
+    "encrypted_key": "AQIDAH...",
+    "encrypted_data": "QzWk...",
+    "wrap_type": "A256GCM",
+    "iv": "T32...",
+    "provider": "aws",
+    "provider_settings": {
+        "region": "us-east-1"
+    },
+    "annotations": {}
+}
+```
+
+### Vault
+
+A vault secret is just a pointer; the value must be provisioned to AWS Secrets
+Manager separately (e.g. `aws secretsmanager create-secret ...`).
+
+```bash
+cargo run -p confidential-data-hub --bin secret --features aws -- seal \
+    --signing-kid kbs://signing/key/uri --signing-jwk-path ./path/to/jwk \
+    vault \
+    --resource-uri my/secret/name \
+    --provider aws \
+    --provider-settings '{"region":"us-east-1"}'
+```
+
+## Unsealing
+
+Unsealing happens in-guest via the CDH, but can be exercised with the CLI by
+pointing `--key-path` at the directory that directly contains `credential.json`
+(this sets `AWS_IN_GUEST_KEY_PATH`, and the driver reads
+`$AWS_IN_GUEST_KEY_PATH/credential.json`):
+
+```bash
+target/debug/secret unseal \
+    --file-path sealed_secret.json \
+    --key-path /path/to/dir/containing/credential.json
+```

--- a/confidential-data-hub/hub/Cargo.toml
+++ b/confidential-data-hub/hub/Cargo.toml
@@ -97,6 +97,9 @@ default = ["aliyun", "kbs", "bin", "ttrpc", "grpc", "cli"]
 # support aliyun stacks (KMS, ..)
 aliyun = ["kms/aliyun"]
 
+# support aws stacks (KMS, Secrets Manager)
+aws = ["kms/aws"]
+
 # support coco-KBS to provide confidential resources
 kbs = ["kms/kbs"]
 

--- a/confidential-data-hub/hub/src/bin/secret_cli.rs
+++ b/confidential-data-hub/hub/src/bin/secret_cli.rs
@@ -15,11 +15,13 @@ use confidential_data_hub::secret::{
 use crypto::WrapType;
 #[cfg(feature = "aliyun")]
 use kms::plugins::aliyun::AliyunKmsClient;
+#[cfg(feature = "aws")]
+use kms::plugins::aws::AwsKmsClient;
 #[cfg(feature = "ehsm")]
 use kms::plugins::ehsm::EhsmKmsClient;
 use kms::{Encrypter, ProviderSettings};
 use rand::RngExt;
-#[cfg(feature = "ehsm")]
+#[cfg(any(feature = "ehsm", feature = "aws"))]
 use serde_json::Value;
 use tokio::{fs, io::AsyncWriteExt};
 use zeroize::Zeroizing;
@@ -126,6 +128,10 @@ enum EnvelopeArgs {
     #[cfg(feature = "ehsm")]
     Ehsm(EhsmProviderArgs),
 
+    /// AWS KMS driver to seal the envelope
+    #[cfg(feature = "aws")]
+    Aws(AwsProviderArgs),
+
     /// Dummy driver to prevent the unreachable pattern for neither aliyun nor ehsm
     Dummy,
 }
@@ -160,6 +166,19 @@ struct EhsmProviderArgs {
     /// endpoint of eHSM service
     #[arg(short, long)]
     endpoint: String,
+}
+
+#[cfg(feature = "aws")]
+#[derive(Args)]
+struct AwsProviderArgs {
+    /// AWS region of the KMS key, e.g. `us-east-1`
+    #[arg(short, long)]
+    region: String,
+
+    /// path of the credential file (JSON with `access_key_id`,
+    /// `secret_access_key` and optional `session_token`)
+    #[arg(short, long)]
+    credential_file_path: String,
 }
 
 #[tokio::main]
@@ -199,6 +218,10 @@ async fn unseal_secret(unseal_args: &UnsealArgs) {
         ),
         "ehsm" => env::set_var(
             "EHSM_IN_GUEST_KEY_PATH",
+            unseal_args.key_path.as_ref().expect("Key Path Required"),
+        ),
+        "aws" => env::set_var(
+            "AWS_IN_GUEST_KEY_PATH",
             unseal_args.key_path.as_ref().expect("Key Path Required"),
         ),
         "kbs" => env::set_var(
@@ -365,6 +388,31 @@ async fn handle_envelope_provider(
                 .export_provider_settings()
                 .expect("aliyun export provider_settings fail");
             (Box::new(client), provider_settings, "ehsm".into())
+        }
+        #[cfg(feature = "aws")]
+        EnvelopeArgs::Aws(arg) => {
+            let cred = fs::read_to_string(&arg.credential_file_path)
+                .await
+                .expect("read aws credential file");
+            let cred_parsed: Value =
+                serde_json::from_str(&cred).expect("parse aws credential file");
+            let access_key_id = cred_parsed
+                .get("access_key_id")
+                .and_then(Value::as_str)
+                .expect("get access_key_id string");
+            let secret_access_key = cred_parsed
+                .get("secret_access_key")
+                .and_then(Value::as_str)
+                .expect("get secret_access_key string");
+            let session_token = cred_parsed.get("session_token").and_then(Value::as_str);
+
+            let client =
+                AwsKmsClient::new(&arg.region, access_key_id, secret_access_key, session_token)
+                    .expect("create aws client");
+            let provider_settings = client
+                .export_provider_settings()
+                .expect("aws export provider_settings failed");
+            (Box::new(client), provider_settings, "aws".into())
         }
         _ => {
             panic!("no kms provider is supported, please rebuild the secret cli tool!")

--- a/confidential-data-hub/kms/Cargo.toml
+++ b/confidential-data-hub/kms/Cargo.toml
@@ -9,6 +9,8 @@ edition = "2021"
 anyhow.workspace = true
 async-trait.workspace = true
 attestation-agent = { path = "../../attestation-agent/attestation-agent", default-features = false }
+aws-sdk-kms = { workspace = true, optional = true }
+aws-sdk-secretsmanager = { workspace = true, optional = true }
 base64.workspace = true
 bincode = { workspace = true, optional = true }
 chrono = { workspace = true, optional = true }
@@ -64,6 +66,7 @@ aliyun = [
     "protos/grpc",
     "prost",
 ]
+aws = ["aws-sdk-kms", "aws-sdk-secretsmanager"]
 kbs = ["kbs_protocol"]
 ehsm = ["ehsm_client"]
 sev = [

--- a/confidential-data-hub/kms/src/error.rs
+++ b/confidential-data-hub/kms/src/error.rs
@@ -13,6 +13,10 @@ pub enum Error {
     #[error("Aliyun KMS error: {0}")]
     AliyunKmsError(String),
 
+    #[cfg(feature = "aws")]
+    #[error("AWS KMS/Secrets Manager error: {0}")]
+    AwsKmsError(String),
+
     #[error("Kbs client error: {0}")]
     KbsClientError(String),
 

--- a/confidential-data-hub/kms/src/plugins/aws/annotations.rs
+++ b/confidential-data-hub/kms/src/plugins/aws/annotations.rs
@@ -1,0 +1,135 @@
+// Copyright (c) 2026 Confidential Containers Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+use std::collections::HashMap;
+
+use serde::{Deserialize, Serialize};
+
+/// Serialized [`crate::ProviderSettings`] for the AWS provider.
+///
+/// The region is the only piece of public information required to reconstruct a
+/// client on the decryptor/getter side. Key material (KMS key ARN/alias) and the
+/// secret name are carried out-of-band in the envelope/vault `key_id`/`name`
+/// fields respectively.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct AwsProviderSettings {
+    pub region: String,
+}
+
+/// Serialized [`crate::Annotations`] for AWS KMS envelope encryption/decryption.
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+pub struct AwsCryptAnnotations {
+    /// Optional AWS KMS [encryption context][ctx] (additional authenticated
+    /// data). If present at encryption time it must be presented verbatim at
+    /// decryption time, otherwise KMS rejects the request.
+    ///
+    /// [ctx]: https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#encrypt_context
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub encryption_context: HashMap<String, String>,
+}
+
+/// Serialized [`crate::Annotations`] for AWS Secrets Manager `GetSecretValue`.
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+pub struct AwsSecretAnnotations {
+    /// Optional specific version id of the secret. Empty means the current
+    /// version (as selected by `version_stage`).
+    #[serde(default)]
+    pub version_id: String,
+
+    /// Optional staging label of the secret version. Empty lets AWS default to
+    /// `AWSCURRENT`.
+    #[serde(default)]
+    pub version_stage: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use rstest::rstest;
+    use serde_json::{json, Value};
+
+    use super::{AwsCryptAnnotations, AwsProviderSettings, AwsSecretAnnotations};
+
+    #[test]
+    fn provider_settings_round_trip() {
+        let settings = AwsProviderSettings {
+            region: "us-east-1".to_string(),
+        };
+        let value = serde_json::to_value(&settings).unwrap();
+        assert_eq!(value, json!({ "region": "us-east-1" }));
+
+        let parsed: AwsProviderSettings = serde_json::from_value(value).unwrap();
+        assert_eq!(parsed.region, "us-east-1");
+    }
+
+    /// Serialization must drop an empty encryption context (so a plain encrypt
+    /// yields `{}`) but preserve a populated one verbatim.
+    #[rstest]
+    #[case::empty(&[], json!({}))]
+    #[case::with_context(&[("purpose", "cdh")], json!({ "encryption_context": { "purpose": "cdh" } }))]
+    fn crypt_annotations_serialize(#[case] entries: &[(&str, &str)], #[case] expected: Value) {
+        let mut annotations = AwsCryptAnnotations::default();
+        for (k, v) in entries {
+            annotations
+                .encryption_context
+                .insert(k.to_string(), v.to_string());
+        }
+        assert_eq!(serde_json::to_value(&annotations).unwrap(), expected);
+    }
+
+    /// Ciphertext sealed without an encryption context carries an empty
+    /// annotations object; a populated one must round-trip its entries.
+    #[rstest]
+    #[case::missing(json!({}), &[])]
+    #[case::with_context(json!({ "encryption_context": { "purpose": "cdh" } }), &[("purpose", "cdh")])]
+    fn crypt_annotations_deserialize(#[case] value: Value, #[case] expected: &[(&str, &str)]) {
+        let parsed: AwsCryptAnnotations = serde_json::from_value(value).unwrap();
+        assert_eq!(parsed.encryption_context.len(), expected.len());
+        for (k, v) in expected {
+            assert_eq!(parsed.encryption_context.get(*k).unwrap(), v);
+        }
+    }
+
+    /// Both secret-version fields always serialize (no skip), so defaults emit
+    /// empty strings and explicit values round-trip unchanged.
+    #[rstest]
+    #[case::default(AwsSecretAnnotations::default(), "", "")]
+    #[case::with_values(
+        AwsSecretAnnotations {
+            version_id: "v-123".to_string(),
+            version_stage: "AWSCURRENT".to_string(),
+        },
+        "v-123",
+        "AWSCURRENT"
+    )]
+    fn secret_annotations_round_trip(
+        #[case] annotations: AwsSecretAnnotations,
+        #[case] version_id: &str,
+        #[case] version_stage: &str,
+    ) {
+        let value: Value = serde_json::to_value(&annotations).unwrap();
+        assert_eq!(
+            value,
+            json!({ "version_id": version_id, "version_stage": version_stage })
+        );
+
+        let parsed: AwsSecretAnnotations = serde_json::from_value(value).unwrap();
+        assert_eq!(parsed.version_id, version_id);
+        assert_eq!(parsed.version_stage, version_stage);
+    }
+
+    /// Missing fields fall back to their defaults thanks to `#[serde(default)]`.
+    #[rstest]
+    #[case::empty(json!({}), "", "")]
+    #[case::partial(json!({ "version_stage": "AWSPREVIOUS" }), "", "AWSPREVIOUS")]
+    fn secret_annotations_deserialize_partial(
+        #[case] value: Value,
+        #[case] version_id: &str,
+        #[case] version_stage: &str,
+    ) {
+        let parsed: AwsSecretAnnotations = serde_json::from_value(value).unwrap();
+        assert_eq!(parsed.version_id, version_id);
+        assert_eq!(parsed.version_stage, version_stage);
+    }
+}

--- a/confidential-data-hub/kms/src/plugins/aws/client.rs
+++ b/confidential-data-hub/kms/src/plugins/aws/client.rs
@@ -1,0 +1,311 @@
+// Copyright (c) 2026 Confidential Containers Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+use std::env;
+
+use async_trait::async_trait;
+use aws_sdk_kms::{
+    config::{BehaviorVersion, Credentials, Region},
+    primitives::Blob,
+    Client as KmsClient,
+};
+use aws_sdk_secretsmanager::Client as SecretsManagerClient;
+use const_format::concatcp;
+use serde_json::Value;
+use tokio::fs;
+use tracing::info;
+
+use crate::plugins::_IN_GUEST_DEFAULT_KEY_PATH;
+use crate::{Annotations, Decrypter, Encrypter, Getter, ProviderSettings, Setter};
+use crate::{Error, Result};
+
+use super::annotations::{AwsCryptAnnotations, AwsProviderSettings, AwsSecretAnnotations};
+use super::credential::AwsCredential;
+
+/// Default in-guest directory holding the AWS credential file. The credential is
+/// expected to be provisioned into the TEE's encrypted memory before use.
+const AWS_IN_GUEST_DEFAULT_KEY_PATH: &str = concatcp!(_IN_GUEST_DEFAULT_KEY_PATH, "/aws");
+
+/// Name of the credential file inside the key path. Unlike Aliyun/eHSM the AWS
+/// credential is not keyed on any public identifier (the decryptor side only
+/// knows the region), so a fixed file name is used.
+const AWS_CREDENTIAL_FILE_NAME: &str = "credential.json";
+
+/// A client that talks to AWS KMS (for envelope secrets) and AWS Secrets Manager
+/// (for vault secrets) using a single set of static IAM credentials.
+#[derive(Clone, Debug)]
+pub struct AwsKmsClient {
+    region: String,
+    kms: KmsClient,
+    secrets_manager: SecretsManagerClient,
+}
+
+impl AwsKmsClient {
+    /// Build a client from a region and explicit static credentials. This is the
+    /// entry point used on the user/encryptor side (e.g. by `secret_cli`).
+    pub fn new(
+        region: &str,
+        access_key_id: &str,
+        secret_access_key: &str,
+        session_token: Option<&str>,
+    ) -> Result<Self> {
+        let credentials = Credentials::new(
+            access_key_id.to_owned(),
+            secret_access_key.to_owned(),
+            session_token.map(ToOwned::to_owned),
+            None,
+            "cdh-aws-static",
+        );
+
+        let region = region.to_owned();
+
+        let kms_config = aws_sdk_kms::config::Builder::new()
+            .behavior_version(BehaviorVersion::latest())
+            .region(Region::new(region.clone()))
+            .credentials_provider(credentials.clone())
+            .build();
+
+        let secrets_manager_config = aws_sdk_secretsmanager::config::Builder::new()
+            .behavior_version(BehaviorVersion::latest())
+            .region(Region::new(region.clone()))
+            .credentials_provider(credentials)
+            .build();
+
+        Ok(Self {
+            region,
+            kms: KmsClient::from_conf(kms_config),
+            secrets_manager: SecretsManagerClient::from_conf(secrets_manager_config),
+        })
+    }
+
+    pub async fn from_provider_settings(provider_settings: &ProviderSettings) -> Result<Self> {
+        let key_path =
+            env::var("AWS_IN_GUEST_KEY_PATH").unwrap_or(AWS_IN_GUEST_DEFAULT_KEY_PATH.to_owned());
+        info!("AWS_IN_GUEST_KEY_PATH = {key_path}");
+
+        let provider_settings: AwsProviderSettings =
+            serde_json::from_value(Value::Object(provider_settings.clone()))
+                .map_err(|e| Error::AwsKmsError(format!("parse provider setting failed: {e:?}")))?;
+
+        let credential_path = format!("{key_path}/{AWS_CREDENTIAL_FILE_NAME}");
+        let credential = fs::read_to_string(&credential_path).await.map_err(|e| {
+            Error::AwsKmsError(format!(
+                "read credential file {credential_path} failed: {e:?}"
+            ))
+        })?;
+        let credential: AwsCredential = serde_json::from_str(&credential)
+            .map_err(|e| Error::AwsKmsError(format!("parse credential failed: {e:?}")))?;
+
+        Self::new(
+            &provider_settings.region,
+            &credential.access_key_id,
+            &credential.secret_access_key,
+            credential.session_token.as_deref(),
+        )
+    }
+
+    /// Export the [`ProviderSettings`] of the current client. This function is to
+    /// be used on the encryptor side. The [`ProviderSettings`] will be used to
+    /// initialize a client on the decryptor side.
+    pub fn export_provider_settings(&self) -> Result<ProviderSettings> {
+        let provider_settings = AwsProviderSettings {
+            region: self.region.clone(),
+        };
+
+        let provider_settings = serde_json::to_value(provider_settings)
+            .map_err(|e| Error::AwsKmsError(format!("serialize ProviderSettings failed: {e:?}")))?
+            .as_object()
+            .expect("must be an object")
+            .to_owned();
+
+        Ok(provider_settings)
+    }
+}
+
+#[async_trait]
+impl Encrypter for AwsKmsClient {
+    async fn encrypt(&mut self, data: &[u8], key_id: &str) -> Result<(Vec<u8>, Annotations)> {
+        let response = self
+            .kms
+            .encrypt()
+            .key_id(key_id)
+            .plaintext(Blob::new(data.to_vec()))
+            .send()
+            .await
+            .map_err(|e| Error::AwsKmsError(format!("AWS KMS encrypt failed: {e:?}")))?;
+
+        let ciphertext = response
+            .ciphertext_blob
+            .ok_or_else(|| Error::AwsKmsError("AWS KMS encrypt returned no ciphertext".into()))?
+            .into_inner();
+
+        // AWS KMS embeds the IV/nonce in the returned ciphertext blob, so no
+        // per-operation annotations are required. We keep the (empty) crypt
+        // annotations struct for forward compatibility with encryption context.
+        let annotations = serde_json::to_value(AwsCryptAnnotations::default())
+            .map_err(|e| Error::AwsKmsError(format!("serialize annotations failed: {e:?}")))?
+            .as_object()
+            .expect("must be an object")
+            .to_owned();
+
+        Ok((ciphertext, annotations))
+    }
+}
+
+#[async_trait]
+impl Decrypter for AwsKmsClient {
+    async fn decrypt(
+        &mut self,
+        ciphertext: &[u8],
+        key_id: &str,
+        annotations: &Annotations,
+    ) -> Result<Vec<u8>> {
+        let crypt_annotations: AwsCryptAnnotations =
+            serde_json::from_value(Value::Object(annotations.clone())).map_err(|e| {
+                Error::AwsKmsError(format!("deserialize crypt annotations failed: {e:?}"))
+            })?;
+
+        let mut request = self
+            .kms
+            .decrypt()
+            .key_id(key_id)
+            .ciphertext_blob(Blob::new(ciphertext.to_vec()));
+
+        if !crypt_annotations.encryption_context.is_empty() {
+            request = request.set_encryption_context(Some(crypt_annotations.encryption_context));
+        }
+
+        let response = request
+            .send()
+            .await
+            .map_err(|e| Error::AwsKmsError(format!("AWS KMS decrypt failed: {e:?}")))?;
+
+        let plaintext = response
+            .plaintext
+            .ok_or_else(|| Error::AwsKmsError("AWS KMS decrypt returned no plaintext".into()))?
+            .into_inner();
+
+        Ok(plaintext)
+    }
+}
+
+#[async_trait]
+impl Getter for AwsKmsClient {
+    async fn get_secret(&self, name: &str, annotations: &Annotations) -> Result<Vec<u8>> {
+        let secret_annotations: AwsSecretAnnotations =
+            serde_json::from_value(Value::Object(annotations.clone())).map_err(|e| {
+                Error::AwsKmsError(format!("deserialize secret annotations failed: {e:?}"))
+            })?;
+
+        let mut request = self.secrets_manager.get_secret_value().secret_id(name);
+
+        if !secret_annotations.version_id.is_empty() {
+            request = request.version_id(secret_annotations.version_id);
+        }
+        if !secret_annotations.version_stage.is_empty() {
+            request = request.version_stage(secret_annotations.version_stage);
+        }
+
+        let response = request.send().await.map_err(|e| {
+            Error::AwsKmsError(format!(
+                "AWS Secrets Manager get_secret_value failed: {e:?}"
+            ))
+        })?;
+
+        if let Some(secret_string) = response.secret_string {
+            return Ok(secret_string.into_bytes());
+        }
+        if let Some(secret_binary) = response.secret_binary {
+            return Ok(secret_binary.into_inner());
+        }
+
+        Err(Error::AwsKmsError(
+            "AWS Secrets Manager secret has neither a string nor a binary value".into(),
+        ))
+    }
+}
+
+#[async_trait]
+impl Setter for AwsKmsClient {
+    async fn set_secret(&mut self, content: Vec<u8>, name: String) -> Result<Annotations> {
+        // Try to create the secret. If it already exists, add a new version
+        // instead. Any other error is surfaced to the caller.
+        if let Err(sdk_error) = self
+            .secrets_manager
+            .create_secret()
+            .name(&name)
+            .secret_binary(Blob::new(content.clone()))
+            .send()
+            .await
+        {
+            let service_error = sdk_error.into_service_error();
+            if service_error.is_resource_exists_exception() {
+                self.secrets_manager
+                    .put_secret_value()
+                    .secret_id(&name)
+                    .secret_binary(Blob::new(content))
+                    .send()
+                    .await
+                    .map_err(|e| {
+                        Error::AwsKmsError(format!(
+                            "AWS Secrets Manager put_secret_value failed: {e:?}"
+                        ))
+                    })?;
+            } else {
+                return Err(Error::AwsKmsError(format!(
+                    "AWS Secrets Manager create_secret failed: {service_error:?}"
+                )));
+            }
+        }
+
+        let annotations = serde_json::to_value(AwsSecretAnnotations::default())
+            .map_err(|e| Error::AwsKmsError(format!("serialize annotations failed: {e:?}")))?
+            .as_object()
+            .expect("must be an object")
+            .to_owned();
+
+        Ok(annotations)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::super::annotations::AwsProviderSettings;
+    use super::AwsKmsClient;
+
+    fn test_client(region: &str) -> AwsKmsClient {
+        // `new` only builds SDK config; it performs no network I/O, so this is a
+        // pure unit test of the user-side construction path.
+        AwsKmsClient::new(region, "AKIAEXAMPLE", "secret", None).expect("build client")
+    }
+
+    #[test]
+    fn export_provider_settings_carries_region() {
+        let client = test_client("eu-west-1");
+        let provider_settings = client.export_provider_settings().unwrap();
+
+        let parsed: AwsProviderSettings = serde_json::from_value(json!(provider_settings)).unwrap();
+        assert_eq!(parsed.region, "eu-west-1");
+    }
+
+    #[test]
+    fn export_provider_settings_round_trips_region() {
+        // The exported settings are exactly what the decryptor side would
+        // consume to rebuild a client, so the region must survive the trip.
+        let region = "ap-south-1";
+        let exported = test_client(region).export_provider_settings().unwrap();
+        let value = serde_json::Value::Object(exported);
+        assert_eq!(value, json!({ "region": region }));
+    }
+
+    #[test]
+    fn client_accepts_session_token() {
+        // Temporary STS credentials (with a session token) must construct too.
+        AwsKmsClient::new("us-east-1", "ASIAEXAMPLE", "secret", Some("token"))
+            .expect("build client with session token");
+    }
+}

--- a/confidential-data-hub/kms/src/plugins/aws/credential.rs
+++ b/confidential-data-hub/kms/src/plugins/aws/credential.rs
@@ -1,0 +1,75 @@
+// Copyright (c) 2026 Confidential Containers Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+//! Static IAM credentials used to access AWS KMS and Secrets Manager.
+//!
+//! These are private parameters and, per the [`crate::api`] contract, are read
+//! from the guest's encrypted filesystem rather than passed through
+//! [`crate::ProviderSettings`]. The expected on-disk format is a JSON document:
+//!
+//! ```json
+//! {
+//!   "access_key_id": "AKIA...",
+//!   "secret_access_key": "...",
+//!   "session_token": null
+//! }
+//! ```
+
+use serde::Deserialize;
+
+#[derive(Clone, Debug, Deserialize)]
+pub(crate) struct AwsCredential {
+    pub access_key_id: String,
+    pub secret_access_key: String,
+
+    /// Optional session token for temporary (STS) credentials.
+    #[serde(default)]
+    pub session_token: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::AwsCredential;
+
+    #[test]
+    fn parse_static_credential_without_session_token() {
+        let json = r#"{
+            "access_key_id": "AKIAEXAMPLE",
+            "secret_access_key": "secret"
+        }"#;
+        let credential: AwsCredential = serde_json::from_str(json).unwrap();
+        assert_eq!(credential.access_key_id, "AKIAEXAMPLE");
+        assert_eq!(credential.secret_access_key, "secret");
+        assert!(credential.session_token.is_none());
+    }
+
+    #[test]
+    fn parse_temporary_credential_with_session_token() {
+        let json = r#"{
+            "access_key_id": "ASIAEXAMPLE",
+            "secret_access_key": "secret",
+            "session_token": "token"
+        }"#;
+        let credential: AwsCredential = serde_json::from_str(json).unwrap();
+        assert_eq!(credential.session_token.as_deref(), Some("token"));
+    }
+
+    #[test]
+    fn parse_credential_with_explicit_null_session_token() {
+        let json = r#"{
+            "access_key_id": "AKIAEXAMPLE",
+            "secret_access_key": "secret",
+            "session_token": null
+        }"#;
+        let credential: AwsCredential = serde_json::from_str(json).unwrap();
+        assert!(credential.session_token.is_none());
+    }
+
+    #[test]
+    fn parse_credential_missing_required_field_fails() {
+        let json = r#"{ "access_key_id": "AKIAEXAMPLE" }"#;
+        assert!(serde_json::from_str::<AwsCredential>(json).is_err());
+    }
+}

--- a/confidential-data-hub/kms/src/plugins/aws/mod.rs
+++ b/confidential-data-hub/kms/src/plugins/aws/mod.rs
@@ -1,0 +1,24 @@
+// Copyright (c) 2026 Confidential Containers Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+//! This is an AWS KMS / Secrets Manager implementation.
+//!
+//! - Envelope secrets are backed by [AWS KMS](https://aws.amazon.com/kms/): the
+//!   data-encryption-key (DEK) is wrapped/unwrapped via KMS `Encrypt`/`Decrypt`.
+//! - Vault secrets are backed by
+//!   [AWS Secrets Manager](https://aws.amazon.com/secrets-manager/): the pointed-to
+//!   value is fetched via `GetSecretValue`.
+//!
+//! Both services are reached with the same set of static IAM credentials that are
+//! provisioned into the guest (see [`client`] for the credential layout). This
+//! mirrors the credential-bootstrap model of the Aliyun and eHSM plugins: the
+//! credentials themselves are expected to be delivered into the TEE's encrypted
+//! filesystem (e.g. as a sealed secret) before this client is used.
+
+mod annotations;
+mod client;
+mod credential;
+
+pub use client::AwsKmsClient;

--- a/confidential-data-hub/kms/src/plugins/mod.rs
+++ b/confidential-data-hub/kms/src/plugins/mod.rs
@@ -14,6 +14,9 @@ const _IN_GUEST_DEFAULT_KEY_PATH: &str = "/run/confidential-containers/cdh/kbs/k
 #[cfg(feature = "aliyun")]
 pub mod aliyun;
 
+#[cfg(feature = "aws")]
+pub mod aws;
+
 pub mod kbs;
 
 #[cfg(feature = "ehsm")]
@@ -24,6 +27,10 @@ pub enum DecryptorProvider {
     #[cfg(feature = "aliyun")]
     #[strum(ascii_case_insensitive)]
     Aliyun,
+
+    #[cfg(feature = "aws")]
+    #[strum(ascii_case_insensitive)]
+    Aws,
 
     #[strum(ascii_case_insensitive)]
     #[cfg(feature = "ehsm")]
@@ -43,6 +50,11 @@ pub async fn new_decryptor(
             aliyun::AliyunKmsClient::from_provider_settings(&_provider_settings).await?,
         ) as Box<dyn Decrypter>),
 
+        #[cfg(feature = "aws")]
+        DecryptorProvider::Aws => Ok(Box::new(
+            aws::AwsKmsClient::from_provider_settings(&_provider_settings).await?,
+        ) as Box<dyn Decrypter>),
+
         #[cfg(feature = "ehsm")]
         DecryptorProvider::Ehsm => Ok(Box::new(
             ehsm::EhsmKmsClient::from_provider_settings(&_provider_settings).await?,
@@ -58,6 +70,10 @@ pub enum VaultProvider {
     #[cfg(feature = "aliyun")]
     #[strum(ascii_case_insensitive)]
     Aliyun,
+
+    #[cfg(feature = "aws")]
+    #[strum(ascii_case_insensitive)]
+    Aws,
 }
 
 /// Create a new [`Getter`] by given provider name and [`ProviderSettings`]
@@ -73,6 +89,11 @@ pub async fn new_getter(
         #[cfg(feature = "aliyun")]
         VaultProvider::Aliyun => Ok(Box::new(
             aliyun::AliyunKmsClient::from_provider_settings(&_provider_settings).await?,
+        ) as Box<dyn Getter>),
+
+        #[cfg(feature = "aws")]
+        VaultProvider::Aws => Ok(Box::new(
+            aws::AwsKmsClient::from_provider_settings(&_provider_settings).await?,
         ) as Box<dyn Getter>),
     }
 }


### PR DESCRIPTION
Fixes #1540 

Adds an `aws`-feature-gated KMS provider to Confidential Data Hub, backed by
  **AWS KMS** (envelope/sealed secrets) and **AWS Secrets Manager** (vault secrets).
  CDH previously supported only Aliyun and eHSM, leaving AWS deployments without a
  native provider.

  ## Details

  - `AwsKmsClient` implements `Encrypter`/`Decrypter` (KMS `Encrypt`/`Decrypt`, with
    optional encryption context) and `Getter`/`Setter` (Secrets Manager).
  - Registered as an `Aws` variant for both decryptor and vault providers.
  - `secret_cli` gains an `aws` envelope subcommand (`--region`, `--credential-file-path`).
  - Static IAM credentials are read in-guest from `AWS_IN_GUEST_KEY_PATH`, mirroring
    the Aliyun/eHSM credential-bootstrap model (credential delivered out-of-band,
    attestation-gated — e.g. as a KBS resource).
  - Docs: `kms-providers/aws.md` + provider table entry.

  Complements the AWS Secrets Manager resource backend added to Trustee in
  confidential-containers/trustee#1374 — this is the guest/CDH-side half.

  ## Testing

  - Unit tests for annotation/credential (de)serialization and the
    `export_provider_settings` round-trip.
  - `cargo test -p kms --features aws` — passing.
  - `cargo check` / `cargo clippy -p kms --features aws` — clean.

  Trim the Testing/Trustee lines if you want it even shorter — say the word.