### PR TITLE
fix: fix zizmor security findings in CI workflow files

### DIFF
--- a/.github/workflows/aa_basic.yml
+++ b/.github/workflows/aa_basic.yml
@@ -24,6 +24,8 @@ concurrency:
 
 jobs:
   basic_ci:
+    permissions:
+      contents: read
     if: github.event_name != 'push'
     name: Check
     defaults:
@@ -56,6 +58,7 @@ jobs:
       - name: Code checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
+          persist-credentials: false
           fetch-depth: 1
 
       - name: Install Rust toolchain

--- a/.github/workflows/aa_cc_kbc.yml
+++ b/.github/workflows/aa_cc_kbc.yml
@@ -24,6 +24,8 @@ concurrency:
 
 jobs:
   cc_kbc_ci:
+    permissions:
+      contents: read
     if: github.event_name != 'push'
     name: Check
     defaults:
@@ -56,6 +58,7 @@ jobs:
       - name: Code checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
+          persist-credentials: false
           fetch-depth: 1
 
       - name: Install Rust toolchain

--- a/.github/workflows/aa_crypto.yml
+++ b/.github/workflows/aa_crypto.yml
@@ -20,6 +20,8 @@ concurrency:
 
 jobs:
   crypto_ci:
+    permissions:
+      contents: read
     if: github.event_name != 'push'
     name: Check
     defaults:
@@ -45,6 +47,7 @@ jobs:
       - name: Code checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
+          persist-credentials: false
           fetch-depth: 1
 
       - name: Install Rust toolchain

--- a/.github/workflows/aa_release.yml
+++ b/.github/workflows/aa_release.yml
@@ -32,6 +32,8 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0

--- a/.github/workflows/aa_sample_keyprovider.yml
+++ b/.github/workflows/aa_sample_keyprovider.yml
@@ -19,6 +19,8 @@ concurrency:
 
 jobs:
   coco_keyprovider_ci:
+    permissions:
+      contents: read
     if: github.event_name != 'push'
     name: Check
     strategy:
@@ -38,6 +40,7 @@ jobs:
       - name: Code checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
+          persist-credentials: false
           fetch-depth: 1
 
       - name: Install Rust toolchain

--- a/.github/workflows/aa_sev_kbc.yml
+++ b/.github/workflows/aa_sev_kbc.yml
@@ -42,14 +42,13 @@ jobs:
       - name: Code checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
+          persist-credentials: false
           fetch-depth: 1
 
       - name: Install Rust toolchain (${{ matrix.rust }})
-        uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # v1.0.7
+        uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
         with:
-          profile: minimal
           toolchain: ${{ matrix.rust }}
-          override: true
           components: rustfmt
 
       - name: Build and install with ${{ matrix.kbc }} feature
@@ -62,7 +61,4 @@ jobs:
           make LIBC=musl KBC=${{ matrix.kbc }}
 
       - name: Run cargo test with ${{ matrix.kbc }} feature
-        uses: actions-rs/cargo@844f36862e911db73fe0815f00a4a2602c279505 # v1.0.3
-        with:
-          command: test
-          args: -p kbc --no-default-features --features ${{ matrix.kbc }},rust-crypto
+        run: cargo test -p kbc --no-default-features --features ${{ matrix.kbc }},rust-crypto

--- a/.github/workflows/api-server-rest-basic.yml
+++ b/.github/workflows/api-server-rest-basic.yml
@@ -24,6 +24,8 @@ concurrency:
 
 jobs:
   basic_ci:
+    permissions:
+      contents: read
     if: github.event_name != 'push'
     name: Check
     defaults:
@@ -46,6 +48,7 @@ jobs:
       - name: Code checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
+          persist-credentials: false
           fetch-depth: 1
 
       - name: Install Rust toolchain

--- a/.github/workflows/cdh_basic.yml
+++ b/.github/workflows/cdh_basic.yml
@@ -26,6 +26,8 @@ concurrency:
 
 jobs:
   basic_ci:
+    permissions:
+      contents: read
     if: github.event_name != 'push'
     name: Check
     defaults:
@@ -48,6 +50,7 @@ jobs:
       - name: Code checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
+          persist-credentials: false
           fetch-depth: 1
 
       - name: Install Rust toolchain

--- a/.github/workflows/coco-extension-image.yml
+++ b/.github/workflows/coco-extension-image.yml
@@ -89,10 +89,13 @@ jobs:
         egress-policy: audit
 
     - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      with:
+        persist-credentials: false
 
     - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
       with:
         target: ${{ env.RUST_TARGET }}
+        cache: false
         # This action injects RUSTFLAGS="-D warnings" by default, which leaks
         # into every cargo invocation in the job — including third-party crates
         # built from source by the NVIDIA Attestation SDK (its vendored regorus

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -47,6 +47,8 @@ jobs:
 
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -23,5 +23,7 @@ jobs:
 
       - name: 'Checkout Repository'
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
       - name: 'Dependency Review'
         uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v4

--- a/.github/workflows/image_rs_build.yml
+++ b/.github/workflows/image_rs_build.yml
@@ -23,6 +23,8 @@ concurrency:
 
 jobs:
   ci:
+    permissions:
+      contents: read
     if: github.event_name != 'push'
     name: Check
     defaults:
@@ -45,6 +47,7 @@ jobs:
       - name: Code checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
+          persist-credentials: false
           fetch-depth: 1
 
       - name: Install Rust toolchain

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -21,6 +21,8 @@ jobs:
 
       - name: Checkout code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
       #  TODO: fix this workflow
       # - name: Restore lychee cache
       #   uses: actions/cache@v4

--- a/.github/workflows/ocicrypt_rs_build.yml
+++ b/.github/workflows/ocicrypt_rs_build.yml
@@ -23,6 +23,8 @@ concurrency:
 
 jobs:
   ci:
+    permissions:
+      contents: read
     if: github.event_name != 'push'
     name: Check
     strategy:
@@ -42,6 +44,7 @@ jobs:
       - name: Code checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
+          persist-credentials: false
           fetch-depth: 1
 
       - name: Install Rust toolchain

--- a/.github/workflows/publish-artifacts.yml
+++ b/.github/workflows/publish-artifacts.yml
@@ -55,6 +55,7 @@ jobs:
 
     - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       with:
+        persist-credentials: false
         fetch-depth: 0
         fetch-tags: true
 
@@ -72,13 +73,15 @@ jobs:
         sudo apt-get install -y --no-install-recommends libtss2-dev
 
     - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      with:
+        persist-credentials: false
 
     - name: Build AA
       env:
         ARCH: ${{ matrix.platform.arch }}
         LIBC: ${{ matrix.platform.libc }}
       run: |
-        make ./target/${{ env.RUST_TARGET }}/release/attestation-agent
+        make ./target/$RUST_TARGET/release/attestation-agent
 
     - name: Publish with ORAS
       id: publish
@@ -87,7 +90,7 @@ jobs:
       run: |
         mkdir oras
         cd oras
-        cp ../target/${{ env.RUST_TARGET }}/release/attestation-agent .
+        cp ../target/$RUST_TARGET/release/attestation-agent .
         tar cJf attestation-agent.tar.xz attestation-agent
         arch="${{ matrix.platform.arch }}"
         # After building for target powerpc64le, tag and push the image as ppc64le to match standard arch naming.
@@ -162,6 +165,8 @@ jobs:
         version: 1.2.0
 
     - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      with:
+        persist-credentials: false
 
     - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
       with:
@@ -180,13 +185,13 @@ jobs:
       env:
         ARCH: ${{ matrix.arch }}
         LIBC: ${{ matrix.libc }}
-      run: make ./target/${{ env.RUST_TARGET }}/release/confidential-data-hub
+      run: make ./target/$RUST_TARGET/release/confidential-data-hub
 
     - name: Build ASR
       env:
         ARCH: ${{ matrix.arch }}
         LIBC: ${{ matrix.libc }}
-      run: make ./target/${{ env.RUST_TARGET }}/release/api-server-rest
+      run: make ./target/$RUST_TARGET/release/api-server-rest
 
     - name: Publish CDH + ASR with ORAS
       id: publish
@@ -197,17 +202,17 @@ jobs:
         tag="${{ github.sha }}-${arch}"
         mkdir oras
         cd oras
-        cp ../target/${{ env.RUST_TARGET }}/release/{confidential-data-hub,api-server-rest} .
+        cp ../target/$RUST_TARGET/release/{confidential-data-hub,api-server-rest} .
 
         tar cJf confidential-data-hub.tar.xz confidential-data-hub
-        image="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/confidential-data-hub"
+        image="${{ env.REGISTRY }}/$IMAGE_NAME/confidential-data-hub"
         oras push "${image}:${tag}" confidential-data-hub.tar.xz
         echo "cdh-image=${image}" >> "$GITHUB_OUTPUT"
         digest="$(oras manifest fetch "${image}:${tag}" --descriptor | jq -r .digest)"
         echo "cdh-digest=${digest}" >> "$GITHUB_OUTPUT"
 
         tar cJf api-server-rest.tar.xz api-server-rest
-        image="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/api-server-rest"
+        image="${{ env.REGISTRY }}/$IMAGE_NAME/api-server-rest"
         oras push "${image}:${tag}" api-server-rest.tar.xz
         echo "asr-image=${image}" >> "$GITHUB_OUTPUT"
         digest="$(oras manifest fetch "${image}:${tag}" --descriptor | jq -r .digest)"

--- a/.github/workflows/rust_stable_check.yml
+++ b/.github/workflows/rust_stable_check.yml
@@ -38,6 +38,7 @@ jobs:
       - name: Code checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
+          persist-credentials: false
           fetch-depth: 1
 
       - name: Install Rust toolchain

--- a/.github/workflows/trustee-attester.yml
+++ b/.github/workflows/trustee-attester.yml
@@ -16,6 +16,8 @@ concurrency:
 
 jobs:
   trustee_attester_ci:
+    permissions:
+      contents: read
     name: Check
     defaults:
       run:
@@ -44,6 +46,7 @@ jobs:
       - name: Code checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
+          persist-credentials: false
           fetch-depth: 1
 
       - name: Install Rust toolchain

--- a/.github/workflows/vendor_release.yml
+++ b/.github/workflows/vendor_release.yml
@@ -6,6 +6,8 @@ on:
 
 jobs:
   generate-and-publish-vendored-code:
+    permissions:
+      contents: write
     runs-on: ubuntu-24.04
     steps:
       - name: Harden the runner (Audit all outbound calls)
@@ -15,6 +17,8 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Generate and publish cargo vendored tarball
         run: |


### PR DESCRIPTION
## Summary

Ran `zizmor v1.25.2` locally against `.github/workflows/` and fixed all findings.

## Changes

### `artipacked` — Low severity
Added `persist-credentials: false` to all `actions/checkout` steps across 18 workflow
files. This prevents the GitHub token from being persisted in the local git config after
checkout, reducing the risk of credential exposure via artifacts.

### `excessive-permissions` — Medium severity
Added explicit `permissions: contents: read` to all jobs that were using broad default
permissions. Exception: `vendor_release.yml` uses `permissions: contents: write` since it
uploads release assets via `gh release upload`.

### `archived-uses` — Medium severity
Replaced the abandoned `actions-rs/toolchain` and `actions-rs/cargo` actions in
`aa_sev_kbc.yml` with `actions-rust-lang/setup-rust-toolchain` (already used consistently
across all other workflows in this repo) and an inline `run:` step respectively.
The `actions-rs` organisation is archived and no longer receives security updates.

### `template-injection` — Medium severity
In `publish-artifacts.yml`, replaced `${{ env.RUST_TARGET }}` and `${{ env.IMAGE_NAME }}`
template expressions inside `run:` blocks with their shell variable equivalents
`$RUST_TARGET` / `$IMAGE_NAME`. Both variables are already defined at the job-level `env:`
block and are automatically available as shell variables — no step-level redeclaration needed.

### `cache-poisoning` — High severity
In `coco-extension-image.yml` (new upstream file), added `cache: false` to the
`actions-rust-lang/setup-rust-toolchain` step. This workflow triggers on `pull_request`
and publishes runtime artifacts, making it vulnerable to cache poisoning without this flag.

## Verification

```bash
zizmor .github/workflows/
# No findings to report. Good job! (88 suppressed)