### PR TITLE
cdh: document and test inline image_security_policy

### DIFF
--- a/confidential-data-hub/example.config.json
+++ b/confidential-data-hub/example.config.json
@@ -22,6 +22,7 @@
         "max_concurrent_layer_downloads_per_image": 3,
         "sigstore_config_uri": "kbs:///default/sigstore-config/test",
         "image_security_policy_uri": "kbs:///default/security-policy/test",
+        "image_security_policy": "{\"default\":[{\"type\": \"reject\"}]}",
         "authenticated_registry_credentials_uri": "kbs:///default/credential/test",
         "registry_configuration_uri": "kbs:///default/registry-configuration/test",
         "registry_config": {

--- a/confidential-data-hub/example.config.toml
+++ b/confidential-data-hub/example.config.toml
@@ -76,9 +76,10 @@ max_concurrent_layer_downloads_per_image = 3
 
 # Sigstore config file URI for simple signing scheme.
 #
-# When `image_security_policy_uri` is set and `SimpleSigning` (signedBy) is
-# used in the policy, the signatures of the images would be used for image
-# signature validation. This policy will record where the signatures is.
+# When `image_security_policy_uri` or `image_security_policy` is set and
+# `SimpleSigning` (signedBy) is used in the policy, the signatures of the
+# images would be used for image signature validation. This policy will
+# record where the signatures is.
 #
 # Now it supports two different forms:
 # - `KBS URI`: the sigstore config file will be fetched from KBS,
@@ -106,6 +107,25 @@ sigstore_config_uri = "kbs:///default/sigstore-config/test"
 #
 # By default this value is not set.
 image_security_policy_uri = "kbs:///default/security-policy/test"
+
+# The image security policy can also be specified directly as a string
+# (for example via init-data) instead of referencing it via a URI.
+# If both `image_security_policy_uri` and this field are set, the URI
+# takes priority.
+#
+# The policy follows the same format as described above for
+# `image_security_policy_uri`.
+#
+# By default this value is not set.
+# image_security_policy = """
+# {
+#     "default": [
+#         {
+#             "type": "reject"
+#         }
+#     ]
+# }
+# """
 
 # If any credential auth (Base) would be used to connect to download
 # image from private registry, this field is used to set the URI of the

--- a/confidential-data-hub/hub/src/config/mod.rs
+++ b/confidential-data-hub/hub/src/config/mod.rs
@@ -392,6 +392,41 @@ some_undefined_field = "unknown value"
         skip_sealed_secret_verification: false,
     })
     )]
+    #[case(
+        r#"
+[kbc]
+name = "offline_fs_kbc"
+
+[image]
+image_security_policy = """
+{
+    "default": [
+        {
+            "type": "reject"
+        }
+    ]
+}
+"""
+"#,
+    Some(CdhConfig {
+        log: LogConfig::default(),
+        kbc: KbsConfig {
+            name: "offline_fs_kbc".to_string(),
+            url: "".to_string(),
+            kbs_cert: None,
+        },
+        credentials: vec![],
+        image: ImageConfig {
+                image_security_policy: Some(
+                    "{\n    \"default\": [\n        {\n            \"type\": \"reject\"\n        }\n    ]\n}\n"
+                        .to_string(),
+                ),
+                ..Default::default()
+        },
+        socket: DEFAULT_CDH_SOCKET_ADDR.to_string(),
+        skip_sealed_secret_verification: false,
+    })
+    )]
     #[serial]
     fn read_config(#[case] config: &str, #[case] expected: Option<CdhConfig>) {
         let mut file = tempfile::Builder::new()

--- a/confidential-data-hub/hub/src/config/mod.rs
+++ b/confidential-data-hub/hub/src/config/mod.rs
@@ -425,6 +425,7 @@ image_security_policy = """
         },
         socket: DEFAULT_CDH_SOCKET_ADDR.to_string(),
         skip_sealed_secret_verification: false,
+        aa: AaConfig::default(),
     })
     )]
     #[serial]


### PR DESCRIPTION
Expose the image-rs image_security_policy option in CDH example configs and cover parsing so init-data can set the policy without a URI.