### PR TITLE
attester: introduce az cvm vtpm evidence v2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -388,6 +388,7 @@ dependencies = [
  "async-trait",
  "az-snp-vtpm",
  "az-tdx-vtpm",
+ "azure-guest-attestation-sdk",
  "base64 0.22.1",
  "cfg-if",
  "clap",
@@ -422,6 +423,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "tss-esapi",
+ "zerocopy",
 ]
 
 [[package]]
@@ -558,6 +560,27 @@ dependencies = [
  "thiserror 2.0.18",
  "ureq",
  "zerocopy",
+]
+
+[[package]]
+name = "azure-guest-attestation-sdk"
+version = "0.1.0"
+source = "git+https://github.com/Azure/azure-guest-attestation-sdk?rev=e606728446cb66d681913983cbe5563c919dd94b#e606728446cb66d681913983cbe5563c919dd94b"
+dependencies = [
+ "aes-gcm 0.10.3",
+ "base64 0.22.1",
+ "bitfield-struct",
+ "digest 0.10.7",
+ "hex",
+ "rand 0.8.6",
+ "reqwest 0.12.28",
+ "serde",
+ "serde_json",
+ "sha1",
+ "sha2 0.10.9",
+ "tracing",
+ "tracing-subscriber",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -720,6 +743,17 @@ name = "bitfield-macros"
 version = "0.19.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f48d6ace212fdf1b45fd6b566bb40808415344642b76c3224c07c8df9da81e97"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "bitfield-struct"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adc0846593a56638b74e136a45610f9934c052e14761bebca6b092d5522599e3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7885,6 +7919,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-serde"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
 name = "tracing-subscriber"
 version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7894,12 +7938,15 @@ dependencies = [
  "nu-ansi-term",
  "once_cell",
  "regex-automata",
+ "serde",
+ "serde_json",
  "sharded-slab",
  "smallvec",
  "thread_local",
  "tracing",
  "tracing-core",
  "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]
@@ -8917,18 +8964,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.48"
+version = "0.8.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+checksum = "b7cbbc0a705a0fd05cc3676525980d2bf5a9bc4adac6d6475209a7887cf59d19"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.48"
+version = "0.8.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+checksum = "e2e817b7b52d0c7358d3246da9d69935ebb18116b2b102b4230dac079b4862f5"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/attestation-agent/attester/Cargo.toml
+++ b/attestation-agent/attester/Cargo.toml
@@ -15,6 +15,7 @@ az-snp-vtpm = { version = "0.8.1", default-features = false, features = [
 az-tdx-vtpm = { version = "0.8.1", default-features = false, features = [
     "attester",
 ], optional = true }
+azure-guest-attestation-sdk = { git = "https://github.com/Azure/azure-guest-attestation-sdk", rev = "e606728446cb66d681913983cbe5563c919dd94b", optional = true }
 base64.workspace = true
 clap = { workspace = true, features = ["derive"], optional = true }
 cfg-if.workspace = true
@@ -53,7 +54,7 @@ picky-asn1 = { version = "0.10.1", optional = true }
 picky-asn1-der = { version = "0.5.6", optional = true }
 picky-asn1-x509 = { version = "0.15.4", optional = true }
 tss-esapi = { version = "7.5", optional = true }
-
+zerocopy = { version = "0.8.54", optional = true }
 
 [dev-dependencies]
 tokio.workspace = true
@@ -86,7 +87,7 @@ tdx-attest-dcap-ioctls = ["tdx-attest-rs"]
 sgx-attester = ["occlum_dcap"]
 nvidia-attester = ["nv-attestation-sdk"]
 az-snp-vtpm-attester = ["az-snp-vtpm", "pem-rfc7468"]
-az-tdx-vtpm-attester = ["az-snp-vtpm-attester", "az-tdx-vtpm"]
+az-tdx-vtpm-attester = ["az-snp-vtpm-attester", "az-tdx-vtpm", "azure-guest-attestation-sdk", "zerocopy"]
 snp-attester = ["sev"]
 csv-attester = ["hygon", "codicon", "hyper", "hyper-tls"]
 hygon-dcu-attester = ["hygon"]

--- a/attestation-agent/attester/src/az_snp_vtpm/mod.rs
+++ b/attestation-agent/attester/src/az_snp_vtpm/mod.rs
@@ -27,7 +27,7 @@ pub fn detect_platform() -> bool {
 #[derive(Debug, Default)]
 pub struct AzSnpVtpmAttester;
 
-const EVIDENCE_VERSION: u32 = 1;
+const EVIDENCE_VERSION: u32 = 2;
 
 /// TPM quote containing PCR values and attestation data.
 ///
@@ -92,8 +92,8 @@ fn pem_to_der(pem: &str) -> Result<Vec<u8>> {
 }
 
 fn get_evidence_sync(report_data: &[u8]) -> anyhow::Result<TeeEvidence> {
-    let hcl_report = vtpm::get_report()?;
-    let tpm_quote = vtpm::get_quote(&report_data)?.into();
+    let hcl_report = vtpm::get_report_with_report_data(report_data)?;
+    let tpm_quote = vtpm::get_quote(report_data)?.into();
     let certs = imds::get_certs()?;
     let vcek = pem_to_der(&certs.vcek)?;
 

--- a/attestation-agent/attester/src/az_snp_vtpm/mod.rs
+++ b/attestation-agent/attester/src/az_snp_vtpm/mod.rs
@@ -9,6 +9,7 @@ use az_snp_vtpm::{imds, is_snp_cvm, vtpm};
 use kbs_types::HashAlgorithm;
 use serde::{Deserialize, Serialize};
 use serde_with::{base64::Base64, hex::Hex, serde_as};
+use tokio::task::spawn_blocking;
 use tracing::{debug, info};
 
 type UrlSafeBase64 = Base64<serde_with::base64::UrlSafe>;
@@ -90,22 +91,26 @@ fn pem_to_der(pem: &str) -> Result<Vec<u8>> {
     Ok(der)
 }
 
+fn get_evidence_sync(report_data: &[u8]) -> anyhow::Result<TeeEvidence> {
+    let hcl_report = vtpm::get_report()?;
+    let tpm_quote = vtpm::get_quote(&report_data)?.into();
+    let certs = imds::get_certs()?;
+    let vcek = pem_to_der(&certs.vcek)?;
+
+    let evidence = Evidence {
+        version: EVIDENCE_VERSION,
+        tpm_quote,
+        hcl_report,
+        vcek,
+    };
+
+    Ok(serde_json::to_value(&evidence)?)
+}
+
 #[async_trait::async_trait]
 impl Attester for AzSnpVtpmAttester {
     async fn get_evidence(&self, report_data: Vec<u8>) -> anyhow::Result<TeeEvidence> {
-        let hcl_report = vtpm::get_report()?;
-        let tpm_quote = vtpm::get_quote(&report_data)?.into();
-        let certs = imds::get_certs()?;
-        let vcek = pem_to_der(&certs.vcek)?;
-
-        let evidence = Evidence {
-            version: EVIDENCE_VERSION,
-            tpm_quote,
-            hcl_report,
-            vcek,
-        };
-
-        Ok(serde_json::to_value(&evidence)?)
+        spawn_blocking(move || get_evidence_sync(&report_data)).await?
     }
 
     fn supports_runtime_measurement(&self) -> bool {
@@ -113,7 +118,8 @@ impl Attester for AzSnpVtpmAttester {
     }
 
     async fn bind_init_data(&self, init_data_digest: &[u8]) -> anyhow::Result<InitDataResult> {
-        utils::extend_pcr(init_data_digest, utils::INIT_DATA_PCR)?;
+        let digest = init_data_digest.to_vec();
+        spawn_blocking(move || utils::extend_pcr_sync(&digest, utils::INIT_DATA_PCR)).await??;
         Ok(InitDataResult::Ok)
     }
 
@@ -122,7 +128,8 @@ impl Attester for AzSnpVtpmAttester {
         event_digest: Vec<u8>,
         register_index: u64,
     ) -> Result<()> {
-        utils::extend_pcr(&event_digest, register_index as u8)?;
+        spawn_blocking(move || utils::extend_pcr_sync(&event_digest, register_index as u8))
+            .await??;
         Ok(())
     }
 
@@ -143,7 +150,7 @@ pub(crate) mod utils {
 
     pub const INIT_DATA_PCR: u8 = 8;
 
-    pub fn extend_pcr(digest: &[u8], pcr: u8) -> Result<()> {
+    pub fn extend_pcr_sync(digest: &[u8], pcr: u8) -> Result<()> {
         let sha256_digest: [u8; 32] = digest.try_into().context("expected sha256 digest")?;
         if pcr > 23 {
             bail!("Invalid PCR index: {pcr}");

--- a/attestation-agent/attester/src/az_tdx_vtpm/mod.rs
+++ b/attestation-agent/attester/src/az_tdx_vtpm/mod.rs
@@ -29,7 +29,7 @@ pub fn detect_platform() -> bool {
 #[derive(Debug, Default)]
 pub struct AzTdxVtpmAttester;
 
-const EVIDENCE_VERSION: u32 = 1;
+const EVIDENCE_VERSION: u32 = 2;
 
 /// Attestation evidence for Azure TDX vTPM.
 ///

--- a/attestation-agent/attester/src/az_tdx_vtpm/mod.rs
+++ b/attestation-agent/attester/src/az_tdx_vtpm/mod.rs
@@ -6,13 +6,15 @@
 use super::{Attester, InitDataResult, TeeEvidence};
 use crate::az_snp_vtpm::{utils, TpmQuote};
 use anyhow::*;
-use az_tdx_vtpm::{hcl, imds, is_tdx_cvm, vtpm};
+use az_tdx_vtpm::{hcl, is_tdx_cvm, tdx::TdReport, vtpm};
+use azure_guest_attestation_sdk::guest_attest::ImdsClient;
 use kbs_types::HashAlgorithm;
 use serde::{Deserialize, Serialize};
 use serde_with::{base64::Base64, serde_as};
 use std::result::Result::Ok;
 use tokio::task::spawn_blocking;
 use tracing::debug;
+use zerocopy::IntoBytes;
 
 type UrlSafeBase64 = Base64<serde_with::base64::UrlSafe>;
 
@@ -53,16 +55,15 @@ struct Evidence {
 }
 
 fn get_evidence_sync(report_data: &[u8]) -> anyhow::Result<TeeEvidence> {
-    let hcl_report_bytes = vtpm::get_report_with_report_data(&report_data)?;
-    let hcl_report = hcl::HclReport::new(hcl_report_bytes.clone())?;
-    let td_report = hcl_report.try_into()?;
-    let td_quote = imds::get_td_quote(&td_report)?;
-    let tpm_quote = vtpm::get_quote(&report_data)?.into();
+    let hcl_report = vtpm::get_report_with_report_data(report_data)?;
+    let td_report: TdReport = hcl::HclReport::new(hcl_report.clone())?.try_into()?;
+    let td_quote = ImdsClient::new().get_td_quote(td_report.as_bytes())?;
+    let tpm_quote = vtpm::get_quote(report_data)?.into();
 
     let evidence = Evidence {
         version: EVIDENCE_VERSION,
         tpm_quote,
-        hcl_report: hcl_report_bytes,
+        hcl_report,
         td_quote,
     };
     Ok(serde_json::to_value(&evidence)?)

--- a/attestation-agent/attester/src/az_tdx_vtpm/mod.rs
+++ b/attestation-agent/attester/src/az_tdx_vtpm/mod.rs
@@ -11,6 +11,7 @@ use kbs_types::HashAlgorithm;
 use serde::{Deserialize, Serialize};
 use serde_with::{base64::Base64, serde_as};
 use std::result::Result::Ok;
+use tokio::task::spawn_blocking;
 use tracing::debug;
 
 type UrlSafeBase64 = Base64<serde_with::base64::UrlSafe>;
@@ -51,26 +52,31 @@ struct Evidence {
     td_quote: Vec<u8>,
 }
 
+fn get_evidence_sync(report_data: &[u8]) -> anyhow::Result<TeeEvidence> {
+    let hcl_report_bytes = vtpm::get_report_with_report_data(&report_data)?;
+    let hcl_report = hcl::HclReport::new(hcl_report_bytes.clone())?;
+    let td_report = hcl_report.try_into()?;
+    let td_quote = imds::get_td_quote(&td_report)?;
+    let tpm_quote = vtpm::get_quote(&report_data)?.into();
+
+    let evidence = Evidence {
+        version: EVIDENCE_VERSION,
+        tpm_quote,
+        hcl_report: hcl_report_bytes,
+        td_quote,
+    };
+    Ok(serde_json::to_value(&evidence)?)
+}
+
 #[async_trait::async_trait]
 impl Attester for AzTdxVtpmAttester {
     async fn get_evidence(&self, report_data: Vec<u8>) -> Result<TeeEvidence> {
-        let hcl_report_bytes = vtpm::get_report_with_report_data(&report_data)?;
-        let hcl_report = hcl::HclReport::new(hcl_report_bytes.clone())?;
-        let td_report = hcl_report.try_into()?;
-        let td_quote = imds::get_td_quote(&td_report)?;
-        let tpm_quote = vtpm::get_quote(&report_data)?.into();
-
-        let evidence = Evidence {
-            version: EVIDENCE_VERSION,
-            tpm_quote,
-            hcl_report: hcl_report_bytes,
-            td_quote,
-        };
-        Ok(serde_json::to_value(&evidence)?)
+        spawn_blocking(move || get_evidence_sync(&report_data)).await?
     }
 
     async fn bind_init_data(&self, init_data_digest: &[u8]) -> anyhow::Result<InitDataResult> {
-        utils::extend_pcr(init_data_digest, utils::INIT_DATA_PCR)?;
+        let digest = init_data_digest.to_vec();
+        spawn_blocking(move || utils::extend_pcr_sync(&digest, utils::INIT_DATA_PCR)).await??;
         Ok(InitDataResult::Ok)
     }
 
@@ -83,7 +89,8 @@ impl Attester for AzTdxVtpmAttester {
         event_digest: Vec<u8>,
         register_index: u64,
     ) -> Result<()> {
-        utils::extend_pcr(&event_digest, register_index as u8)?;
+        spawn_blocking(move || utils::extend_pcr_sync(&event_digest, register_index as u8))
+            .await??;
         Ok(())
     }
 


### PR DESCRIPTION
This PR will make the attester produce v2 evidence, those are structurally equal to v1 evidence, but the hcl_report.var_data.user-data field is now guaranteed to be populated, as we are fetching fresh reports with the kbs provided-nonce mixed into them. This has been the case for TDX already, but we didn't assert it on the verifier side, yet. We also extend this for the SNP case.

Verifiers can assert the freshness not only for the TPM quote, but also for SNP/TDX Attestation Reports.

This has some technical implications. Now evidence retrieval will take a couple of seconds, so there will be more latency for the SNP attester. The TEE platform code is not async and longer running sync blocks that perform FFI need to be put into their own sync context within the attesters async get_evidence() fn's. Finally, to receive a TD quote TDX VMs on azure pass a TD report to IMDS. We switched to the azure-guest-attestation-sdk for this functionality to improve reliability of interactions with this IMDS endpoint. we'll probably migrate further parts to that SDK in the future. 