### PR TITLE
api-server-rest: retry requests on LocalClosed

### DIFF
--- a/api-server-rest/src/client/aa.rs
+++ b/api-server-rest/src/client/aa.rs
@@ -11,6 +11,7 @@ use protos::ttrpc::aa::attestation_agent::{
 use protos::ttrpc::aa::attestation_agent_ttrpc::AttestationAgentServiceClient;
 use serde::Deserialize;
 
+use crate::client::ttrpc_client::CachedTtrpcClient;
 use crate::TTRPC_TIMEOUT;
 
 /// ROOT path for Confidential Data Hub API
@@ -23,7 +24,7 @@ pub const AA_ADDITIONAL_EVIDENCE_URL: &str = "/additional-evidence";
 pub const AA_AAEL_URL: &str = "/aael";
 
 pub struct AAClient {
-    client: AttestationAgentServiceClient,
+    client: CachedTtrpcClient<AttestationAgentServiceClient>,
 }
 
 #[derive(Deserialize)]
@@ -35,46 +36,63 @@ pub struct AaelEvent {
 
 impl AAClient {
     pub async fn new(aa_addr: &str) -> Result<Self> {
-        let inner = ttrpc::asynchronous::Client::connect(aa_addr)
-            .await
-            .context(format!("ttrpc connect to AA addr: {aa_addr} failed!"))?;
-        let client = AttestationAgentServiceClient::new(inner);
+        let client = CachedTtrpcClient::new(
+            aa_addr,
+            "Attestation Agent",
+            AttestationAgentServiceClient::new,
+        )
+        .await?;
 
         Ok(Self { client })
     }
 
     pub async fn get_token(&self, token_type: &str) -> Result<Vec<u8>> {
-        let req = GetTokenRequest {
-            TokenType: token_type.to_string(),
-            ..Default::default()
-        };
         let res = self
             .client
-            .get_token(ttrpc::context::with_timeout(TTRPC_TIMEOUT), &req)
+            .call_with_retry(|client| async move {
+                let req = GetTokenRequest {
+                    TokenType: token_type.to_string(),
+                    ..Default::default()
+                };
+                client
+                    .get_token(ttrpc::context::with_timeout(TTRPC_TIMEOUT), &req)
+                    .await
+            })
             .await?;
+
         Ok(res.Token)
     }
 
     pub async fn get_evidence(&self, runtime_data: &[u8]) -> Result<Vec<u8>> {
-        let req = GetEvidenceRequest {
-            RuntimeData: runtime_data.to_vec(),
-            ..Default::default()
-        };
         let res = self
             .client
-            .get_evidence(ttrpc::context::with_timeout(TTRPC_TIMEOUT), &req)
+            .call_with_retry(|client| async move {
+                let req = GetEvidenceRequest {
+                    RuntimeData: runtime_data.to_vec(),
+                    ..Default::default()
+                };
+
+                client
+                    .get_evidence(ttrpc::context::with_timeout(TTRPC_TIMEOUT), &req)
+                    .await
+            })
             .await?;
         Ok(res.Evidence)
     }
 
     pub async fn get_additional_evidence(&self, runtime_data: &[u8]) -> Result<Vec<u8>> {
-        let req = GetAdditionalEvidenceRequest {
-            RuntimeData: runtime_data.to_vec(),
-            ..Default::default()
-        };
         let res = self
             .client
-            .get_additional_evidence(ttrpc::context::with_timeout(TTRPC_TIMEOUT), &req)
+            .call_with_retry(|client| async move {
+                let req = GetAdditionalEvidenceRequest {
+                    RuntimeData: runtime_data.to_vec(),
+                    ..Default::default()
+                };
+
+                client
+                    .get_additional_evidence(ttrpc::context::with_timeout(TTRPC_TIMEOUT), &req)
+                    .await
+            })
             .await?;
         Ok(res.Evidence)
     }
@@ -85,15 +103,20 @@ impl AAClient {
         operation: &str,
         content: &str,
     ) -> Result<String> {
-        let req = ExtendRuntimeMeasurementRequest {
-            Domain: domain.into(),
-            Operation: operation.into(),
-            Content: content.into(),
-            ..Default::default()
-        };
         let res = self
             .client
-            .extend_runtime_measurement(ttrpc::context::with_timeout(TTRPC_TIMEOUT), &req)
+            .call_with_retry(|client| async move {
+                let req = ExtendRuntimeMeasurementRequest {
+                    Domain: domain.into(),
+                    Operation: operation.into(),
+                    Content: content.into(),
+                    ..Default::default()
+                };
+
+                client
+                    .extend_runtime_measurement(ttrpc::context::with_timeout(TTRPC_TIMEOUT), &req)
+                    .await
+            })
             .await?
             .Result
             .value();
@@ -109,23 +132,33 @@ impl AAClient {
     }
 
     pub async fn get_tee_type(&self) -> Result<String> {
-        let req = GetTeeTypeRequest {
-            ..Default::default()
-        };
         let res = self
             .client
-            .get_tee_type(ttrpc::context::with_timeout(TTRPC_TIMEOUT), &req)
+            .call_with_retry(|client| async move {
+                let req = GetTeeTypeRequest {
+                    ..Default::default()
+                };
+
+                client
+                    .get_tee_type(ttrpc::context::with_timeout(TTRPC_TIMEOUT), &req)
+                    .await
+            })
             .await?;
         Ok(res.tee)
     }
 
     pub async fn get_additional_tees(&self) -> Result<Vec<String>> {
-        let req = GetAdditionalTeesRequest {
-            ..Default::default()
-        };
         let res = self
             .client
-            .get_additional_tees(ttrpc::context::with_timeout(TTRPC_TIMEOUT), &req)
+            .call_with_retry(|client| async move {
+                let req = GetAdditionalTeesRequest {
+                    ..Default::default()
+                };
+
+                client
+                    .get_additional_tees(ttrpc::context::with_timeout(TTRPC_TIMEOUT), &req)
+                    .await
+            })
             .await?;
         Ok(res.additional_tees)
     }

--- a/api-server-rest/src/client/cdh.rs
+++ b/api-server-rest/src/client/cdh.rs
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+use crate::client::ttrpc_client::CachedTtrpcClient;
 use crate::TTRPC_TIMEOUT;
 use anyhow::*;
 use protos::ttrpc::cdh::api::GetResourceRequest;
@@ -17,28 +18,37 @@ pub const CDH_RESOURCE_URL: &str = "/resource";
 const KBS_PREFIX: &str = "kbs://";
 
 pub struct CDHClient {
-    client: GetResourceServiceClient,
+    client: CachedTtrpcClient<GetResourceServiceClient>,
 }
 
 impl CDHClient {
     pub async fn new(cdh_addr: &str) -> Result<Self> {
-        let inner = ttrpc::asynchronous::Client::connect(cdh_addr)
-            .await
-            .context(format!("ttrpc connect to CDH addr: {cdh_addr} failed!"))?;
-        let client = GetResourceServiceClient::new(inner);
+        let client = CachedTtrpcClient::new(cdh_addr, "CDH", GetResourceServiceClient::new).await?;
 
         Ok(Self { client })
     }
 
     pub async fn get_resource(&self, resource_path: &str) -> Result<Vec<u8>> {
-        let req = GetResourceRequest {
-            ResourcePath: format!("{KBS_PREFIX}{resource_path}"),
-            ..Default::default()
-        };
+        let resource_path = format!("{KBS_PREFIX}{resource_path}");
+
         let res = self
             .client
-            .get_resource(ttrpc::context::with_timeout(TTRPC_TIMEOUT), &req)
+            .call_with_retry(|client| {
+                let resource_path = resource_path.clone();
+
+                async move {
+                    let req = GetResourceRequest {
+                        ResourcePath: resource_path,
+                        ..Default::default()
+                    };
+
+                    client
+                        .get_resource(ttrpc::context::with_timeout(TTRPC_TIMEOUT), &req)
+                        .await
+                }
+            })
             .await?;
+
         Ok(res.Resource)
     }
 }

--- a/api-server-rest/src/client/mod.rs
+++ b/api-server-rest/src/client/mod.rs
@@ -5,3 +5,4 @@
 
 pub mod aa;
 pub mod cdh;
+pub(crate) mod ttrpc_client;

--- a/api-server-rest/src/client/ttrpc_client.rs
+++ b/api-server-rest/src/client/ttrpc_client.rs
@@ -29,8 +29,6 @@ where
             new_client,
         };
 
-        this.ensure_client().await?;
-
         Ok(this)
     }
 

--- a/api-server-rest/src/client/ttrpc_client.rs
+++ b/api-server-rest/src/client/ttrpc_client.rs
@@ -1,0 +1,94 @@
+// Copyright (c) 2026 Confidential Containers Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+use anyhow::{Context, Result};
+use tokio::sync::RwLock;
+
+pub struct CachedTtrpcClient<C> {
+    client: RwLock<Option<C>>,
+    addr: String,
+    name: &'static str,
+    new_client: fn(ttrpc::asynchronous::Client) -> C,
+}
+
+impl<C> CachedTtrpcClient<C>
+where
+    C: Clone,
+{
+    pub async fn new(
+        addr: &str,
+        name: &'static str,
+        new_client: fn(ttrpc::asynchronous::Client) -> C,
+    ) -> Result<Self> {
+        let this = Self {
+            client: RwLock::new(None),
+            addr: addr.to_string(),
+            name,
+            new_client,
+        };
+
+        this.ensure_client().await?;
+
+        Ok(this)
+    }
+
+    async fn connect_client(&self) -> Result<C> {
+        let inner = ttrpc::asynchronous::Client::connect(&self.addr)
+            .await
+            .with_context(|| {
+                format!("ttrpc connect to {} addr: {} failed", self.name, self.addr)
+            })?;
+
+        Ok((self.new_client)(inner))
+    }
+
+    pub async fn ensure_client(&self) -> Result<C> {
+        {
+            let client_guard = self.client.read().await;
+            if let Some(client) = client_guard.as_ref() {
+                return Ok(client.clone());
+            }
+        }
+
+        let mut client_guard = self.client.write().await;
+        if client_guard.is_none() {
+            let client = self.connect_client().await?;
+            *client_guard = Some(client);
+        }
+
+        client_guard
+            .as_ref()
+            .cloned()
+            .with_context(|| format!("{} ttrpc client is not initialized", self.name))
+    }
+
+    pub async fn call_with_retry<F, Fut, T>(&self, f: F) -> Result<T>
+    where
+        F: Fn(C) -> Fut,
+        Fut: std::future::Future<Output = ttrpc::Result<T>>,
+    {
+        let client = self.ensure_client().await?;
+
+        match f(client).await {
+            std::result::Result::Ok(res) => std::result::Result::Ok(res),
+
+            std::result::Result::Err(ttrpc::Error::LocalClosed) => {
+                *self.client.write().await = None;
+
+                let client = self.ensure_client().await.with_context(|| {
+                    format!("failed to reconnect to {} after LocalClosed", self.name)
+                })?;
+
+                f(client)
+                    .await
+                    .context("ttrpc request error after reconnect")
+            }
+
+            std::result::Result::Err(e) => {
+                std::result::Result::Err(e).context("ttrpc request error")
+            }
+        }
+    }
+}


### PR DESCRIPTION
The current implementation establishes a connection during process startup and reuses it for all subsequent requests. As a result, if the Attestation Agent is restarted, requests can fail with the error `ttrpc err: local stream closed`.

When a `LocalClosed` error is returned, clear the cached client, reconnect to the Attestation Agent, and retry the request once.