### PR TITLE
sync coco-extension with kata build config

### DIFF
--- a/.github/workflows/coco-extension-image.yml
+++ b/.github/workflows/coco-extension-image.yml
@@ -57,7 +57,7 @@ jobs:
         include:
         - arch: x86_64
           oci_arch: amd64
-          libc: musl
+          libc: gnu
           attester: snp-attester,tdx-attester
           measured_rootfs: "yes"
           runner: ubuntu-24.04

--- a/tools/coco-extension/assemble-rootfs.sh
+++ b/tools/coco-extension/assemble-rootfs.sh
@@ -36,7 +36,7 @@ repo_root_dir="$(cd "${script_dir}/../.." && pwd)"
 # Target selection. Defaults match a native x86_64 build; the CI workflow
 # overrides these per architecture.
 ARCH="${ARCH:-$(uname -m)}"
-LIBC="${LIBC:-musl}"
+LIBC="${LIBC:-gnu}"
 
 # Attesters and resource providers compiled into the guest components. These are
 # architecture specific (e.g. tdx/snp attesters only build on x86_64, se-attester
@@ -111,12 +111,12 @@ copy_non_glibc_library_closure() {
 
 		dep_name="$(basename "${dep_path}")"
 		case "${dep_name}" in
-			ld-linux-*|libc.so.*|libdl.so.*|libm.so.*|libpthread.so.*|librt.so.*)
+			ld-linux-*|libc.so.*|libdl.so.*|libm.so.*|libpthread.so.*|librt.so.*|linux-vdso*)
 				continue
 				;;
 		esac
 
-		cp -a "${dep_path}" "${dest_dir}/"
+		install -D -m0755 "${dep_path}" "${dest_dir}/${dep_name}"
 	done < <(ldd "${lib}")
 }
 
@@ -136,7 +136,7 @@ build_nvidia_attestation_agent() {
 	[[ -e "${NVAT_LIB_DIR}/libnvat.so" || -e "${NVAT_LIB_DIR}/libnvat.so.1" ]] || \
 		die "NVIDIA SDK libnvat.so not found in ${NVAT_LIB_DIR}"
 
-	info "Building NVIDIA attester variant (ATTESTER=${NV_ATTESTER})"
+	info "Building NVIDIA attester variant (ATTESTER=${NV_ATTESTER} LIBC=${LIBC})"
 	rm -f "${build_dir}/attestation-agent"
 
 	NVAT_USE_SYSTEM_LIB=1 \

--- a/tools/coco-extension/components.toml
+++ b/tools/coco-extension/components.toml
@@ -34,14 +34,11 @@ select        = "${attester_variant}"
   [process.variants.nvidia]
   path = "usr/local/bin/attestation-agent-nv"
   # attestation-agent-nv links libnvat.so (bundled in this CoCo extension under
-  # usr/local/lib), which dlopens libnvidia-ml.so.1 at runtime to collect GPU
-  # attestation evidence. NVML ships in the GPU extension, mounted by NVRC at the
-  # well-known /run/kata-extensions/gpu with its driver libraries under usr/lib, so
-  # both dirs must be on the loader path. The nvidia variant only runs when the
-  # GPU extension is present, so referencing its mount path here is safe; without
-  # the GPU lib dir NVML init fails ("NVAT Error 500: NVML Initialization
-  # Failed") and the RCAR handshake never produces GPU evidence.
-  env  = { LD_LIBRARY_PATH = "${extension_root}/usr/local/lib:/run/kata-extensions/gpu/usr/lib" }
+  # usr/local/lib), which dlopens libnvidia-ml.so.1 for GPU attestation evidence.
+  # Only NVAT's own libs need LD_LIBRARY_PATH: NVML lives in the GPU extension,
+  # which NVRC folds into the guest loader cache before starting kata-agent, so it
+  # resolves without a path here (see NVRC gpu::setup).
+  env  = { LD_LIBRARY_PATH = "${extension_root}/usr/local/lib" }
 
 [[process]]
 id           = "confidential-data-hub"
@@ -50,11 +47,12 @@ path         = "usr/local/bin/confidential-data-hub"
 config       = "${cdh_config_path}"
 # CDH's secure_mount shells out (by PATH lookup) to cryptsetup for encrypted
 # storage and to mke2fs/mkfs.ext4/dd for the filesystem. cryptsetup is CoCo-only
-# and ships in this extension under usr/sbin (see
-# build-static-coco-guest-components.sh); the plain mkfs/dd tooling lives in the
-# base-nvidia image's /sbin and /bin. The agent launches CDH with
-# PATH=/bin:/sbin:/usr/bin:/usr/sbin, but setting any env here overrides it
-# wholesale, so prepend the extension's usr/sbin and restore the base dirs.
+# and ships in this extension under usr/sbin; its shared libraries are resolved
+# against the base image, which already carries veritysetup's identical library
+# closure. The plain mkfs/dd tooling also lives in the base image's /sbin and
+# /bin. The agent launches CDH with PATH=/bin:/sbin:/usr/bin:/usr/sbin, but
+# setting any env here overrides it wholesale, so prepend the extension's
+# usr/sbin and restore the base dirs.
 env          = { OCICRYPT_KEYPROVIDER_CONFIG = "${ocicrypt_config_path}", PATH = "${extension_root}/usr/sbin:/bin:/sbin:/usr/bin:/usr/sbin" }
 wait_socket  = "${cdh_socket}"
 timeout_secs = "${launch_process_timeout}"


### PR DESCRIPTION
The current coco-extension build fails in kata CI integration.

