### PR TITLE
aa/eventlog: fix WAL crash recovery

### DIFF
--- a/attestation-agent/attestation-agent/src/eventlog/mod.rs
+++ b/attestation-agent/attestation-agent/src/eventlog/mod.rs
@@ -49,9 +49,24 @@ pub struct FileWriter {
     pos: u64,
 }
 
+impl FileWriter {
+    /// Open the log file for writing, positioned at its end. No `O_APPEND`,
+    /// so that recovery can rewrite an entry at its recorded offset.
+    fn open(path: &Path) -> Result<Self> {
+        let mut file = File::options()
+            .write(true)
+            .create(true)
+            .truncate(false)
+            .open(path)
+            .context("open log file")?;
+        let pos = file.seek(SeekFrom::End(0))?;
+        Ok(Self { file, pos })
+    }
+}
+
 impl Writer for FileWriter {
     fn write(&mut self, data: &[u8]) -> Result<()> {
-        self.file.write(data).context("failed to write log")?;
+        self.file.write_all(data).context("failed to write log")?;
         self.file
             .sync_data()
             .context("failed to flush log to I/O media")?;
@@ -85,18 +100,20 @@ struct WalCache {
 }
 
 impl EventLog {
+    /// Serialize an AAEL event into TCG2 entry bytes and its digest.
+    fn serialize_tcg2_event(event: Event<'_>, rtmr: u64, alg: HashAlgorithm) -> (Vec<u8>, Vec<u8>) {
+        let (tcg2_event, digest) = Into::<Tcg2EventEntry>::into(event)
+            .with_target_measurement_register(rtmr as u32)
+            .digest(alg);
+        (tcg2_event.to_le_bytes(), digest)
+    }
+
     pub async fn new(rtmr_extender: Arc<BoxedAttester>, pcr: u64) -> Result<Self> {
         tokio::fs::create_dir_all(EVENTLOG_PARENT_DIR_PATH)
             .await
             .context("create eventlog parent dir")?;
-        let mut file = File::options()
-            .append(true)
-            .create(true)
-            .open(EVENTLOG_PATH)
-            .context("open AAEL file")?;
-        let pos = file.stream_position()?;
-
-        let mut writer = Box::new(FileWriter { file, pos });
+        let mut writer =
+            Box::new(FileWriter::open(Path::new(EVENTLOG_PATH)).context("open AAEL file")?);
         let alg = rtmr_extender.ccel_hash_algorithm();
         // if any WAL cache file exists, we should handle recovering from crash
         match Self::read_wal_cache(alg.digest_len()) {
@@ -104,8 +121,8 @@ impl EventLog {
                 warn!("Recover from a previous crash.");
                 let current_pcr = rtmr_extender.get_runtime_measurement(pcr).await.context("get runtime measurement")?;
                 let aael_event = Event::try_from(&wal_cache.event_data[..])?;
-                let (tcg2_event, tcg2_event_digest) = Into::<Tcg2EventEntry>::into(aael_event).digest(alg);
-                let tcg2_event_data = tcg2_event.to_le_bytes();
+                let rtmr = rtmr_extender.pcr_to_ccmr(pcr);
+                let (tcg2_event_data, tcg2_event_digest) = Self::serialize_tcg2_event(aael_event, rtmr, alg);
 
                 // if the PCR has not been extended yet, we should just write eventlog
                 if current_pcr != wal_cache.expected_pcr {
@@ -161,13 +178,17 @@ impl EventLog {
 
     /// Try to read the wal cache file.
     fn read_wal_cache(digest_len: usize) -> Result<Option<WalCache>> {
-        if !Path::new(WAL_CACHE).exists() {
+        Self::read_wal_cache_from(Path::new(WAL_CACHE), digest_len)
+    }
+
+    fn read_wal_cache_from(path: &Path, digest_len: usize) -> Result<Option<WalCache>> {
+        if !path.exists() {
             return Ok(None);
         }
-        let mut file = File::open(WAL_CACHE)?;
+        let mut file = File::open(path)?;
         let mut event_offset = [0u8; 8];
         file.read_exact(&mut event_offset)?;
-        let event_offset = u64::from_le_bytes(event_offset);
+        let event_offset = u64::from_be_bytes(event_offset);
 
         let mut expected_pcr = vec![0u8; digest_len];
         file.read_exact(&mut expected_pcr)?;
@@ -197,11 +218,7 @@ impl EventLog {
     pub async fn extend_entry(&mut self, log_entry: Event<'_>, pcr: u64) -> Result<()> {
         let aael_event_data = log_entry.to_string();
         let rtmr = self.rtmr_extender.pcr_to_ccmr(self.pcr);
-        let (tcg2_event, event_digest) = Into::<Tcg2EventEntry>::into(log_entry)
-            .with_target_measurement_register(rtmr as u32)
-            .digest(self.alg);
-
-        let tcg2_event_data = tcg2_event.to_le_bytes();
+        let (tcg2_event_data, event_digest) = Self::serialize_tcg2_event(log_entry, rtmr, self.alg);
         let mut current_pcr = self.rtmr_extender.get_runtime_measurement(pcr).await?;
 
         current_pcr.extend_from_slice(&event_digest);
@@ -314,6 +331,38 @@ mod tests {
         fn current_pos(&self) -> u64 {
             self.pos
         }
+    }
+
+    #[test]
+    fn test_wal_cache_offset_is_big_endian() {
+        let tmp = tempfile::tempdir().unwrap();
+        let wal_path = tmp.path().join("wal_cache");
+
+        let mut raw = vec![0u8, 0, 0, 0, 0, 0, 2, 0];
+        raw.extend_from_slice(&[0xab; 32]);
+        raw.extend_from_slice(b"domain operation content");
+        std::fs::write(&wal_path, raw).unwrap();
+
+        let wal_cache = EventLog::read_wal_cache_from(&wal_path, 32)
+            .unwrap()
+            .unwrap();
+        assert_eq!(wal_cache.event_offset, 512);
+        assert_eq!(wal_cache.expected_pcr, vec![0xab; 32]);
+        assert_eq!(wal_cache.event_data, "domain operation content");
+    }
+
+    #[test]
+    fn test_file_writer_reopen_and_rewrite() {
+        let tmp = tempfile::tempdir().unwrap();
+        let log_path = tmp.path().join("eventlog");
+        std::fs::write(&log_path, b"0123456789").unwrap();
+
+        let mut writer = FileWriter::open(&log_path).unwrap();
+        assert_eq!(writer.current_pos(), 10);
+
+        writer.seek(2).unwrap();
+        writer.write(b"AB").unwrap();
+        assert_eq!(std::fs::read(&log_path).unwrap(), b"01AB456789");
     }
 
     #[test]


### PR DESCRIPTION
Crash recovery for the eventlog didn't work:

- The WAL offset was written big-endian but read back little-endian,
  so recovery seeked to a wrong position.
- The eventlog file was opened with O_APPEND, so the recovery seek did
  nothing and a half-written entry was never overwritten.
- After reopening an existing log, the writer position started at 0
  instead of the end of the file.

Also use write_all() so short writes are not silently dropped, and
serialize the recovered entry the same way as the normal write path.

Fixes: #1566