### PR TITLE
ci: publish secret CLI as a released binary artifact

### DIFF
--- a/.github/workflows/secret_cli_release.yml
+++ b/.github/workflows/secret_cli_release.yml
@@ -1,0 +1,119 @@
+name: Release secret CLI binary
+
+on:
+  release:
+    types: [published]
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  build-and-upload:
+    permissions:
+      # Write scopes are only exercised by the release-only upload/publish
+      # steps below (gated on github.event_name == 'release'). On pull_request
+      # the job just builds the binary to catch breakage early; fork PRs get a
+      # read-only token regardless of what is requested here.
+      contents: write
+      packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+        - arch: x86_64
+          libc: musl
+          runner: ubuntu-24.04
+        - arch: aarch64
+          libc: musl
+          runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.platform.runner }}
+    env:
+      RUST_TARGET: ${{ matrix.platform.arch }}-unknown-linux-${{ matrix.platform.libc }}
+      # KMS providers bundled into the released binary. Building all of them
+      # into one artifact keeps the released tool provider-agnostic.
+      CLI_FEATURES: cli,aliyun,aws,kbs
+      REGISTRY: ghcr.io
+      IMAGE_NAME: ${{ github.repository }}
+    steps:
+    - name: Harden the runner (Audit all outbound calls)
+      uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+      with:
+        egress-policy: audit
+
+    - name: Log in to the Container registry
+      if: github.event_name == 'release'
+      uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+      with:
+        registry: ${{ env.REGISTRY }}
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Set up ORAS
+      if: github.event_name == 'release'
+      uses: oras-project/setup-oras@1d808f7d7f6995cc68b7bf507bfe5c5446e1dc9d # v2.0.1
+      with:
+        version: 1.2.0
+
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      with:
+        persist-credentials: false
+
+    - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
+      with:
+        # The bundled AWS SDK crates require a newer rustc than the repo's
+        # pinned toolchain (rust-toolchain.toml). Build the release binary on
+        # stable so the aws feature compiles.
+        toolchain: stable
+        target: ${{ env.RUST_TARGET }}
+
+    - name: Install dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y --no-install-recommends \
+          protobuf-compiler libclang-dev cmake pkg-config
+        if [ "${{ matrix.platform.libc }}" = "musl" ]; then
+          sudo apt-get install -y --no-install-recommends musl-tools
+        fi
+
+    - name: Build secret CLI
+      run: |
+        cargo build \
+          -p confidential-data-hub \
+          --bin secret \
+          --release \
+          --target "$RUST_TARGET" \
+          --no-default-features \
+          --features "$CLI_FEATURES"
+
+    - name: Package artifact
+      if: github.event_name == 'release'
+      id: package
+      run: |
+        name="secret-${RUST_TARGET}"
+        mkdir -p "$name"
+        cp "target/${RUST_TARGET}/release/secret" "$name/"
+        tar czf "${name}.tar.gz" "$name"
+        sha256sum "${name}.tar.gz" > "${name}.tar.gz.sha256"
+        echo "asset=${name}.tar.gz" >> "$GITHUB_OUTPUT"
+
+    - name: Upload release assets
+      if: github.event_name == 'release'
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        TAG: ${{ github.event.release.tag_name }}
+        ASSET: ${{ steps.package.outputs.asset }}
+      run: |
+        gh release upload "$TAG" "$ASSET" "${ASSET}.sha256" \
+          --repo "$GITHUB_REPOSITORY" --clobber
+
+    - name: Publish with ORAS
+      if: github.event_name == 'release'
+      env:
+        TAG: ${{ github.event.release.tag_name }}
+        ASSET: ${{ steps.package.outputs.asset }}
+      run: |
+        image="${REGISTRY}/${IMAGE_NAME}/secret_cli"
+        oras push \
+          "${image}:${TAG}-${RUST_TARGET},latest-${RUST_TARGET}" \
+          "$ASSET"

--- a/confidential-data-hub/docs/SEALED_SECRET.md
+++ b/confidential-data-hub/docs/SEALED_SECRET.md
@@ -10,7 +10,26 @@ in conjunction with an attestation.
 The Confidential Data Hub provides an API for unsealing secrets inside
 of a confidential guest.
 
-You can use the secret cli tool to generate a sealed secret:
+You can use the secret cli tool to generate a sealed secret.
+
+### Prebuilt binary (recommended)
+
+Each [GitHub release](https://github.com/confidential-containers/guest-components/releases)
+ships the `secret` CLI as a prebuilt artifact with all KMS providers bundled,
+so you do not need a Rust toolchain. Download the tarball matching your
+platform, verify it, and extract the binary:
+
+```bash
+# Pick the asset for your platform, e.g. secret-x86_64-unknown-linux-musl.tar.gz
+ASSET=secret-x86_64-unknown-linux-musl.tar.gz
+sha256sum -c "${ASSET}.sha256"
+tar xzf "$ASSET"
+./secret-x86_64-unknown-linux-musl/secret --help
+```
+
+### Build from source
+
+Alternatively, build it yourself:
 
 ```bash
 cargo run -p confidential-data-hub --bin secret

--- a/confidential-data-hub/docs/kms-providers/alibaba.md
+++ b/confidential-data-hub/docs/kms-providers/alibaba.md
@@ -116,6 +116,10 @@ nc8BTncWI0KGWIzTQasuSEye50R6gc9wZCGIElmhWcu3NYk=
 ```
 - `plaintext`: The file whose content will be sealed.
 
+A prebuilt `secret` CLI (with all KMS providers bundled) is available from the
+[GitHub releases](https://github.com/confidential-containers/guest-components/releases);
+using it lets you skip the build-from-source step below.
+
 Then, let's 
 ```bash
 # define the parameters

--- a/confidential-data-hub/docs/kms-providers/aws.md
+++ b/confidential-data-hub/docs/kms-providers/aws.md
@@ -117,6 +117,10 @@ Prepare:
 - `aws-credential.json`: the credential file shown above
 - `plaintext`: the file whose content will be sealed
 
+A prebuilt `secret` CLI (with all KMS providers bundled) is available from the
+[GitHub releases](https://github.com/confidential-containers/guest-components/releases);
+using it lets you skip the build-from-source step below.
+
 ```bash
 KEY_ID=$(cat kms-key-id.txt)
 REGION=$(cat aws-region.txt)


### PR DESCRIPTION
Build the sealed-secret 'secret' CLI with all KMS providers bundled and upload per-platform tarballs (x86_64 gnu/musl, aarch64 gnu) as release assets on publish. Update KMS provider docs to reference the prebuilt binary instead of requiring a build from source.

Fixes #1554