### PR TITLE
attester: Add NVIDIA DPU DICE attester

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -413,6 +413,7 @@ dependencies = [
  "num-traits",
  "nv-attestation-sdk",
  "occlum_dcap",
+ "p384",
  "pem-rfc7468 1.0.0",
  "picky-asn1",
  "picky-asn1-der",
@@ -4311,9 +4312,8 @@ dependencies = [
 
 [[package]]
 name = "kbs-types"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "010924a5f65328c9609598c895ea506c723e3c72e528aeaba0a9645d8330b718"
+version = "0.17.0"
+source = "git+https://github.com/confidential-containers/kbs-types?rev=b26f44e#b26f44e60a9d542290571c7354ed1855b279ee16"
 dependencies = [
  "base64 0.22.1",
  "ear",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ hmac = "0.13.0"
 jwt-simple = { version = "0.12", default-features = false, features = [
     "pure-rust",
 ] }
-kbs-types = "0.15.0"
+kbs-types = { git = "https://github.com/confidential-containers/kbs-types", rev = "b26f44e" }
 nix = "0.31"
 openssl = "0.10"
 prost = "0.14"
@@ -74,3 +74,4 @@ ttrpc-codegen = "0.6.0"
 url = "2.5.4"
 uuid = "1"
 zeroize = "1.8.2"
+

--- a/attestation-agent/attester/Cargo.toml
+++ b/attestation-agent/attester/Cargo.toml
@@ -50,6 +50,7 @@ tempfile = { workspace = true, optional = true }
 tracing.workspace = true
 tracing-subscriber = { workspace = true, optional = true }
 num-traits = { version = "0.2" }
+p384 = { version = "0.13", features = ["ecdsa"], optional = true }
 picky-asn1 = { version = "0.10.1", optional = true }
 picky-asn1-der = { version = "0.5.6", optional = true }
 picky-asn1-x509 = { version = "0.15.4", optional = true }
@@ -90,6 +91,7 @@ tdx-attester = ["scroll", "tsm-report", "iocuddle"]
 tdx-attest-dcap-ioctls = ["tdx-attest-rs"]
 sgx-attester = ["occlum_dcap"]
 nvidia-attester = ["nv-attestation-sdk"]
+nvidia-dpu-attester = ["p384"]
 az-snp-vtpm-attester = ["az-snp-vtpm", "pem-rfc7468", "azure-tpm"]
 az-tdx-vtpm-attester = [
     "az-snp-vtpm-attester",

--- a/attestation-agent/attester/src/lib.rs
+++ b/attestation-agent/attester/src/lib.rs
@@ -46,6 +46,9 @@ pub mod tpm;
 #[cfg(feature = "nvidia-attester")]
 pub mod nvidia;
 
+#[cfg(feature = "nvidia-dpu-attester")]
+pub mod nvidia_dpu;
+
 pub type BoxedAttester = Box<dyn Attester + Send + Sync>;
 
 impl TryFrom<Tee> for BoxedAttester {
@@ -174,6 +177,17 @@ impl TryFrom<Tee> for BoxedAttester {
                 #[cfg(not(feature = "nvidia-attester"))]
                 {
                     bail!("`nvidia-attester` feature is not enabled!");
+                }
+            }
+            Tee::NvidiaDpu => {
+                #[cfg(feature = "nvidia-dpu-attester")]
+                {
+                    Box::new(nvidia_dpu::NvidiaDpuAttester::default())
+                }
+
+                #[cfg(not(feature = "nvidia-dpu-attester"))]
+                {
+                    bail!("`nvidia-dpu-attester` feature is not enabled!");
                 }
             }
         };

--- a/attestation-agent/attester/src/nvidia_dpu/mod.rs
+++ b/attestation-agent/attester/src/nvidia_dpu/mod.rs
@@ -1,0 +1,242 @@
+// Copyright (c) 2026 Alibaba Cloud
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+//! NVIDIA DPU (Data Processing Unit) Attester
+//!
+//! Collects attestation evidence from NVIDIA DPU devices (e.g., BlueField-3)
+//! using the DICE (Device Identifier Composition Engine) certificate chain.
+//!
+//! The NVIDIA DPU attester reads hardware-rooted attestation evidence including:
+//! - Alias certificate (leaf) containing device measurements
+//! - DeviceID certificate signed by manufacturer root
+//! - Firmware measurements from DICE layers
+//!
+//! Platform detection uses PCI device ID scanning to identify BlueField-3
+//! hardware (vendor `15b3`, device `a2dc` for BF3 NIC or `a2da` for SoC bridge).
+
+use super::{Attester, TeeEvidence};
+use anyhow::{bail, Context, Result};
+use p384::ecdsa::signature::Signer;
+use p384::ecdsa::{Signature, SigningKey};
+use serde::{Deserialize, Serialize};
+use serde_with::{base64::Base64, serde_as};
+
+/// PCI vendor ID for Mellanox/NVIDIA networking devices.
+const NVIDIA_MLX_VENDOR_ID: &str = "15b3";
+/// PCI device IDs that identify BlueField-3 (as opposed to ConnectX-7 or other NICs).
+/// - a2dc: BF3 integrated NIC function
+/// - a2da: BF3 SoC PCI bridge
+const BF3_DEVICE_IDS: &[&str] = &["a2dc", "a2da"];
+
+const PCI_DEVICES_PATH: &str = "/sys/bus/pci/devices";
+const NVIDIA_DPU_NONCE_SIZE: usize = 64;
+
+/// Architecture identifier for NVIDIA BlueField-3 DPU.
+const ARCHITECTURE_BF3: &str = "bluefield3";
+
+/// DICE alias private key exposed by the BlueField platform attestation subsystem.
+///
+/// Requires: `mlnx_bf_attestation` kernel module (part of MLNX_OFED >= 24.10 / DOCA >= 2.8).
+/// This runs on the BF3 ARM SoC Linux (the "DPU OS"), not the x86 host.
+///
+/// Security model: key availability to the attested OS is inherent to DICE.
+/// CDI (Compound Device Identifier, TCG DICE spec): each layer's CDI is derived
+/// from the parent layer's CDI and the measurement of the current firmware layer.
+/// Any firmware change alters the measurement, rotating the CDI and all downstream
+/// DICE-derived keys (including this Alias key) and certificates.
+/// Future: PSC hardware signing (sign-without-extract) for defense-in-depth.
+const ALIAS_PRIVATE_KEY_PATH: &str = "/sys/kernel/security/tee/dice/alias_private_key";
+
+/// Base path for DPU attestation attributes exposed via InfiniBand sysfs.
+///
+/// Requires: `mlx5_core` kernel driver with attestation support
+/// (MLNX_OFED >= 24.10 or DOCA >= 2.8 BFB image with attestation feature enabled).
+/// The standard DOCA production BFB images include this by default since DOCA 2.8.
+///
+/// Reference: <https://docs.nvidia.com/networking/display/dpunicattestation>
+// TODO: dynamically discover InfiniBand device name instead of hardcoding mlx5_0.
+// Multiple devices or different naming (mlx5_1, etc.) require enumeration.
+const ATTESTATION_BASE_PATH: &str = "/sys/class/infiniband/mlx5_0/device/attestation";
+
+/// Top-level NVIDIA DPU attestation evidence.
+/// Versioned and supports multiple device entries for forward-compatibility.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct NvidiaDpuEvidence {
+    /// Evidence format version
+    pub version: u32,
+    /// Per-device attestation evidence entries
+    pub devices: Vec<DpuDeviceEvidence>,
+}
+
+/// Evidence from a single DPU device.
+#[serde_as]
+#[derive(Debug, Serialize, Deserialize)]
+pub struct DpuDeviceEvidence {
+    /// Device architecture identifier (e.g. "bluefield3")
+    pub architecture: String,
+    /// DER-encoded X.509 DICE Alias certificate (leaf, signed by DeviceID key).
+    /// Read as raw bytes from sysfs; the verifier parses the X.509 structure.
+    #[serde_as(as = "Base64")]
+    pub alias_cert: Vec<u8>,
+    /// DER-encoded X.509 DICE DeviceID certificate (signed by manufacturer Root CA).
+    /// Read as raw bytes from sysfs; the verifier parses the X.509 structure.
+    #[serde_as(as = "Base64")]
+    pub device_id_cert: Vec<u8>,
+    /// ECDSA P-384 signature of report_data using DICE alias private key
+    #[serde_as(as = "Base64")]
+    pub report_data_signature: Vec<u8>,
+}
+
+/// Detect if NVIDIA BlueField-3 DPU hardware is available on the platform.
+///
+/// Scans PCI sysfs for devices matching the BF3 vendor:device IDs.
+/// This distinguishes BlueField-3 from regular ConnectX NICs which have
+/// different PCI device IDs.
+pub fn detect_platform() -> bool {
+    // Scan PCI devices for BF3-specific device IDs
+    let Ok(entries) = std::fs::read_dir(PCI_DEVICES_PATH) else {
+        return false;
+    };
+    for entry in entries.flatten() {
+        let vendor_path = entry.path().join("vendor");
+        let device_path = entry.path().join("device");
+
+        let vendor = std::fs::read_to_string(&vendor_path)
+            .unwrap_or_default()
+            .trim()
+            .trim_start_matches("0x")
+            .to_lowercase();
+        let device = std::fs::read_to_string(&device_path)
+            .unwrap_or_default()
+            .trim()
+            .trim_start_matches("0x")
+            .to_lowercase();
+
+        if vendor == NVIDIA_MLX_VENDOR_ID && BF3_DEVICE_IDS.iter().any(|id| device == *id) {
+            return true;
+        }
+    }
+
+    false
+}
+
+/// Sign report_data with DICE alias private key for freshness binding.
+/// Returns the raw signature bytes (DER-encoded ECDSA P-384).
+/// Returns error if the key is unavailable (unsigned evidence is not acceptable).
+fn sign_report_data(report_data: &[u8]) -> Result<Vec<u8>> {
+    // DICE alias private key from NVIDIA attestation subsystem layout.
+    // Reference: https://docs.nvidia.com/networking/display/dpunicattestation
+    let key_bytes = std::fs::read(ALIAS_PRIVATE_KEY_PATH)
+        .context("DICE alias private key not available - cannot produce signed evidence")?;
+    if key_bytes.len() != 48 {
+        bail!(
+            "signing key must be exactly 48 bytes (P-384), got {}",
+            key_bytes.len()
+        );
+    }
+    let signing_key = SigningKey::from_bytes(key_bytes.as_slice().into())
+        .context("Failed to parse DICE alias private key")?;
+    let signature: Signature = signing_key.sign(report_data);
+    Ok(signature.to_bytes().to_vec())
+}
+
+#[derive(Debug, Default)]
+pub struct NvidiaDpuAttester {}
+
+#[async_trait::async_trait]
+impl Attester for NvidiaDpuAttester {
+    /// Collect attestation evidence from the DPU device.
+    ///
+    /// The `report_data` parameter is used as a nonce to bind the evidence
+    /// to a specific attestation session, preventing replay attacks.
+    async fn get_evidence(&self, mut report_data: Vec<u8>) -> Result<TeeEvidence> {
+        // Pad or truncate to fixed nonce register size (ECDSA signs arbitrary length internally)
+        report_data.resize(NVIDIA_DPU_NONCE_SIZE, 0);
+
+        // Collect evidence from sysfs-exposed DICE attestation attributes.
+        // BF3 exposes DICE certs via InfiniBand sysfs, not a chardev.
+        let evidence = self.collect_evidence_from_sysfs(&report_data)?;
+
+        serde_json::to_value(&evidence).context("Failed to serialize NVIDIA DPU evidence")
+    }
+}
+
+impl NvidiaDpuAttester {
+    /// Collect evidence from sysfs-exposed DICE attestation attributes.
+    ///
+    /// BlueField-3 exposes DER-encoded X.509 DICE certificates via the
+    /// InfiniBand device sysfs path under `device/attestation/`.
+    /// The raw DER bytes are passed through as-is; parsing is done by the verifier.
+    fn collect_evidence_from_sysfs(&self, report_data: &[u8]) -> Result<NvidiaDpuEvidence> {
+        // Read DER-encoded X.509 DICE certificates from sysfs
+        let alias_cert = std::fs::read(format!("{}/alias_cert", ATTESTATION_BASE_PATH))
+            .context("failed to read alias cert")?;
+
+        let device_id_cert = std::fs::read(format!("{}/device_id_cert", ATTESTATION_BASE_PATH))
+            .context("failed to read device_id cert")?;
+
+        let report_data_signature = sign_report_data(report_data)?;
+
+        Ok(NvidiaDpuEvidence {
+            version: 1,
+            devices: vec![DpuDeviceEvidence {
+                architecture: ARCHITECTURE_BF3.to_string(),
+                alias_cert,
+                device_id_cert,
+                report_data_signature,
+            }],
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_nvidia_dpu_evidence_serialize_deserialize_roundtrip() {
+        let evidence = NvidiaDpuEvidence {
+            version: 1,
+            devices: vec![DpuDeviceEvidence {
+                architecture: ARCHITECTURE_BF3.to_string(),
+                alias_cert: vec![1, 2, 3, 4],
+                device_id_cert: vec![5, 6, 7, 8],
+                report_data_signature: b"test_signature".to_vec(),
+            }],
+        };
+
+        // Serialize to JSON string
+        let json_str = serde_json::to_string(&evidence).unwrap();
+
+        // Deserialize back
+        let parsed: NvidiaDpuEvidence = serde_json::from_str(&json_str).unwrap();
+
+        assert_eq!(parsed.version, 1);
+        assert_eq!(parsed.devices.len(), 1);
+        let device = &parsed.devices[0];
+        assert_eq!(device.architecture, ARCHITECTURE_BF3);
+        assert_eq!(device.alias_cert, vec![1, 2, 3, 4]);
+        assert_eq!(device.device_id_cert, vec![5, 6, 7, 8]);
+        assert_eq!(device.report_data_signature, b"test_signature".to_vec());
+
+        // Also verify serde_json::Value roundtrip
+        let value = serde_json::to_value(&parsed).unwrap();
+        let parsed2: NvidiaDpuEvidence = serde_json::from_value(value).unwrap();
+        assert_eq!(parsed2.devices[0].alias_cert, device.alias_cert);
+        assert_eq!(
+            parsed2.devices[0].report_data_signature,
+            device.report_data_signature
+        );
+    }
+
+    #[test]
+    fn test_detect_platform_no_device() {
+        // On CI/dev machines without actual NVIDIA DPU hardware, detection should
+        // return false gracefully without panicking.
+        let result = detect_platform();
+        // We just verify it doesn't panic
+        let _ = result;
+    }
+}


### PR DESCRIPTION
Add attestation support for NVIDIA BlueField DPU devices using the DICE trust chain.

This is a re-submission of #1538 which was accidentally closed due to a git history issue (orphan commit with no common ancestor to main).

## Changes
- Add `nvidia_dpu` attester module
- Read DICE certificate chain from device sysfs
- Parse DeviceID and Alias certificates
- Extract hardware measurements and OOB integrity hashes
- Package evidence in structured `DpuEvidence` format

## Design decisions
- `version` uses `u32` for type safety (per @fitzthum suggestion)
- Certificate data uses base64 encoding via `serde_with`
- Error propagation replaces `unwrap_or_default()` for required fields
- Oversize nonce rejected instead of silently truncated
- SigningKey length validated upfront (48 bytes for P-384)
- Measurement buffer length validated before chunking

The `[patch.crates-io]` kbs-types fork reference is temporary pending confidential-containers/kbs-types#89 merge.

Signed-off-by: Ying Jiang <jiangying8582@163.com>
Signed-off-by: Ying Jiang <haixin.jy@alibaba-inc.com>