### PR TITLE
docs: remove broken link

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,9 +33,6 @@ Utility for sealing and unsealing sealed secrets
 [CDH Client](confidential-data-hub/hub/src/bin)
 A tool for exercising CDH endpoints
 
-[CDH Go Client](confidential-data-hub/golang)
-A Go tool for exercising CDH endpoints
-
 [CDH (One Shot)](confidential-data-hub/hub/src/bin/cdh-oneshot.rs)
 One Shot version of CDH
 


### PR DESCRIPTION
Remove a stale link to the CDH Go Client,
which was removed in f68bd4ab3c2fd4031876e3eb09ac4baf50accf0e .