### PR TITLE
bump to Rust 1.95.0

### DIFF
--- a/api-server-rest/build.rs
+++ b/api-server-rest/build.rs
@@ -153,7 +153,7 @@ fn generate_openapi_document() -> std::io::Result<()> {
     struct ApiDoc;
     let mut file = File::create("openapi/api.json")?;
     let json = ApiDoc::openapi().to_pretty_json()?;
-    println!("{}", &json);
+    println!("{}", json);
     file.write_all(json.as_bytes())
 }
 

--- a/attestation-agent/deps/crypto/src/native/ec.rs
+++ b/attestation-agent/deps/crypto/src/native/ec.rs
@@ -213,28 +213,6 @@ fn left_pad_with_zeroes(data: Vec<u8>, target_len: usize) -> Vec<u8> {
     padded
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn default_curve_is_p256() {
-        assert!(matches!(EcKeyPair::default(), EcKeyPair::P256(_)));
-    }
-
-    #[test]
-    fn p521_roundtrip_and_coordinates() {
-        let p521 = EcKeyPair::P521(P521EcKeyPair::default());
-        assert!(matches!(p521.curve(), Curve::P521));
-        assert_eq!(p521.x().expect("x should exist").len(), 66);
-        assert_eq!(p521.y().expect("y should exist").len(), 66);
-
-        let pem = p521.to_pkcs8_pem().expect("serialize pem");
-        let parsed = EcKeyPair::from_pkcs8_pem(&pem).expect("parse pem");
-        assert!(matches!(parsed.curve(), Curve::P521));
-    }
-}
-
 impl Default for P256EcKeyPair {
     fn default() -> Self {
         Self::new().expect("Create P256 key pair failed")
@@ -271,5 +249,27 @@ impl P256EcKeyPair {
         let mut ctx = BigNumContext::new()?;
         public_key.affine_coordinates_gfp(private_key.group(), &mut _x, &mut y, &mut ctx)?;
         Ok(left_pad_with_zeroes(y.to_vec(), 32))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_curve_is_p256() {
+        assert!(matches!(EcKeyPair::default(), EcKeyPair::P256(_)));
+    }
+
+    #[test]
+    fn p521_roundtrip_and_coordinates() {
+        let p521 = EcKeyPair::P521(P521EcKeyPair::default());
+        assert!(matches!(p521.curve(), Curve::P521));
+        assert_eq!(p521.x().expect("x should exist").len(), 66);
+        assert_eq!(p521.y().expect("y should exist").len(), 66);
+
+        let pem = p521.to_pkcs8_pem().expect("serialize pem");
+        let parsed = EcKeyPair::from_pkcs8_pem(&pem).expect("parse pem");
+        assert!(matches!(parsed.curve(), Curve::P521));
     }
 }

--- a/attestation-agent/deps/resource_uri/src/lib.rs
+++ b/attestation-agent/deps/resource_uri/src/lib.rs
@@ -278,8 +278,7 @@ mod tests {
 
         // Conversion to Url
         let url_from_string = url::Url::try_from(url).expect("failed to parse url");
-        let url_from_resource: url::Url =
-            resource.clone().try_into().expect("failed to try into url");
+        let url_from_resource: url::Url = resource.clone().into();
         assert_eq!(url_from_string, url_from_resource);
 
         // Conversion to ResourceUri

--- a/attestation-agent/docker/Dockerfile.keyprovider
+++ b/attestation-agent/docker/Dockerfile.keyprovider
@@ -1,7 +1,7 @@
 # Copyright (c) 2023 by Alibaba.
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-FROM rust:1.90-slim-bookworm as builder
+FROM rust:1.95-slim-bookworm as builder
 
 LABEL org.opencontainers.image.source="https://github.com/confidential-containers/guest-components/blob/main/attestation-agent/docker/Dockerfile.keyprovider"
 

--- a/attestation-agent/kbs_protocol/src/client/rcar_client.rs
+++ b/attestation-agent/kbs_protocol/src/client/rcar_client.rs
@@ -529,7 +529,7 @@ mod test {
                     "Actual error: {e:#?}"
                 );
                 println!("NOTE: the test is skipped due to KBS protocol incompatibility.");
-                return ();
+                return;
             }
         };
 
@@ -605,7 +605,7 @@ mod test {
     #[case(json!({SELECTED_HASH_ALGORITHM_JSON_KEY: {}}), Err(Error::UnexpectedJSONDataType("string".into(), "{}".into())))]
     #[case(json!({SELECTED_HASH_ALGORITHM_JSON_KEY: true}), Err(Error::UnexpectedJSONDataType("string".into(), "true".into())))]
     #[case(json!({SELECTED_HASH_ALGORITHM_JSON_KEY: 99999}), Err(Error::UnexpectedJSONDataType("string".into(), "99999".into())))]
-    #[case(json!({SELECTED_HASH_ALGORITHM_JSON_KEY: 3.141}), Err(Error::UnexpectedJSONDataType("string".into(), "3.141".into())))]
+    #[case(json!({SELECTED_HASH_ALGORITHM_JSON_KEY: 42.141}), Err(Error::UnexpectedJSONDataType("string".into(), "42.141".into())))]
     fn test_get_hash_algorithm(
         #[case] extra_params: Value,
         #[case] expected_result: Result<HashAlgorithm>,

--- a/confidential-data-hub/hub/src/secret/mod.rs
+++ b/confidential-data-hub/hub/src/secret/mod.rs
@@ -284,7 +284,7 @@ mod tests {
         assert_eq!(parsed, secret_object);
 
         let jwk = include_str!("./tests/test-key.json");
-        let jwk: Jwk = serde_json::from_str(&jwk).expect("Could not parse signing JWK");
+        let jwk: Jwk = serde_json::from_str(jwk).expect("Could not parse signing JWK");
 
         let kid = "test-key".to_string();
         let kid_cred_path = format!("{SIGNING_CREDENTIALS_PATH}/{}", &kid);
@@ -322,7 +322,7 @@ mod tests {
         };
 
         let jwk = include_str!("./tests/test-key.json");
-        let jwk: Jwk = serde_json::from_str(&jwk).expect("Could not parse signing JWK");
+        let jwk: Jwk = serde_json::from_str(jwk).expect("Could not parse signing JWK");
 
         let kid = "test-key".to_string();
         let kid_cred_path = format!("{SIGNING_CREDENTIALS_PATH}/{}", &kid);
@@ -360,10 +360,10 @@ mod tests {
         };
 
         let jwk = include_str!("./tests/test-key.json");
-        let jwk: Jwk = serde_json::from_str(&jwk).expect("Could not parse signing JWK");
+        let jwk: Jwk = serde_json::from_str(jwk).expect("Could not parse signing JWK");
 
         let jwk2 = include_str!("./tests/test-key-2.json");
-        let jwk2: Jwk = serde_json::from_str(&jwk2).expect("Could not parse signing JWK");
+        let jwk2: Jwk = serde_json::from_str(jwk2).expect("Could not parse signing JWK");
 
         let kid = "test-key".to_string();
         let kid_cred_path = format!("{SIGNING_CREDENTIALS_PATH}/{}", &kid);

--- a/image-rs/src/resource/kbs/mod.rs
+++ b/image-rs/src/resource/kbs/mod.rs
@@ -21,7 +21,11 @@ use sha2::{Digest, Sha256};
 use tokio::fs;
 use tracing::info;
 
-#[cfg(feature = "keywrap-grpc")]
+#[cfg(all(
+    feature = "keywrap-grpc",
+    not(feature = "keywrap-ttrpc"),
+    not(feature = "keywrap-native")
+))]
 mod grpc;
 
 #[cfg(feature = "keywrap-ttrpc")]

--- a/image-rs/tests/image_decryption.rs
+++ b/image-rs/tests/image_decryption.rs
@@ -9,7 +9,13 @@
 pub mod common;
 
 /// Ocicrypt-rs config for grpc
-#[cfg(all(feature = "kbs", feature = "encryption", feature = "keywrap-grpc"))]
+#[cfg(all(
+    feature = "kbs",
+    feature = "encryption",
+    feature = "keywrap-grpc",
+    not(feature = "keywrap-ttrpc"),
+    not(feature = "keywrap-native")
+))]
 const OCICRYPT_CONFIG: &str = "test_data/ocicrypt_keyprovider_grpc.conf";
 
 /// Ocicrypt-rs config for ttrpc
@@ -19,7 +25,10 @@ const OCICRYPT_CONFIG: &str = "test_data/ocicrypt_keyprovider_ttrpc.conf";
 #[cfg(all(
     feature = "kbs",
     feature = "encryption",
-    any(feature = "keywrap-ttrpc", feature = "keywrap-grpc")
+    any(
+        feature = "keywrap-ttrpc",
+        all(feature = "keywrap-grpc", not(feature = "keywrap-native"))
+    )
 ))]
 #[rstest::rstest]
 #[case("ghcr.io/confidential-containers/test-container:unencrypted")]

--- a/ocicrypt-rs/src/blockcipher/aes_ctr.rs
+++ b/ocicrypt-rs/src/blockcipher/aes_ctr.rs
@@ -168,7 +168,7 @@ impl<R: Read> Read for AESCTRBlockCipher<R> {
                     .map_err(|_| {
                         std::io::Error::other(format!(
                             "failed decrypt byte stream, exp hmac: {:?} , actual hmac: {:?}",
-                            &state.exp_hmac,
+                            state.exp_hmac,
                             state.hmac.clone().finalize().into_bytes()
                         ))
                     })?;

--- a/ocicrypt-rs/src/encryption.rs
+++ b/ocicrypt-rs/src/encryption.rs
@@ -215,7 +215,7 @@ pub fn encrypt_layer<'a, R: 'a + Read>(
     EncLayerFinalizer,
 )> {
     let mut encrypted = false;
-    for (annotations_id, _scheme) in KEY_WRAPPERS_ANNOTATIONS.iter() {
+    for annotations_id in KEY_WRAPPERS_ANNOTATIONS.keys() {
         let anno = annotations.unwrap_or(&DEFAULT_ANNOTATION_MAP);
         if anno.contains_key(annotations_id) {
             if let Some(decrypt_config) = ec.decrypt_config.as_ref() {

--- a/ocicrypt-rs/src/keywrap/keyprovider/mod.rs
+++ b/ocicrypt-rs/src/keywrap/keyprovider/mod.rs
@@ -438,7 +438,7 @@ impl KeyWrapper for KeyProviderKeyWrapper {
         if !enc_config.param.contains_key(&self.provider) {
             return Err(anyhow!(
                 "keyprovider: unknown provider {} for operation {}",
-                &self.provider,
+                self.provider,
                 OpKey::Wrap
             ));
         }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.90.0"
+channel = "1.95.0"


### PR DESCRIPTION
The PR contains clippy fixes for both 1.95.0 and 1.97.x (as reported by our "rust stable" weekly action). Some findings were only seen when running with `cargo clippy --workspace --all-targets  -- -D warnings`