### PR TITLE
image-rs: fix fchmodat EINVAL on kernels older than 6.6

### DIFF
--- a/image-rs/src/stream/unpack.rs
+++ b/image-rs/src/stream/unpack.rs
@@ -497,17 +497,20 @@ fn fchown_at(fd: BorrowedFd<'_>, uid: u32, gid: u32) -> Result<()> {
 }
 
 /// Set mode on the inode referenced by an `O_PATH` fd (`Root` / `Handle` from pathrs).
+///
+/// The underlying `fchmodat(2)` syscall has no flags argument, so `AT_EMPTY_PATH`
+/// is only honored through the `fchmodat2(2)` syscall introduced in Linux 6.6.
+/// On older guest kernels the libc falls back and rejects `AT_EMPTY_PATH` with
+/// `EINVAL`. `chmod(2)` cannot be issued on an `O_PATH` fd directly either, so
+/// resolve the inode via `/proc/self/fd/<N>`, which works on any kernel as long
+/// as procfs is mounted (always the case in the guest).
 fn fchmodat(fd: BorrowedFd<'_>, mode: u32) -> Result<()> {
-    let ret = unsafe {
-        libc::fchmodat(
-            fd.as_raw_fd(),
-            c"".as_ptr(),
-            mode as libc::mode_t,
-            libc::AT_EMPTY_PATH,
-        )
-    };
+    let proc_path = format!("/proc/self/fd/{}", fd.as_raw_fd());
+    let proc_path =
+        CString::new(proc_path).map_err(|_| anyhow!("procfs path contains null byte"))?;
+    let ret = unsafe { libc::chmod(proc_path.as_ptr(), mode as libc::mode_t) };
     if ret != 0 {
-        bail!("failed to fchmodat: {:?}", io::Error::last_os_error());
+        bail!("failed to chmod: {:?}", io::Error::last_os_error());
     }
     Ok(())
 }


### PR DESCRIPTION
The unpack logic sets file modes through fchmodat() with AT_EMPTY_PATH on the O_PATH fd returned by pathrs. The underlying fchmodat(2) syscall has no flags argument, so AT_EMPTY_PATH is only honored via the fchmodat2(2) syscall introduced in Linux 6.6. On older guest kernels the libc falls back and rejects AT_EMPTY_PATH with EINVAL, which breaks image pull on peer-pod guests (cloud-api-adaptor) whose guest kernel predates 6.6, while bare-metal kata guests with newer kernels are unaffected.

Resolve the inode via /proc/self/fd/<N> and call chmod(2) instead, which works on any kernel as long as procfs is mounted (always the case in the guest). chmod is used rather than fchmod because an O_PATH fd cannot be passed to fchmod directly. fchownat is left untouched since that syscall natively supports AT_EMPTY_PATH on all kernels.

Related to https://github.com/confidential-containers/cloud-api-adaptor/pull/3202