### PR TITLE
cdh: make the AA socket path configurable

### DIFF
--- a/attestation-agent/kbs_protocol/src/token_provider/aa/mod.rs
+++ b/attestation-agent/kbs_protocol/src/token_provider/aa/mod.rs
@@ -33,7 +33,11 @@ struct Message {
 
 impl AATokenProvider {
     pub async fn new() -> Result<Self> {
-        let c = ttrpc::r#async::Client::connect(AA_SOCKET_FILE)
+        Self::new_with_socket(AA_SOCKET_FILE).await
+    }
+
+    pub async fn new_with_socket(aa_socket: &str) -> Result<Self> {
+        let c = ttrpc::r#async::Client::connect(aa_socket)
             .await
             .map_err(|e| Error::AATokenProvider(format!("ttrpc connect failed {e:?}")))?;
         let client = AttestationAgentServiceClient::new(c);

--- a/confidential-data-hub/example.config.json
+++ b/confidential-data-hub/example.config.json
@@ -1,5 +1,8 @@
 {
     "socket": "unix:///run/confidential-containers/cdh.sock",
+    "aa": {
+        "aa_socket": "unix:///run/confidential-containers/attestation-agent/attestation-agent.sock"
+    },
     "kbc": {
         "name": "cc_kbc",
         "url": "http://example.io:8080",

--- a/confidential-data-hub/example.config.toml
+++ b/confidential-data-hub/example.config.toml
@@ -1,6 +1,9 @@
 # The ttrpc sock of CDH that is used to listen to the requests
 socket = "unix:///run/confidential-containers/cdh.sock"
 
+[aa]
+aa_socket = "unix:///run/confidential-containers/attestation-agent/attestation-agent.sock"
+
 # KBC related configs.
 [kbc]
 # Required. The KBC name. It could be `cc_kbc`, `online_sev_kbc` or

--- a/confidential-data-hub/hub/src/config/mod.rs
+++ b/confidential-data-hub/hub/src/config/mod.rs
@@ -25,6 +25,8 @@ cfg_if::cfg_if! {
     }
 }
 
+pub const DEFAULT_AA_SOCKET_ADDR: &str =
+    "unix:///run/confidential-containers/attestation-agent/attestation-agent.sock";
 pub const DEFAULT_LOG_LEVEL: &str = "info";
 
 #[derive(Clone, Deserialize, Debug, PartialEq)]
@@ -74,6 +76,24 @@ impl Default for LogConfig {
     }
 }
 
+fn default_aa_socket_addr() -> String {
+    DEFAULT_AA_SOCKET_ADDR.to_string()
+}
+
+#[derive(Clone, Deserialize, Debug, PartialEq)]
+pub struct AaConfig {
+    #[serde(default = "default_aa_socket_addr")]
+    pub aa_socket: String,
+}
+
+impl Default for AaConfig {
+    fn default() -> Self {
+        Self {
+            aa_socket: DEFAULT_AA_SOCKET_ADDR.to_string(),
+        }
+    }
+}
+
 fn default_socket_addr() -> String {
     DEFAULT_CDH_SOCKET_ADDR.to_string()
 }
@@ -81,6 +101,9 @@ fn default_socket_addr() -> String {
 #[derive(Clone, Deserialize, Debug, PartialEq)]
 pub struct CdhConfig {
     pub kbc: KbsConfig,
+
+    #[serde(default)]
+    pub aa: AaConfig,
 
     #[serde(default)]
     pub credentials: Vec<Credential>,
@@ -113,6 +136,7 @@ impl CdhConfig {
     pub fn default_with_kernel_cmdline() -> Result<Self> {
         Ok(Self {
             kbc: KbsConfig::new()?,
+            aa: AaConfig::default(),
             credentials: Vec::new(),
             socket: default_socket_addr(),
             image: ImageConfig::from_kernel_cmdline(),
@@ -126,6 +150,7 @@ impl CdhConfig {
     pub fn from_file(config_path: &str) -> Result<Self> {
         let c = Config::builder()
             .set_default("socket", DEFAULT_CDH_SOCKET_ADDR)?
+            .set_default("aa.aa_socket", DEFAULT_AA_SOCKET_ADDR)?
             .set_default("kbc.url", "")?
             .add_source(File::with_name(config_path))
             .build()?;
@@ -178,6 +203,9 @@ impl CdhConfig {
                 format!("{}::{}", self.kbc.name, self.kbc.url),
             );
         }
+        if env::var("AA_SOCKET").is_err() {
+            env::set_var("AA_SOCKET", &self.aa.aa_socket);
+        }
         // KBS configurations
         if let Some(kbs_cert) = &self.kbc.kbs_cert {
             env::set_var("KBS_CERT", kbs_cert);
@@ -208,12 +236,18 @@ mod tests {
     use rstest::rstest;
     use serial_test::serial;
 
-    use crate::{config::DEFAULT_CDH_SOCKET_ADDR, CdhConfig, KbsConfig, LogConfig};
+    use crate::{
+        config::DEFAULT_AA_SOCKET_ADDR, config::DEFAULT_CDH_SOCKET_ADDR, AaConfig, CdhConfig,
+        KbsConfig, LogConfig,
+    };
 
     #[rstest]
     #[case(
         r#"
 socket = "unix:///run/confidential-containers/cdh.sock"
+
+[aa]
+aa_socket = "unix:///run/confidential-containers/attestation-agent/attestation-agent.sock"
 
 [kbc]
 name = "offline_fs_kbc"
@@ -244,6 +278,7 @@ https_proxy = "http://127.0.0.1:8080"
     "#,
         Some(CdhConfig {
             log: LogConfig::default(),
+            aa: AaConfig::default(),
             kbc: KbsConfig {
                 name: "offline_fs_kbc".to_string(),
                 url: "".to_string(),
@@ -304,6 +339,7 @@ name = "offline_fs_kbc"
 "#,
     Some(CdhConfig {
         log: LogConfig::default(),
+        aa: AaConfig::default(),
         kbc: KbsConfig {
             name: "offline_fs_kbc".to_string(),
             url: "".to_string(),
@@ -335,6 +371,9 @@ some_undefined_field = "unknown value"
     Some(CdhConfig {
         log: LogConfig {
             level: "warn".to_string(),
+        },
+        aa: AaConfig {
+            aa_socket: DEFAULT_AA_SOCKET_ADDR.to_string(),
         },
         kbc: KbsConfig {
             name: "offline_fs_kbc".to_string(),

--- a/confidential-data-hub/hub/src/config/ocicrypt_config.rs
+++ b/confidential-data-hub/hub/src/config/ocicrypt_config.rs
@@ -89,11 +89,12 @@ mod tests {
     use serial_test::serial;
 
     use super::OCICRYPT_KEYPROVIDER_CONFIG_ENV;
-    use crate::{CdhConfig, KbsConfig, LogConfig};
+    use crate::{AaConfig, CdhConfig, KbsConfig, LogConfig};
 
     fn test_config(socket: &str) -> CdhConfig {
         CdhConfig {
             log: LogConfig::default(),
+            aa: AaConfig::default(),
             kbc: KbsConfig {
                 name: "offline_fs_kbc".to_string(),
                 url: "".to_string(),

--- a/confidential-data-hub/hub/src/hub.rs
+++ b/confidential-data-hub/hub/src/hub.rs
@@ -124,7 +124,9 @@ impl DataHub for Hub {
 
             let aa_client = self
                 .aa_client
-                .get_or_try_init(|| async move { initialize_aa_client().await })
+                .get_or_try_init(
+                    || async move { initialize_aa_client(&self.config.aa.aa_socket).await },
+                )
                 .await?;
 
             let Some(aa_client) = aa_client else {
@@ -183,17 +185,15 @@ async fn initialize_image_client(config: ImageConfig) -> Result<Mutex<ImageClien
 }
 
 #[cfg(feature = "ttrpc")]
-async fn initialize_aa_client() -> Result<Option<AttestationAgentServiceClient>> {
+async fn initialize_aa_client(aa_socket: &str) -> Result<Option<AttestationAgentServiceClient>> {
     use anyhow::anyhow;
 
-    const AA_SOCKET_FILE: &str =
-        "/run/confidential-containers/attestation-agent/attestation-agent.sock";
-
-    if !Path::new(AA_SOCKET_FILE).exists() {
+    let socket_path = aa_socket.strip_prefix("unix://").unwrap_or(aa_socket);
+    if !Path::new(socket_path).exists() {
         return Ok(None);
     }
 
-    let c = ttrpc::r#async::Client::connect(&format!("unix://{AA_SOCKET_FILE}"))
+    let c = ttrpc::r#async::Client::connect(aa_socket)
         .await
         .map_err(|e| Error::AttestationAgentClientError {
             source: anyhow!("failed to connect to attestation agent: {e:?}"),

--- a/confidential-data-hub/kms/src/plugins/kbs/cc_kbc.rs
+++ b/confidential-data-hub/kms/src/plugins/kbs/cc_kbc.rs
@@ -22,10 +22,12 @@ pub struct CcKbc {
 }
 
 impl CcKbc {
-    pub async fn new(kbs_host_url: &str) -> Result<Self> {
-        let token_provider = AATokenProvider::new().await.map_err(|e| {
-            Error::KbsClientError(format!("create AA token provider failed: {e:?}"))
-        })?;
+    pub async fn new(kbs_host_url: &str, aa_socket: &str) -> Result<Self> {
+        let token_provider = AATokenProvider::new_with_socket(aa_socket)
+            .await
+            .map_err(|e| {
+                Error::KbsClientError(format!("create AA token provider failed: {e:?}"))
+            })?;
         let client = kbs_protocol::KbsClientBuilder::with_token_provider(
             Box::new(token_provider),
             kbs_host_url,

--- a/confidential-data-hub/kms/src/plugins/kbs/mod.rs
+++ b/confidential-data-hub/kms/src/plugins/kbs/mod.rs
@@ -35,10 +35,11 @@ impl RealClient {
         let params = env::var("AA_KBC_PARAMS").expect("must be initialized");
         let params = AaKbcParams::try_from(params)
             .map_err(|e| Error::KbsClientError(format!("Failed to parse aa_kbc_params: {e:?}")))?;
+        let aa_socket = env::var("AA_SOCKET").expect("must be initialized");
 
         let c = match &params.kbc[..] {
             #[cfg(feature = "kbs")]
-            "cc_kbc" => RealClient::Cc(cc_kbc::CcKbc::new(&params.uri).await?),
+            "cc_kbc" => RealClient::Cc(cc_kbc::CcKbc::new(&params.uri, &aa_socket).await?),
             #[cfg(feature = "sev")]
             "online_sev_kbc" => RealClient::Sev(sev::OnlineSevKbc::new(&params.uri).await?),
             "offline_fs_kbc" => RealClient::OfflineFs(offline_fs::OfflineFsKbc::new().await?),


### PR DESCRIPTION
AA allows changing its socket file path via the `--attestation-sock` argument. However, CDH currently connects to the fixed path
`unix:///run/confidential-containers/attestation-agent/attestation-agent.sock`.

This patch allows the socket path to be passed through the configuration file, so that CDH can connect to an arbitrary AA socket path.