### PR TITLE
ci: fix weekly Rust stable test

### DIFF
--- a/.github/workflows/rust_stable_check.yml
+++ b/.github/workflows/rust_stable_check.yml
@@ -57,5 +57,9 @@ jobs:
       - name: Install dm-verity dependencies
         run: sudo apt install -y libdevmapper-dev
 
+      - name: Install NVIDIA Attestation SDK
+        if: contains(fromJSON('["attestation-agent", "kbc", "kbs_protocol"]'), matrix.package)
+        uses: ./.github/actions/install-nvat-sdk
+
       - name: Run rust lint checks (${{matrix.package}})
         run: cargo clippy -p ${{matrix.package}} ${{matrix.feature-parameters}} -- -D warnings

--- a/image-rs/src/signature/payload/simple_signing.rs
+++ b/image-rs/src/signature/payload/simple_signing.rs
@@ -38,8 +38,8 @@ impl SigPayload {
         if self.manifest_digest() != ref_manifest_digest {
             bail!(
                 "SigPayload's manifest digest does not match, the input is {}, but in SigPayload it is {}",
-                &ref_manifest_digest,
-                &self.manifest_digest()
+                ref_manifest_digest,
+                self.manifest_digest()
             );
         }
         Ok(())

--- a/image-rs/src/signature/policy/simple/mod.rs
+++ b/image-rs/src/signature/policy/simple/mod.rs
@@ -156,7 +156,7 @@ impl SignatureValidator {
             .base_url(&image.reference)?
             .ok_or_else(|| anyhow!("The sigstore base url is none"))?;
 
-        let sigstore = format!("{}/{}", &sigstore_base_url, &sigstore_name);
+        let sigstore = format!("{sigstore_base_url}/{sigstore_name}");
         let sigstore_uri = url::Url::parse(&sigstore)
             .map_err(|e| anyhow!("Failed to parse sigstore_uri: {:?}", e))?;
 

--- a/image-rs/src/signature/policy/simple/sigstore.rs
+++ b/image-rs/src/signature/policy/simple/sigstore.rs
@@ -99,7 +99,7 @@ impl SigstoreConfig {
                     if namespace != ns_config {
                         bail!(
                             "Error parsing sigstore config: {} defined repeatedly.",
-                            &ns_name
+                            ns_name
                         );
                     }
                     continue;
@@ -175,7 +175,7 @@ pub async fn get_sigs_from_specific_sigstore(sigstore_uri: url::Url) -> Result<V
                 anyhow!(
                     "Read Sigstore Dir failed: {:?}, path: {}",
                     e,
-                    &sigstore_dir_path
+                    sigstore_dir_path
                 )
             })?;
             while let Some(entry) = dirs.next_entry().await? {

--- a/image-rs/src/signature/policy/simple/verify.rs
+++ b/image-rs/src/signature/policy/simple/verify.rs
@@ -41,8 +41,8 @@ impl SigKeyIDs {
             Err(
                 anyhow!(
                     "Key ID not matched. trusted key id is: {:X?}, but key id in signature info is: {:X?}", 
-                    &self.trusted_key_id,
-                    &self.sig_info_key_id
+                    self.trusted_key_id,
+                    self.sig_info_key_id
                 )
             )
         }


### PR DESCRIPTION
The building of Nvidia Attestation SDK needs to install nvat sdk to be installed.

cc @fitzthum 