### PR TITLE
workspace: migrate a subset of crates to Rust edition 2024

### DIFF
--- a/api-server-rest/Cargo.toml
+++ b/api-server-rest/Cargo.toml
@@ -2,7 +2,7 @@
 name = "api-server-rest"
 version = "0.1.0"
 authors = ["The Confidential Container Authors"]
-edition = "2021"
+edition = "2024"
 license = "Apache-2.0"
 
 [dependencies]

--- a/api-server-rest/src/client/aa.rs
+++ b/api-server-rest/src/client/aa.rs
@@ -11,8 +11,8 @@ use protos::ttrpc::aa::attestation_agent::{
 use protos::ttrpc::aa::attestation_agent_ttrpc::AttestationAgentServiceClient;
 use serde::Deserialize;
 
-use crate::client::ttrpc_client::CachedTtrpcClient;
 use crate::TTRPC_TIMEOUT;
+use crate::client::ttrpc_client::CachedTtrpcClient;
 
 /// ROOT path for Confidential Data Hub API
 pub const AA_ROOT: &str = "/aa";
@@ -123,8 +123,12 @@ impl AAClient {
 
         let res = match res {
             0 => "{\"success\":\"true\"}",
-            1 => "{\"success\":\"false\",\"message\": \"The platform does not support runtime measurement\"}",
-            2 => "{\"success\":\"false\",\"message\": \"Attestation Agent does not enable eventlog recording\"}",
+            1 => {
+                "{\"success\":\"false\",\"message\": \"The platform does not support runtime measurement\"}"
+            }
+            2 => {
+                "{\"success\":\"false\",\"message\": \"Attestation Agent does not enable eventlog recording\"}"
+            }
             _ => "{\"success\":\"false\",\"message\": \"Unknown runtime measurement result\"}",
         };
 

--- a/api-server-rest/src/client/cdh.rs
+++ b/api-server-rest/src/client/cdh.rs
@@ -3,8 +3,8 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-use crate::client::ttrpc_client::CachedTtrpcClient;
 use crate::TTRPC_TIMEOUT;
+use crate::client::ttrpc_client::CachedTtrpcClient;
 use anyhow::*;
 use protos::ttrpc::cdh::api::GetResourceRequest;
 use protos::ttrpc::cdh::api_ttrpc::GetResourceServiceClient;

--- a/api-server-rest/src/main.rs
+++ b/api-server-rest/src/main.rs
@@ -4,14 +4,14 @@
 //
 
 use clap::Parser;
+use hyper::Server;
 use hyper::server::conn::AddrStream;
 use hyper::service::{make_service_fn, service_fn};
-use hyper::Server;
 use shadow_rs::shadow;
 use std::net::SocketAddr;
 use std::sync::Arc;
 use tracing::{error, info};
-use tracing_subscriber::{fmt::Subscriber, EnvFilter};
+use tracing_subscriber::{EnvFilter, fmt::Subscriber};
 
 shadow!(build);
 

--- a/api-server-rest/src/router.rs
+++ b/api-server-rest/src/router.rs
@@ -5,21 +5,21 @@
 
 use anyhow::*;
 use hyper::body::HttpBody;
-use hyper::{header, Body, Method, Request, Response, StatusCode};
+use hyper::{Body, Method, Request, Response, StatusCode, header};
 use serde::Serialize;
 use std::collections::HashMap;
 use std::net::SocketAddr;
 use tracing::{debug, error, info};
 
+use crate::VERSION;
 use crate::client::{
     aa::{
-        AAClient, AaelEvent, AA_AAEL_URL, AA_ADDITIONAL_EVIDENCE_URL, AA_EVIDENCE_URL, AA_ROOT,
-        AA_TOKEN_URL,
+        AA_AAEL_URL, AA_ADDITIONAL_EVIDENCE_URL, AA_EVIDENCE_URL, AA_ROOT, AA_TOKEN_URL, AAClient,
+        AaelEvent,
     },
-    cdh::{CDHClient, CDH_RESOURCE_URL, CDH_ROOT},
+    cdh::{CDH_RESOURCE_URL, CDH_ROOT, CDHClient},
 };
 use crate::utils::{decode_runtime_data, split_nth_slash};
-use crate::VERSION;
 
 pub struct Router {
     aa_client: Option<AAClient>,
@@ -160,7 +160,7 @@ impl Router {
                             match params.get("token_type") {
                                 Some(token_type) => match client.get_token(token_type).await {
                                     std::result::Result::Ok(results) => {
-                                        return self.octet_stream_response(results)
+                                        return self.octet_stream_response(results);
                                     }
                                     Err(e) => {
                                         error!("Failed to get token: {e:#}");
@@ -183,7 +183,7 @@ impl Router {
                                     };
                                     match client.get_evidence(&runtime_data).await {
                                         std::result::Result::Ok(results) => {
-                                            return self.octet_stream_response(results)
+                                            return self.octet_stream_response(results);
                                         }
                                         Err(e) => {
                                             error!("Failed to get evidence: {e:#}");
@@ -207,7 +207,7 @@ impl Router {
                                     };
                                     match client.get_additional_evidence(&runtime_data).await {
                                         std::result::Result::Ok(results) => {
-                                            return self.octet_stream_response(results)
+                                            return self.octet_stream_response(results);
                                         }
                                         Err(e) => {
                                             error!("Failed to get additional evidence: {e:#}");
@@ -244,7 +244,7 @@ impl Router {
                                 .await
                             {
                                 std::result::Result::Ok(message) => {
-                                    return self.json_response(message)
+                                    return self.json_response(message);
                                 }
                                 Err(e) => {
                                     error!("Failed to extend AAEL entry: {e:#}");
@@ -270,7 +270,7 @@ impl Router {
                         match api {
                             CDH_RESOURCE_URL => match client.get_resource(resource_path).await {
                                 std::result::Result::Ok(results) => {
-                                    return self.octet_stream_response(results)
+                                    return self.octet_stream_response(results);
                                 }
                                 Err(e) => {
                                     error!("Failed to get resource: {e:#}");

--- a/api-server-rest/src/router.rs
+++ b/api-server-rest/src/router.rs
@@ -5,21 +5,21 @@
 
 use anyhow::*;
 use hyper::body::HttpBody;
-use hyper::{header, Body, Method, Request, Response, StatusCode};
+use hyper::{Body, Method, Request, Response, StatusCode, header};
 use serde::Serialize;
 use std::collections::HashMap;
 use std::net::SocketAddr;
 use tracing::{debug, info};
 
+use crate::VERSION;
 use crate::client::{
     aa::{
-        AAClient, AaelEvent, AA_AAEL_URL, AA_ADDITIONAL_EVIDENCE_URL, AA_EVIDENCE_URL, AA_ROOT,
-        AA_TOKEN_URL,
+        AA_AAEL_URL, AA_ADDITIONAL_EVIDENCE_URL, AA_EVIDENCE_URL, AA_ROOT, AA_TOKEN_URL, AAClient,
+        AaelEvent,
     },
-    cdh::{CDHClient, CDH_RESOURCE_URL, CDH_ROOT},
+    cdh::{CDH_RESOURCE_URL, CDH_ROOT, CDHClient},
 };
 use crate::utils::{decode_runtime_data, split_nth_slash};
-use crate::VERSION;
 
 pub struct Router {
     aa_client: Option<AAClient>,
@@ -160,7 +160,7 @@ impl Router {
                             match params.get("token_type") {
                                 Some(token_type) => match client.get_token(token_type).await {
                                     std::result::Result::Ok(results) => {
-                                        return self.octet_stream_response(results)
+                                        return self.octet_stream_response(results);
                                     }
                                     Err(e) => return self.internal_error(e.to_string()),
                                 },
@@ -180,7 +180,7 @@ impl Router {
                                     };
                                     match client.get_evidence(&runtime_data).await {
                                         std::result::Result::Ok(results) => {
-                                            return self.octet_stream_response(results)
+                                            return self.octet_stream_response(results);
                                         }
                                         Err(e) => return self.internal_error(e.to_string()),
                                     }
@@ -201,7 +201,7 @@ impl Router {
                                     };
                                     match client.get_additional_evidence(&runtime_data).await {
                                         std::result::Result::Ok(results) => {
-                                            return self.octet_stream_response(results)
+                                            return self.octet_stream_response(results);
                                         }
                                         Err(e) => return self.internal_error(e.to_string()),
                                     }
@@ -232,7 +232,7 @@ impl Router {
                                 .await
                             {
                                 std::result::Result::Ok(message) => {
-                                    return self.json_response(message)
+                                    return self.json_response(message);
                                 }
                                 Err(e) => return self.internal_error(e.to_string()),
                             }
@@ -254,7 +254,7 @@ impl Router {
                         match api {
                             CDH_RESOURCE_URL => match client.get_resource(resource_path).await {
                                 std::result::Result::Ok(results) => {
-                                    return self.octet_stream_response(results)
+                                    return self.octet_stream_response(results);
                                 }
                                 Err(e) => return self.internal_error(e.to_string()),
                             },

--- a/api-server-rest/src/utils.rs
+++ b/api-server-rest/src/utils.rs
@@ -3,8 +3,8 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-use anyhow::{anyhow, Context, Result};
-use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
+use anyhow::{Context, Result, anyhow};
+use base64::{Engine, engine::general_purpose::URL_SAFE_NO_PAD};
 
 /// Parse `runtime_data` from the evidence query string.
 ///

--- a/attestation-agent/attestation-agent/Cargo.toml
+++ b/attestation-agent/attestation-agent/Cargo.toml
@@ -3,7 +3,7 @@ name = "attestation-agent"
 version = "0.1.0"
 authors = ["The Attestation Agent Authors"]
 publish = false
-edition = "2021"
+edition = "2024"
 license = "Apache-2.0"
 
 [[bin]]

--- a/attestation-agent/attestation-agent/src/bin/grpc-aa/main.rs
+++ b/attestation-agent/attestation-agent/src/bin/grpc-aa/main.rs
@@ -6,15 +6,15 @@
 mod server;
 
 use anyhow::*;
-use attestation_agent::{config::Config, initdata::Initdata, AttestationAPIs, AttestationAgent};
+use attestation_agent::{AttestationAPIs, AttestationAgent, config::Config, initdata::Initdata};
 use base64::Engine;
 use clap::Parser;
 use const_format::concatcp;
 use shadow_rs::shadow;
 use std::net::SocketAddr;
-use tokio::signal::unix::{signal, SignalKind};
+use tokio::signal::unix::{SignalKind, signal};
 use tracing::{debug, info};
-use tracing_subscriber::{fmt::Subscriber, EnvFilter};
+use tracing_subscriber::{EnvFilter, fmt::Subscriber};
 
 shadow!(build);
 

--- a/attestation-agent/attestation-agent/src/bin/grpc-aa/server.rs
+++ b/attestation-agent/attestation-agent/src/bin/grpc-aa/server.rs
@@ -6,14 +6,14 @@
 use anyhow::*;
 use attestation_agent::{AttestationAPIs, AttestationAgent, RuntimeMeasurement};
 use protos::grpc::aa::attestation_agent::{
-    attestation_agent_service_server::{AttestationAgentService, AttestationAgentServiceServer},
     BindInitDataRequest, BindInitDataResponse, ExtendRuntimeMeasurementRequest,
     ExtendRuntimeMeasurementResponse, GetAdditionalEvidenceRequest, GetAdditionalTeesRequest,
     GetAdditionalTeesResponse, GetEvidenceRequest, GetEvidenceResponse, GetTeeTypeRequest,
     GetTeeTypeResponse, GetTokenRequest, GetTokenResponse, RuntimeMeasurementResult,
+    attestation_agent_service_server::{AttestationAgentService, AttestationAgentServiceServer},
 };
 use std::net::SocketAddr;
-use tonic::{transport::Server, Request, Response, Status};
+use tonic::{Request, Response, Status, transport::Server};
 use tracing::{debug, error};
 
 pub const AGENT_NAME: &str = "attestation-agent";

--- a/attestation-agent/attestation-agent/src/bin/ttrpc-aa.rs
+++ b/attestation-agent/attestation-agent/src/bin/ttrpc-aa.rs
@@ -4,15 +4,15 @@
 //
 
 use anyhow::*;
-use attestation_agent::{config::Config, initdata::Initdata, AttestationAPIs, AttestationAgent};
+use attestation_agent::{AttestationAPIs, AttestationAgent, config::Config, initdata::Initdata};
 use base64::Engine;
 use clap::Parser;
 use const_format::concatcp;
 use shadow_rs::shadow;
 use std::{collections::HashMap, path::Path, sync::Arc};
-use tokio::signal::unix::{signal, SignalKind};
+use tokio::signal::unix::{SignalKind, signal};
 use tracing::{debug, info};
-use tracing_subscriber::{fmt::Subscriber, EnvFilter};
+use tracing_subscriber::{EnvFilter, fmt::Subscriber};
 use ttrpc::asynchronous::{Server, Service};
 use ttrpc_dep::server::AA;
 

--- a/attestation-agent/attestation-agent/src/config/aa_kbc_params.rs
+++ b/attestation-agent/attestation-agent/src/config/aa_kbc_params.rs
@@ -59,7 +59,9 @@ impl AaKbcParams {
 
     pub fn new() -> Result<Self, ParamError> {
         let Ok(value) = Self::get_value() else {
-            debug!("failed to get aa_kbc_params in either both env or kernel cmdline, use `offline_fs_kbc::null` as default.");
+            debug!(
+                "failed to get aa_kbc_params in either both env or kernel cmdline, use `offline_fs_kbc::null` as default."
+            );
             return Ok(Self::default());
         };
 

--- a/attestation-agent/attestation-agent/src/config/kbs.rs
+++ b/attestation-agent/attestation-agent/src/config/kbs.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-use anyhow::{bail, Result};
+use anyhow::{Result, bail};
 use serde::Deserialize;
 
 use super::aa_kbc_params::AaKbcParams;

--- a/attestation-agent/attestation-agent/src/eventlog/mod.rs
+++ b/attestation-agent/attestation-agent/src/eventlog/mod.rs
@@ -7,13 +7,13 @@ pub mod tcg2;
 
 use std::{
     fmt::Display,
-    fs::{remove_file, File},
+    fs::{File, remove_file},
     io::{Read, Seek, SeekFrom, Write},
     path::Path,
     sync::Arc,
 };
 
-use anyhow::{anyhow, bail, Context, Result};
+use anyhow::{Context, Result, anyhow, bail};
 use attester::BoxedAttester;
 use const_format::concatcp;
 
@@ -119,10 +119,14 @@ impl EventLog {
         match Self::read_wal_cache(alg.digest_len()) {
             Ok(Some(wal_cache)) => {
                 warn!("Recover from a previous crash.");
-                let current_pcr = rtmr_extender.get_runtime_measurement(pcr).await.context("get runtime measurement")?;
+                let current_pcr = rtmr_extender
+                    .get_runtime_measurement(pcr)
+                    .await
+                    .context("get runtime measurement")?;
                 let aael_event = Event::try_from(&wal_cache.event_data[..])?;
                 let rtmr = rtmr_extender.pcr_to_ccmr(pcr);
-                let (tcg2_event_data, tcg2_event_digest) = Self::serialize_tcg2_event(aael_event, rtmr, alg);
+                let (tcg2_event_data, tcg2_event_digest) =
+                    Self::serialize_tcg2_event(aael_event, rtmr, alg);
 
                 // if the PCR has not been extended yet, we should just write eventlog
                 if current_pcr != wal_cache.expected_pcr {
@@ -132,11 +136,15 @@ impl EventLog {
                     let digest_to_be_updated = alg.digest(&pcr_status);
 
                     if digest_to_be_updated != wal_cache.expected_pcr {
-                        bail!("fatal error when recovering. The eventlog file {EVENTLOG_PATH} is probably corrupted, or other process has extend the target PCR {pcr}.")
+                        bail!(
+                            "fatal error when recovering. The eventlog file {EVENTLOG_PATH} is probably corrupted, or other process has extend the target PCR {pcr}."
+                        )
                     }
 
                     // else, update the PCR
-                    rtmr_extender.extend_runtime_measurement(tcg2_event_digest, pcr).await?;
+                    rtmr_extender
+                        .extend_runtime_measurement(tcg2_event_digest, pcr)
+                        .await?;
                 }
 
                 writer.seek(wal_cache.event_offset)?;
@@ -149,13 +157,15 @@ impl EventLog {
                     pcr,
                 })
             }
-            Err(_) => bail!("Failed to read wal cache. This is a significant error caused by a previous crash. Please try delete `{WAL_CACHE}` and restart the attestation agent."),
+            Err(_) => bail!(
+                "Failed to read wal cache. This is a significant error caused by a previous crash. Please try delete `{WAL_CACHE}` and restart the attestation agent."
+            ),
             Ok(None) => Ok(Self {
                 writer,
                 rtmr_extender,
                 alg,
                 pcr,
-            })
+            }),
         }
     }
 
@@ -429,8 +439,20 @@ mod tests {
         "46df8dacf00a07d34a83cdf56d7978697790787cf2ba1432ef7c38f22cd96351",
         HashAlgorithm::Sha256
     )]
-    #[case("domain", "operation", "content", "dad5f0e226318ffa9839b75a472c6aa7fdb5834949d0a0a22990cf04d5692440fb00f3aa0609db7e49cd8d793f670d02", HashAlgorithm::Sha384)]
-    #[case("domain", "operation", "content", "b708d222ca8bd44dfe6ba0c4ca2cbb72379276fba8091025217064be45a813e5d6124ccf073219edb617d1faf007d55061465bdf34b7437dbdc9a7405bd4e9c0", HashAlgorithm::Sha512)]
+    #[case(
+        "domain",
+        "operation",
+        "content",
+        "dad5f0e226318ffa9839b75a472c6aa7fdb5834949d0a0a22990cf04d5692440fb00f3aa0609db7e49cd8d793f670d02",
+        HashAlgorithm::Sha384
+    )]
+    #[case(
+        "domain",
+        "operation",
+        "content",
+        "b708d222ca8bd44dfe6ba0c4ca2cbb72379276fba8091025217064be45a813e5d6124ccf073219edb617d1faf007d55061465bdf34b7437dbdc9a7405bd4e9c0",
+        HashAlgorithm::Sha512
+    )]
     fn test_event_digest(
         #[case] domain: &str,
         #[case] operation: &str,

--- a/attestation-agent/attestation-agent/src/lib.rs
+++ b/attestation-agent/attestation-agent/src/lib.rs
@@ -5,7 +5,7 @@
 
 use anyhow::{Context, Result};
 use async_trait::async_trait;
-use attester::{detect_attestable_devices, detect_tee_type, BoxedAttester};
+use attester::{BoxedAttester, detect_attestable_devices, detect_tee_type};
 use kbs_types::Tee;
 use std::{collections::HashMap, str::FromStr, sync::Arc};
 use tokio::sync::{Mutex, RwLock};

--- a/attestation-agent/attestation-agent/src/token/coco_as.rs
+++ b/attestation-agent/attestation-agent/src/token/coco_as.rs
@@ -6,9 +6,9 @@
 use crate::config::coco_as::CoCoASConfig;
 
 use anyhow::*;
-use attester::{detect_tee_type, BoxedAttester};
-use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use attester::{BoxedAttester, detect_tee_type};
 use base64::Engine;
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
 
 #[derive(Default)]
 pub struct CoCoASTokenGetter {

--- a/attestation-agent/attestation-agent/src/token/kbs.rs
+++ b/attestation-agent/attestation-agent/src/token/kbs.rs
@@ -6,7 +6,7 @@
 use crate::config::kbs::KbsConfig;
 
 use anyhow::*;
-use kbs_protocol::{evidence_provider::NativeEvidenceProvider, KbsClientBuilder, TeeKeyAlgorithm};
+use kbs_protocol::{KbsClientBuilder, TeeKeyAlgorithm, evidence_provider::NativeEvidenceProvider};
 use serde::Serialize;
 
 #[derive(Serialize)]

--- a/attestation-agent/attester/Cargo.toml
+++ b/attestation-agent/attester/Cargo.toml
@@ -3,7 +3,7 @@ name = "attester"
 version = "0.1.0"
 authors = ["The Attestation Agent Authors"]
 publish = false
-edition = "2021"
+edition = "2024"
 license = "Apache-2.0"
 
 [dependencies]

--- a/attestation-agent/attester/src/az_snp_vtpm/mod.rs
+++ b/attestation-agent/attester/src/az_snp_vtpm/mod.rs
@@ -4,7 +4,7 @@
 //
 
 use super::{Attester, InitDataResult, TeeEvidence};
-use anyhow::{bail, Context, Result};
+use anyhow::{Context, Result, bail};
 use az_snp_vtpm::{imds, is_snp_cvm, vtpm};
 use azure_tpm::{Tpm, TpmCommandExt};
 use kbs_types::HashAlgorithm;

--- a/attestation-agent/attester/src/az_tdx_vtpm/mod.rs
+++ b/attestation-agent/attester/src/az_tdx_vtpm/mod.rs
@@ -4,7 +4,7 @@
 //
 
 use super::{Attester, InitDataResult, TeeEvidence};
-use crate::az_snp_vtpm::{utils, TpmQuote};
+use crate::az_snp_vtpm::{TpmQuote, utils};
 use anyhow::*;
 use az_tdx_vtpm::{hcl, is_tdx_cvm, tdx::TdReport, vtpm};
 use azure_guest_attestation_sdk::guest_attest::ImdsClient;

--- a/attestation-agent/attester/src/bin/evidence_getter.rs
+++ b/attestation-agent/attester/src/bin/evidence_getter.rs
@@ -51,7 +51,7 @@ async fn main() {
 
     match cli {
         Cli::Stdio => {
-            std::io::stdin()
+            let _ = std::io::stdin()
                 .read(&mut report_data)
                 .expect("read input failed");
         }

--- a/attestation-agent/attester/src/bin/evidence_getter.rs
+++ b/attestation-agent/attester/src/bin/evidence_getter.rs
@@ -3,12 +3,12 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-use attester::{detect_attestable_devices, detect_tee_type, BoxedAttester};
+use attester::{BoxedAttester, detect_attestable_devices, detect_tee_type};
 use clap::Parser;
 use kbs_types::Tee;
 use std::io::Read;
 use tokio::fs;
-use tracing_subscriber::{fmt, EnvFilter};
+use tracing_subscriber::{EnvFilter, fmt};
 
 #[derive(Debug, Parser)]
 #[command(author)]

--- a/attestation-agent/attester/src/csv/mod.rs
+++ b/attestation-agent/attester/src/csv/mod.rs
@@ -15,13 +15,13 @@ const CSV_INCLUDE_CERT_CHAIN_ENV: &str = "CSV_INCLUDE_CERT_CHAIN_IN_ATTESTATION_
 use crate::utils::read_eventlog;
 
 use super::{Attester, TeeEvidence};
-use anyhow::{bail, Context, Result};
+use anyhow::{Context, Result, bail};
 use codicon::Decoder;
 use csv_rs::{
     api::guest::{AttestationReport, AttestationReportWrapper, CsvGuest},
     certs::{ca, csv},
 };
-use hyper::{body::HttpBody, Client};
+use hyper::{Client, body::HttpBody};
 use hyper_tls::HttpsConnector;
 use kbs_types::HashAlgorithm;
 use serde::{Deserialize, Serialize};

--- a/attestation-agent/attester/src/lib.rs
+++ b/attestation-agent/attester/src/lib.rs
@@ -302,7 +302,9 @@ pub fn detect_tee_type() -> Tee {
     // Kept as the last entry after all vTPM TEE attesters (i.e., az-*-vtpm-attester).
     #[cfg(feature = "tpm-attester")]
     if tpm::detect_platform() {
-        tracing::warn!("The TPM device was detected, but please note that it is not bound to the TEE, so there may be security risks.");
+        tracing::warn!(
+            "The TPM device was detected, but please note that it is not bound to the TEE, so there may be security risks."
+        );
         return Tee::Tpm;
     }
 
@@ -348,7 +350,9 @@ pub fn detect_attestable_devices() -> Vec<Tee> {
         not(feature = "az-tdx-vtpm-attester")
     ))]
     if detect_tee_type() != Tee::Tpm && tpm::detect_platform() {
-        tracing::warn!("The TPM device was detected as an additional device, but please note that it is not bound to the TEE, so there may be security risks.");
+        tracing::warn!(
+            "The TPM device was detected as an additional device, but please note that it is not bound to the TEE, so there may be security risks."
+        );
         additional_devices.push(Tee::Tpm);
     }
 

--- a/attestation-agent/attester/src/lib.rs
+++ b/attestation-agent/attester/src/lib.rs
@@ -288,7 +288,9 @@ pub fn detect_tee_type() -> Tee {
     // Kept as the last entry after all vTPM TEE attesters (i.e., az-*-vtpm-attester).
     #[cfg(feature = "tpm-attester")]
     if tpm::detect_platform() {
-        tracing::warn!("The TPM device was detected, but please note that it is not bound to the TEE, so there may be security risks.");
+        tracing::warn!(
+            "The TPM device was detected, but please note that it is not bound to the TEE, so there may be security risks."
+        );
         return Tee::Tpm;
     }
 
@@ -334,7 +336,9 @@ pub fn detect_attestable_devices() -> Vec<Tee> {
         not(feature = "az-tdx-vtpm-attester")
     ))]
     if detect_tee_type() != Tee::Tpm && tpm::detect_platform() {
-        tracing::warn!("The TPM device was detected as an additional device, but please note that it is not bound to the TEE, so there may be security risks.");
+        tracing::warn!(
+            "The TPM device was detected as an additional device, but please note that it is not bound to the TEE, so there may be security risks."
+        );
         additional_devices.push(Tee::Tpm);
     }
 

--- a/attestation-agent/attester/src/nvidia/mod.rs
+++ b/attestation-agent/attester/src/nvidia/mod.rs
@@ -6,9 +6,9 @@
 #[cfg(target_arch = "x86_64")]
 mod nvat;
 #[cfg(target_arch = "x86_64")]
-pub use nvat::{detect_platform, NvAttester};
+pub use nvat::{NvAttester, detect_platform};
 
 #[cfg(not(target_arch = "x86_64"))]
 mod unsupported;
 #[cfg(not(target_arch = "x86_64"))]
-pub use unsupported::{detect_platform, NvAttester};
+pub use unsupported::{NvAttester, detect_platform};

--- a/attestation-agent/attester/src/nvidia/nvat.rs
+++ b/attestation-agent/attester/src/nvidia/nvat.rs
@@ -4,7 +4,7 @@
 //
 
 use crate::{Attester, TeeEvidence};
-use anyhow::{anyhow, Context, Result};
+use anyhow::{Context, Result, anyhow};
 use nv_attestation_sdk::{GpuEvidenceSource, Nonce, NvatSdk, SdkOptions, SwitchEvidenceSource};
 use serde::{Deserialize, Serialize};
 use std::sync::OnceLock;

--- a/attestation-agent/attester/src/nvidia/unsupported.rs
+++ b/attestation-agent/attester/src/nvidia/unsupported.rs
@@ -4,7 +4,7 @@
 //
 
 use crate::{Attester, TeeEvidence};
-use anyhow::{bail, Result};
+use anyhow::{Result, bail};
 
 pub fn detect_platform() -> bool {
     false

--- a/attestation-agent/attester/src/nvidia_dpu/mod.rs
+++ b/attestation-agent/attester/src/nvidia_dpu/mod.rs
@@ -17,7 +17,7 @@
 //! hardware (vendor `15b3`, device `a2dc` for BF3 NIC or `a2da` for SoC bridge).
 
 use super::{Attester, TeeEvidence};
-use anyhow::{bail, Context, Result};
+use anyhow::{Context, Result, bail};
 use p384::ecdsa::signature::Signer;
 use p384::ecdsa::{Signature, SigningKey};
 use serde::{Deserialize, Serialize};

--- a/attestation-agent/attester/src/se/mod.rs
+++ b/attestation-agent/attester/src/se/mod.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-use super::{utils::validate_and_pad_data, Attester, TeeEvidence};
+use super::{Attester, TeeEvidence, utils::validate_and_pad_data};
 use anyhow::*;
 use pv::{
     misc,

--- a/attestation-agent/attester/src/sgx_dcap/mod.rs
+++ b/attestation-agent/attester/src/sgx_dcap/mod.rs
@@ -4,9 +4,9 @@
 //
 
 use super::{Attester, TeeEvidence};
-use anyhow::{bail, Context, Result};
+use anyhow::{Context, Result, bail};
 use base64::Engine;
-use occlum_dcap::{sgx_report_data_t, DcapQuote};
+use occlum_dcap::{DcapQuote, sgx_report_data_t};
 use serde::{Deserialize, Serialize};
 
 const OCCLUM_ENV: &str = "OCCLUM";

--- a/attestation-agent/attester/src/snp/mod.rs
+++ b/attestation-agent/attester/src/snp/mod.rs
@@ -3,8 +3,8 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-use crate::utils::pad;
 use crate::InitDataResult;
+use crate::utils::pad;
 
 use super::{Attester, TeeEvidence};
 use anyhow::*;

--- a/attestation-agent/attester/src/tdx/mod.rs
+++ b/attestation-agent/attester/src/tdx/mod.rs
@@ -5,8 +5,8 @@
 
 use super::tsm_report::*;
 use super::{Attester, TeeEvidence};
-use crate::utils::{pad, read_eventlog};
 use crate::InitDataResult;
+use crate::utils::{pad, read_eventlog};
 use anyhow::*;
 use base64::Engine;
 use iocuddle::{Group, Ioctl, WriteRead};

--- a/attestation-agent/attester/src/tdx/mod.rs
+++ b/attestation-agent/attester/src/tdx/mod.rs
@@ -5,8 +5,8 @@
 
 use super::tsm_report::*;
 use super::{Attester, TeeEvidence};
-use crate::utils::{pad, read_eventlog};
 use crate::InitDataResult;
+use crate::utils::{pad, read_eventlog};
 use anyhow::*;
 use base64::Engine;
 use iocuddle::{Group, Ioctl, WriteRead};
@@ -176,12 +176,8 @@ impl Attester for TdxAttester {
 
     async fn bind_init_data(&self, init_data_digest: &[u8]) -> Result<InitDataResult> {
         let mr_configid = match self.supports_tsm_measurements {
-            true => {
-                let mrconfigid = std::fs::read(Path::new(TDX_TSM_SYSFS_PATH).join("mrconfigid"))
-                    .context("Failed to read MRCONFIGID via sysfs")?;
-
-                mrconfigid
-            }
+            true => std::fs::read(Path::new(TDX_TSM_SYSFS_PATH).join("mrconfigid"))
+                .context("Failed to read MRCONFIGID via sysfs")?,
             false => {
                 let report = self.ioctl_get_report()?;
                 report.tdinfo.mrconfigid.to_vec()

--- a/attestation-agent/attester/src/tdx/report.rs
+++ b/attestation-agent/attester/src/tdx/report.rs
@@ -115,15 +115,27 @@ mod test {
     use rstest::rstest;
     use scroll::Pread;
 
-    use crate::tdx::{report::TdReport, TdxAttester};
+    use crate::tdx::{TdxAttester, report::TdReport};
 
     /// This test uses a fixture of tdx-report to check if the get_runtime_measurement function works correctly.
     /// The following test PCRs are mapping to TDX RTMR 0, 1, 2 and 3
     #[rstest]
-    #[case(1, "f4ec1a04670fe7926cd5de4aef9aaa7689ab4ceaa132d7c5242b47f67dfaaea64c372a17ad68fef9a6ac99aabbddabdc")]
-    #[case(2, "4e5f8826653198ab4bc5156fbe4bc99db054c0b8239a16c4b59249fb427f4acc50eed1b46a85c7d526c4e1e47621b14c")]
-    #[case(8, "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000")]
-    #[case(16, "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000")]
+    #[case(
+        1,
+        "f4ec1a04670fe7926cd5de4aef9aaa7689ab4ceaa132d7c5242b47f67dfaaea64c372a17ad68fef9a6ac99aabbddabdc"
+    )]
+    #[case(
+        2,
+        "4e5f8826653198ab4bc5156fbe4bc99db054c0b8239a16c4b59249fb427f4acc50eed1b46a85c7d526c4e1e47621b14c"
+    )]
+    #[case(
+        8,
+        "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
+    )]
+    #[case(
+        16,
+        "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
+    )]
     fn get_runtime_measurement(#[case] pcr_index: u64, #[case] expected: &str) {
         use crate::Attester;
 

--- a/attestation-agent/attester/src/tpm/mod.rs
+++ b/attestation-agent/attester/src/tpm/mod.rs
@@ -7,10 +7,10 @@ use super::{Attester, InitDataResult, TeeEvidence};
 pub mod utils;
 
 use self::utils::{
-    detect_tpm_device, extend_pcr, get_ak_handle, get_quote, read_ak_public_key, read_all_pcrs,
-    TpmQuote,
+    TpmQuote, detect_tpm_device, extend_pcr, get_ak_handle, get_quote, read_ak_public_key,
+    read_all_pcrs,
 };
-use anyhow::{anyhow, Result};
+use anyhow::{Result, anyhow};
 use base64::Engine;
 use serde::{Deserialize, Serialize};
 use tracing::info;

--- a/attestation-agent/attester/src/tpm/utils.rs
+++ b/attestation-agent/attester/src/tpm/utils.rs
@@ -3,24 +3,24 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-use anyhow::{anyhow, bail, Context, Result};
+use anyhow::{Context, Result, anyhow, bail};
 use base64::Engine;
 use num_traits::cast::FromPrimitive;
 use serde::{Deserialize, Serialize};
 use std::env;
 use std::str::FromStr;
+use tss_esapi::Context as TssContext;
 use tss_esapi::attributes::SessionAttributesBuilder;
 use tss_esapi::constants::SessionType;
 use tss_esapi::handles::{PcrHandle, TpmHandle};
 use tss_esapi::interface_types::algorithm::HashingAlgorithm;
 use tss_esapi::structures::digest_values::DigestValues;
 use tss_esapi::structures::{
-    pcr_selection_list::PcrSelectionListBuilder, pcr_slot::PcrSlot, AttestInfo, PcrSelectionList,
-    Signature, SignatureScheme as TpmSignatureScheme, SymmetricDefinition,
+    AttestInfo, PcrSelectionList, Signature, SignatureScheme as TpmSignatureScheme,
+    SymmetricDefinition, pcr_selection_list::PcrSelectionListBuilder, pcr_slot::PcrSlot,
 };
 use tss_esapi::tcti_ldr::TctiNameConf;
 use tss_esapi::traits::Marshall;
-use tss_esapi::Context as TssContext;
 use tss_esapi::{
     abstraction::{pcr, public::DecodedKey},
     structures::HashScheme,

--- a/attestation-agent/attester/src/utils.rs
+++ b/attestation-agent/attester/src/utils.rs
@@ -5,8 +5,8 @@
 
 use std::{env, path::Path};
 
-use anyhow::{bail, Result};
-use base64::{engine::general_purpose::STANDARD, Engine};
+use anyhow::{Result, bail};
+use base64::{Engine, engine::general_purpose::STANDARD};
 use tokio::{fs::File, io::AsyncReadExt};
 use tracing::debug;
 

--- a/attestation-agent/coco_keyprovider/Cargo.toml
+++ b/attestation-agent/coco_keyprovider/Cargo.toml
@@ -3,7 +3,7 @@ name = "coco_keyprovider"
 version = "0.1.0"
 authors = ["The Attestation Agent Authors"]
 publish = false
-edition = "2021"
+edition = "2024"
 license = "Apache-2.0"
 
 [dependencies]

--- a/attestation-agent/coco_keyprovider/src/enc_mods/crypto.rs
+++ b/attestation-agent/coco_keyprovider/src/enc_mods/crypto.rs
@@ -5,7 +5,7 @@
 
 use std::fmt::Display;
 
-use aes_gcm::{aead::Aead, aes::Aes256, Aes256Gcm, Key, Nonce};
+use aes_gcm::{Aes256Gcm, Key, Nonce, aead::Aead, aes::Aes256};
 use anyhow::*;
 use strum::EnumString;
 

--- a/attestation-agent/coco_keyprovider/src/enc_mods/mod.rs
+++ b/attestation-agent/coco_keyprovider/src/enc_mods/mod.rs
@@ -5,7 +5,7 @@
 
 use std::collections::HashMap;
 
-use anyhow::{anyhow, bail, Context, Result};
+use anyhow::{Context, Result, anyhow, bail};
 use base64::Engine;
 use jwt_simple::prelude::Ed25519KeyPair;
 use rand::RngExt;
@@ -210,14 +210,14 @@ pub async fn enc_optsdata_gen_anno(
     let encrypt_optsdata = crypto::encrypt(optsdata, &key, &iv, &algorithm)
         .map_err(|e| anyhow!("Encrypt failed: {:?}", e))?;
 
-    if let (Some(addr), Some(private_key)) = kbs_parameter {
-        if !input_params.sample {
-            // We do not register KEK for sample kbc
-            register_kek(private_key, addr, key, &k_path)
-                .await
-                .context("register KEK failed")?;
-            info!("register KEK succeeded.");
-        }
+    if let (Some(addr), Some(private_key)) = kbs_parameter
+        && !input_params.sample
+    {
+        // We do not register KEK for sample kbc
+        register_kek(private_key, addr, key, &k_path)
+            .await
+            .context("register KEK failed")?;
+        info!("register KEK succeeded.");
     }
 
     let engine = base64::engine::general_purpose::STANDARD;

--- a/attestation-agent/coco_keyprovider/src/grpc/mod.rs
+++ b/attestation-agent/coco_keyprovider/src/grpc/mod.rs
@@ -8,14 +8,14 @@ use anyhow::*;
 use base64::Engine;
 use jwt_simple::prelude::Ed25519KeyPair;
 use protos::grpc::cdh::keyprovider::{
-    key_provider_service_server::{KeyProviderService, KeyProviderServiceServer},
     KeyProviderKeyWrapProtocolInput, KeyProviderKeyWrapProtocolOutput,
+    key_provider_service_server::{KeyProviderService, KeyProviderServiceServer},
 };
 use reqwest::Url;
 use std::net::SocketAddr;
 use std::path::PathBuf;
 use tokio::fs;
-use tonic::{transport::Server, Request, Response, Status};
+use tonic::{Request, Response, Status, transport::Server};
 use tracing::debug;
 
 use protocol::keyprovider_structs::*;

--- a/attestation-agent/coco_keyprovider/src/main.rs
+++ b/attestation-agent/coco_keyprovider/src/main.rs
@@ -10,7 +10,7 @@ use shadow_rs::shadow;
 use std::{fs::File, net::SocketAddr, path::PathBuf};
 use tokio::fs;
 use tracing::{debug, info};
-use tracing_subscriber::{fmt::Subscriber, EnvFilter};
+use tracing_subscriber::{EnvFilter, fmt::Subscriber};
 
 shadow!(build);
 

--- a/attestation-agent/deps/crypto/Cargo.toml
+++ b/attestation-agent/deps/crypto/Cargo.toml
@@ -3,7 +3,7 @@ name = "crypto"
 version = "0.1.0"
 authors = ["The Attestation Agent Authors"]
 publish = false
-edition = "2021"
+edition = "2024"
 license = "Apache-2.0"
 
 [dependencies]

--- a/attestation-agent/deps/crypto/src/native/ec.rs
+++ b/attestation-agent/deps/crypto/src/native/ec.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-use anyhow::{anyhow, bail, Context, Result};
+use anyhow::{Context, Result, anyhow, bail};
 use openssl::{
     aes::{self, AesKey},
     bn::{BigNum, BigNumContext},
@@ -16,8 +16,8 @@ use openssl::{
 use zeroize::Zeroizing;
 
 use crate::{
-    ec::{Curve, KeyWrapAlgorithm},
     AES_GCM_256_KEY_BITS,
+    ec::{Curve, KeyWrapAlgorithm},
 };
 
 #[derive(Clone, Debug)]

--- a/attestation-agent/deps/crypto/src/rust/aes256ctr.rs
+++ b/attestation-agent/deps/crypto/src/rust/aes256ctr.rs
@@ -8,8 +8,8 @@
 use aes_gcm::aes::Aes256;
 use anyhow::*;
 use ctr::{
-    cipher::{KeyIvInit, StreamCipher},
     Ctr128BE,
+    cipher::{KeyIvInit, StreamCipher},
 };
 
 pub fn decrypt(key: &[u8], encrypted_data: &[u8], iv: &[u8]) -> Result<Vec<u8>> {

--- a/attestation-agent/deps/crypto/src/rust/aes256gcm.rs
+++ b/attestation-agent/deps/crypto/src/rust/aes256gcm.rs
@@ -6,8 +6,8 @@
 //! This mod implements aes-256-gcm encryption & decryption.
 use crate::AeadCipher;
 use aes_gcm::{
-    aead::{Aead, AeadInOut},
     Aes256Gcm, Key, KeyInit, Nonce,
+    aead::{Aead, AeadInOut},
 };
 use anyhow::*;
 

--- a/attestation-agent/deps/crypto/src/rust/ec.rs
+++ b/attestation-agent/deps/crypto/src/rust/ec.rs
@@ -4,22 +4,22 @@
 //
 
 use crate::{
-    ec::{Curve, KeyWrapAlgorithm},
     AES_GCM_256_KEY_BITS,
+    ec::{Curve, KeyWrapAlgorithm},
 };
 
 use aes_kw::{KeyInit, KwAes256};
-use anyhow::{anyhow, Result};
+use anyhow::{Result, anyhow};
 use p256::{
+    EncodedPoint as P256EncodedPoint, FieldBytes as P256FieldBytes, PublicKey as P256PublicKey,
+    SecretKey as P256SecretKey,
     ecdh::diffie_hellman as diffie_hellman_p256,
     elliptic_curve::sec1::FromEncodedPoint,
     pkcs8::{DecodePrivateKey, EncodePrivateKey, LineEnding},
-    EncodedPoint as P256EncodedPoint, FieldBytes as P256FieldBytes, PublicKey as P256PublicKey,
-    SecretKey as P256SecretKey,
 };
 use p521::{
-    ecdh::diffie_hellman as diffie_hellman_p521, EncodedPoint as P521EncodedPoint,
-    FieldBytes as P521FieldBytes, PublicKey as P521PublicKey, SecretKey as P521SecretKey,
+    EncodedPoint as P521EncodedPoint, FieldBytes as P521FieldBytes, PublicKey as P521PublicKey,
+    SecretKey as P521SecretKey, ecdh::diffie_hellman as diffie_hellman_p521,
 };
 use zeroize::Zeroizing;
 

--- a/attestation-agent/deps/crypto/src/rust/rsa.rs
+++ b/attestation-agent/deps/crypto/src/rust/rsa.rs
@@ -7,10 +7,10 @@
 
 use anyhow::*;
 use rsa::{
+    Oaep, Pkcs1v15Encrypt, RsaPrivateKey, RsaPublicKey,
     pkcs1::{DecodeRsaPrivateKey, EncodeRsaPrivateKey},
     pkcs8::LineEnding,
     traits::PublicKeyParts,
-    Oaep, Pkcs1v15Encrypt, RsaPrivateKey, RsaPublicKey,
 };
 use zeroize::Zeroizing;
 

--- a/attestation-agent/deps/crypto/src/symmetric.rs
+++ b/attestation-agent/deps/crypto/src/symmetric.rs
@@ -5,7 +5,7 @@
 
 //! APIs for symmetric keys
 
-use anyhow::{bail, Result};
+use anyhow::{Result, bail};
 use serde::{Deserialize, Serialize};
 use zeroize::Zeroizing;
 

--- a/attestation-agent/deps/resource_uri/Cargo.toml
+++ b/attestation-agent/deps/resource_uri/Cargo.toml
@@ -3,7 +3,7 @@ name = "resource_uri"
 version = "0.1.0"
 authors = ["The Attestation Agent Authors"]
 publish = false
-edition = "2021"
+edition = "2024"
 license = "Apache-2.0"
 
 [dev-dependencies]

--- a/attestation-agent/deps/resource_uri/src/lib.rs
+++ b/attestation-agent/deps/resource_uri/src/lib.rs
@@ -7,7 +7,7 @@
 //! obtained from `get_resource` endpoint. Also, `kid` field in an
 //! [`super::AnnotationPacket`] of `decrypt_payload` should also follow this.
 
-use anyhow::{anyhow, bail, Result};
+use anyhow::{Result, anyhow, bail};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 const RESOURCE_ID_ERROR_INFO: &str =
@@ -53,11 +53,11 @@ impl TryFrom<url::Url> for ResourceUri {
     fn try_from(value: url::Url) -> Result<Self, Self::Error> {
         let mut kbs_address = value.host_str().unwrap_or_default().to_string();
 
-        if !kbs_address.is_empty() {
-            if let Some(port) = value.port() {
-                kbs_address += ":";
-                kbs_address += &port.to_string();
-            }
+        if !kbs_address.is_empty()
+            && let Some(port) = value.port()
+        {
+            kbs_address += ":";
+            kbs_address += &port.to_string();
         }
 
         let scheme = value.scheme();

--- a/attestation-agent/deps/sev/Cargo.toml
+++ b/attestation-agent/deps/sev/Cargo.toml
@@ -3,7 +3,7 @@ name = "sev"
 version = "0.1.0"
 authors = ["The Attestation Agent Authors"]
 publish = false
-edition = "2021"
+edition = "2024"
 license = "Apache-2.0"
 
 [dependencies]

--- a/attestation-agent/deps/sev/src/lib.rs
+++ b/attestation-agent/deps/sev/src/lib.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-use anyhow::{anyhow, Result};
+use anyhow::{Result, anyhow};
 use std::process::Command;
 
 const SECRET_MODULE_NAME: &str = "efi_secret";

--- a/attestation-agent/kbc/Cargo.toml
+++ b/attestation-agent/kbc/Cargo.toml
@@ -3,7 +3,7 @@ name = "kbc"
 version = "0.1.0"
 authors = ["The Attestation Agent Authors"]
 publish = false
-edition = "2021"
+edition = "2024"
 license = "Apache-2.0"
 
 [dependencies]

--- a/attestation-agent/kbc/src/cc_kbc/mod.rs
+++ b/attestation-agent/kbc/src/cc_kbc/mod.rs
@@ -4,11 +4,11 @@
 //
 
 use crate::{KbcCheckInfo, KbcInterface};
-use crypto::{decrypt, WrapType};
+use crypto::{WrapType, decrypt};
 use kbs_protocol::{
+    KbsClientBuilder, KbsClientCapabilities,
     client::KbsClient,
     evidence_provider::{EvidenceProvider, NativeEvidenceProvider},
-    KbsClientBuilder, KbsClientCapabilities,
 };
 
 use super::AnnotationPacket;

--- a/attestation-agent/kbc/src/offline_fs_kbc/common.rs
+++ b/attestation-agent/kbc/src/offline_fs_kbc/common.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-use anyhow::{anyhow, Result};
+use anyhow::{Result, anyhow};
 use base64::Engine;
 use std::collections::HashMap;
 use std::fs;

--- a/attestation-agent/kbc/src/offline_fs_kbc/mod.rs
+++ b/attestation-agent/kbc/src/offline_fs_kbc/mod.rs
@@ -8,7 +8,7 @@ use crate::{KbcCheckInfo, KbcInterface};
 pub mod common;
 use common::*;
 
-use anyhow::{anyhow, Context, Result};
+use anyhow::{Context, Result, anyhow};
 use async_trait::async_trait;
 use base64::Engine;
 use crypto::WrapType;

--- a/attestation-agent/kbc/src/sample_kbc/mod.rs
+++ b/attestation-agent/kbc/src/sample_kbc/mod.rs
@@ -5,7 +5,7 @@
 
 use crate::{KbcCheckInfo, KbcInterface};
 use base64::Engine;
-use crypto::{decrypt, WrapType};
+use crypto::{WrapType, decrypt};
 
 use anyhow::*;
 use async_trait::async_trait;

--- a/attestation-agent/kbs_protocol/Cargo.toml
+++ b/attestation-agent/kbs_protocol/Cargo.toml
@@ -3,7 +3,7 @@ name = "kbs_protocol"
 version = "0.1.0"
 authors = ["The Attestation Agent Authors"]
 publish = false
-edition = "2021"
+edition = "2024"
 license = "Apache-2.0"
 build = "build.rs"
 

--- a/attestation-agent/kbs_protocol/src/akp.rs
+++ b/attestation-agent/kbs_protocol/src/akp.rs
@@ -17,10 +17,10 @@
 //! vectors when those emerge.
 
 use aes_kw::{KeyInit, KwAes192};
-use anyhow::{anyhow, Result};
-use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
+use anyhow::{Result, anyhow};
+use base64::{Engine, engine::general_purpose::URL_SAFE_NO_PAD};
 use kbs_types::TeePubKey;
-use ml_kem::{kem::KeyExport, Decapsulate, DecapsulationKey, EncapsulationKey, Kem, MlKem768};
+use ml_kem::{Decapsulate, DecapsulationKey, EncapsulationKey, Kem, MlKem768, kem::KeyExport};
 use sha3_kmac::Kmac256;
 
 /// `kty` value for the Algorithm Key Pair (AKP) key type per

--- a/attestation-agent/kbs_protocol/src/bin/trustee-attester/main.rs
+++ b/attestation-agent/kbs_protocol/src/bin/trustee-attester/main.rs
@@ -7,19 +7,19 @@
 
 use anyhow::Context;
 use anyhow::Result;
-use base64::engine::general_purpose::STANDARD;
 use base64::Engine;
+use base64::engine::general_purpose::STANDARD;
 use clap::{Parser, Subcommand};
 use shadow_rs::{formatcp, shadow};
 use std::fs;
 use std::path::PathBuf;
 use tracing::debug;
-use tracing_subscriber::{fmt::Subscriber, EnvFilter};
+use tracing_subscriber::{EnvFilter, fmt::Subscriber};
 
-use kbs_protocol::evidence_provider::NativeEvidenceProvider;
 use kbs_protocol::KbsClientBuilder;
 use kbs_protocol::KbsClientCapabilities;
 use kbs_protocol::ResourceUri;
+use kbs_protocol::evidence_provider::NativeEvidenceProvider;
 
 shadow!(build);
 

--- a/attestation-agent/kbs_protocol/src/client/rcar_client.rs
+++ b/attestation-agent/kbs_protocol/src/client/rcar_client.rs
@@ -5,7 +5,7 @@
 
 use std::time::Duration;
 
-use anyhow::{bail, Context};
+use anyhow::{Context, bail};
 use async_trait::async_trait;
 use kbs_types::HashAlgorithm;
 use kbs_types::{
@@ -18,14 +18,14 @@ use serde_json::json;
 use tracing::{debug, warn};
 
 use crate::{
+    Error, Result,
     api::KbsClientCapabilities,
     client::{
-        ClientTee, KbsClient, KBS_GET_RESOURCE_MAX_ATTEMPT, KBS_PREFIX, KBS_PROTOCOL_VERSION,
+        ClientTee, KBS_GET_RESOURCE_MAX_ATTEMPT, KBS_PREFIX, KBS_PROTOCOL_VERSION, KbsClient,
     },
     evidence_provider::EvidenceProvider,
     keypair::TeeKeyPair,
     token_provider::Token,
-    Error, Result,
 };
 
 /// When executing get token, RCAR handshake should retry if failed to
@@ -133,7 +133,9 @@ impl KbsClient<Box<dyn EvidenceProvider>> {
                 Ok(_) => break,
                 Err(e) => {
                     if retry_count >= RCAR_MAX_ATTEMPT {
-                        return Err(Error::RcarHandshake(format!("Unable to get token. RCAR handshake retried {RCAR_MAX_ATTEMPT} times. Final attempt failed with: {e:?}")));
+                        return Err(Error::RcarHandshake(format!(
+                            "Unable to get token. RCAR handshake retried {RCAR_MAX_ATTEMPT} times. Final attempt failed with: {e:?}"
+                        )));
                     } else {
                         warn!("RCAR handshake failed: {e:?}, retry {retry_count}...");
                         retry_count += 1;
@@ -401,24 +403,24 @@ impl KbsClientCapabilities for KbsClient<Box<dyn EvidenceProvider>> {
 mod test {
     use kbs_types::HashAlgorithm;
     use rstest::rstest;
-    use serde_json::{json, Value};
+    use serde_json::{Value, json};
     use std::{env, path::PathBuf, time::Duration};
     use testcontainers::{
+        GenericImage, ImageExt,
         core::{IntoContainerPort, Mount},
         runners::AsyncRunner,
-        GenericImage, ImageExt,
     };
     use tokio::fs;
     use tokio::io::AsyncBufReadExt;
 
     use crate::{
-        evidence_provider::NativeEvidenceProvider, Error, KbsClientBuilder, KbsClientCapabilities,
+        Error, KbsClientBuilder, KbsClientCapabilities, evidence_provider::NativeEvidenceProvider,
     };
 
     use crate::client::rcar_client::{
-        build_request, get_hash_algorithm, get_request_extra_params, Result,
-        DEFAULT_HASH_ALGORITHM, KBS_PROTOCOL_VERSION, SELECTED_HASH_ALGORITHM_JSON_KEY,
-        SUPPORTED_HASH_ALGORITHMS_JSON_KEY,
+        DEFAULT_HASH_ALGORITHM, KBS_PROTOCOL_VERSION, Result, SELECTED_HASH_ALGORITHM_JSON_KEY,
+        SUPPORTED_HASH_ALGORITHMS_JSON_KEY, build_request, get_hash_algorithm,
+        get_request_extra_params,
     };
     use kbs_types::Tee;
 

--- a/attestation-agent/kbs_protocol/src/client/token_client.rs
+++ b/attestation-agent/kbs_protocol/src/client/token_client.rs
@@ -9,10 +9,10 @@ use resource_uri::ResourceUri;
 use tracing::{debug, warn};
 
 use crate::{
-    api::KbsClientCapabilities,
-    client::{KbsClient, KBS_GET_RESOURCE_MAX_ATTEMPT, KBS_PREFIX},
-    token_provider::TokenProvider,
     Error, Result,
+    api::KbsClientCapabilities,
+    client::{KBS_GET_RESOURCE_MAX_ATTEMPT, KBS_PREFIX, KbsClient},
+    token_provider::TokenProvider,
 };
 
 impl KbsClient<Box<dyn TokenProvider>> {
@@ -72,7 +72,9 @@ impl KbsClientCapabilities for KbsClient<Box<dyn TokenProvider>> {
                 reqwest::StatusCode::UNAUTHORIZED => {
                     warn!(
                         "Authenticating with KBS failed. Get a new token from the token provider: {:#?}",
-                        res.json::<ErrorInformation>().await.map_err(|e| Error::KbsResponseDeserializationFailed(e.to_string()))?
+                        res.json::<ErrorInformation>()
+                            .await
+                            .map_err(|e| Error::KbsResponseDeserializationFailed(e.to_string()))?
                     );
                     self.update_token().await?;
 

--- a/attestation-agent/kbs_protocol/src/evidence_provider/native.rs
+++ b/attestation-agent/kbs_protocol/src/evidence_provider/native.rs
@@ -6,7 +6,7 @@
 use std::collections::HashMap;
 
 use async_trait::async_trait;
-use attester::{detect_attestable_devices, detect_tee_type, BoxedAttester, TeeEvidence};
+use attester::{BoxedAttester, TeeEvidence, detect_attestable_devices, detect_tee_type};
 use kbs_types::Tee;
 
 use super::EvidenceProvider;

--- a/attestation-agent/kbs_protocol/src/keypair.rs
+++ b/attestation-agent/kbs_protocol/src/keypair.rs
@@ -3,11 +3,11 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-use anyhow::{anyhow, bail, Context, Result};
+use anyhow::{Context, Result, anyhow, bail};
 
 #[cfg(feature = "pqc-experimental")]
 use crate::akp::{AkpKeyPair, ML_KEM_768_A192KW_ALGORITHM};
-use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
+use base64::{Engine, engine::general_purpose::URL_SAFE_NO_PAD};
 use crypto::{
     ec::{EcKeyPair, KeyWrapAlgorithm, P256EcKeyPair, P521EcKeyPair},
     rsa::{PaddingMode, RSAKeyPair},
@@ -292,7 +292,7 @@ mod tests {
 #[cfg(all(test, feature = "pqc-experimental"))]
 mod pqc_tests {
     use super::*;
-    use crate::akp::{kmac256_kdf, ML_KEM_768_A192KW_ALGORITHM};
+    use crate::akp::{ML_KEM_768_A192KW_ALGORITHM, kmac256_kdf};
     use aes_kw::{KeyInit, KwAes192};
     use ml_kem::{Encapsulate, EncapsulationKey, Key, MlKem768};
 

--- a/attestation-agent/kbs_protocol/src/keypair.rs
+++ b/attestation-agent/kbs_protocol/src/keypair.rs
@@ -3,9 +3,9 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-use anyhow::{anyhow, bail, Context, Result};
+use anyhow::{Context, Result, anyhow, bail};
 
-use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
+use base64::{Engine, engine::general_purpose::URL_SAFE_NO_PAD};
 use crypto::{
     ec::{EcKeyPair, KeyWrapAlgorithm, P256EcKeyPair, P521EcKeyPair},
     rsa::{PaddingMode, RSAKeyPair},

--- a/attestation-agent/kbs_protocol/src/token_provider/mod.rs
+++ b/attestation-agent/kbs_protocol/src/token_provider/mod.rs
@@ -13,7 +13,7 @@ pub use aa::*;
 
 use anyhow::*;
 use async_trait::async_trait;
-use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
+use base64::{Engine, engine::general_purpose::URL_SAFE_NO_PAD};
 use jwt_simple::{
     claims::JWTClaims,
     prelude::{Clock, UnixTimeStamp},
@@ -54,16 +54,16 @@ impl Token {
 
     pub fn check_valid(&self) -> Result<()> {
         let now = Clock::now_since_epoch();
-        if let Some(exp) = self.exp {
-            if exp < now {
-                bail!("token expired");
-            }
+        if let Some(exp) = self.exp
+            && exp < now
+        {
+            bail!("token expired");
         }
 
-        if let Some(nbf) = self.nbf {
-            if nbf > now {
-                bail!("before validity");
-            }
+        if let Some(nbf) = self.nbf
+            && nbf > now
+        {
+            bail!("before validity");
         }
 
         Ok(())

--- a/confidential-data-hub/kms/Cargo.toml
+++ b/confidential-data-hub/kms/Cargo.toml
@@ -3,7 +3,7 @@ name = "kms"
 version = "0.1.0"
 authors = ["The Confidential Container Authors"]
 publish = false
-edition = "2021"
+edition = "2024"
 
 [dependencies]
 anyhow.workspace = true

--- a/confidential-data-hub/kms/src/plugins/aliyun/client/client_key_client/credential.rs
+++ b/confidential-data-hub/kms/src/plugins/aliyun/client/client_key_client/credential.rs
@@ -6,7 +6,7 @@
 //! Credentials to access aliyun KMS
 
 use anyhow::*;
-use base64::{engine::general_purpose::STANDARD, Engine};
+use base64::{Engine, engine::general_purpose::STANDARD};
 use openssl::hash::MessageDigest;
 use openssl::pkcs12::Pkcs12;
 use openssl::pkey::PKey;

--- a/confidential-data-hub/kms/src/plugins/aliyun/client/client_key_client/mod.rs
+++ b/confidential-data-hub/kms/src/plugins/aliyun/client/client_key_client/mod.rs
@@ -6,11 +6,11 @@
 use std::{collections::BTreeMap, env};
 
 use async_trait::async_trait;
-use base64::{engine::general_purpose::STANDARD, Engine};
+use base64::{Engine, engine::general_purpose::STANDARD};
 use chrono::Utc;
 use prost::Message;
 use protos::grpc::cdh::dkms_api;
-use reqwest::{header::HeaderMap, Certificate, ClientBuilder};
+use reqwest::{Certificate, ClientBuilder, header::HeaderMap};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use sha2::{Digest, Sha256};

--- a/confidential-data-hub/kms/src/plugins/aliyun/client/ecs_ram_role_client/mod.rs
+++ b/confidential-data-hub/kms/src/plugins/aliyun/client/ecs_ram_role_client/mod.rs
@@ -15,7 +15,7 @@ use crate::{Annotations, ProviderSettings};
 use crate::{Error, Result};
 
 use super::sts_token_client::credential::StsCredential;
-use super::{sts_token_client::StsTokenClient, ALIYUN_IN_GUEST_DEFAULT_KEY_PATH};
+use super::{ALIYUN_IN_GUEST_DEFAULT_KEY_PATH, sts_token_client::StsTokenClient};
 
 #[derive(Clone, Debug)]
 pub struct EcsRamRoleClient {

--- a/confidential-data-hub/kms/src/plugins/aliyun/client/mod.rs
+++ b/confidential-data-hub/kms/src/plugins/aliyun/client/mod.rs
@@ -74,7 +74,7 @@ impl AliyunKmsClient {
                 None => {
                     return Err(Error::AliyunKmsError(
                         "client type value is not str.".to_string(),
-                    ))
+                    ));
                 }
             }
         } else {
@@ -155,7 +155,7 @@ impl AliyunKmsClient {
 impl Encrypter for AliyunKmsClient {
     async fn encrypt(&mut self, data: &[u8], key_id: &str) -> Result<(Vec<u8>, Annotations)> {
         match &mut self {
-            AliyunKmsClient::ClientKey { ref mut inner } => inner.encrypt(data, key_id).await,
+            AliyunKmsClient::ClientKey { inner } => inner.encrypt(data, key_id).await,
             AliyunKmsClient::EcsRamRole { .. } => Err(Error::AliyunKmsError(
                 "Encrypter does not suppot accessing through Aliyun EcsRamRole".to_string(),
             )),
@@ -175,7 +175,7 @@ impl Decrypter for AliyunKmsClient {
         annotations: &Annotations,
     ) -> Result<Vec<u8>> {
         match &mut self {
-            AliyunKmsClient::ClientKey { ref mut inner } => {
+            AliyunKmsClient::ClientKey { inner } => {
                 inner.decrypt(ciphertext, key_id, annotations).await
             }
             AliyunKmsClient::EcsRamRole { .. } => Err(Error::AliyunKmsError(
@@ -192,11 +192,11 @@ impl Decrypter for AliyunKmsClient {
 impl Getter for AliyunKmsClient {
     async fn get_secret(&self, name: &str, annotations: &Annotations) -> Result<Vec<u8>> {
         match &self {
-            AliyunKmsClient::ClientKey { ref inner } => inner.get_secret(name, annotations).await,
+            AliyunKmsClient::ClientKey { inner } => inner.get_secret(name, annotations).await,
             AliyunKmsClient::EcsRamRole {
-                ref ecs_ram_role_client,
+                ecs_ram_role_client,
             } => ecs_ram_role_client.get_secret(name, annotations).await,
-            AliyunKmsClient::StsToken { ref client } => client.get_secret(name, annotations).await,
+            AliyunKmsClient::StsToken { client } => client.get_secret(name, annotations).await,
         }
     }
 }
@@ -204,10 +204,10 @@ impl Getter for AliyunKmsClient {
 #[cfg(test)]
 mod tests {
     use rstest::rstest;
-    use serde_json::{json, Map, Value};
+    use serde_json::{Map, Value, json};
 
     use crate::{
-        plugins::aliyun::client::AliyunKmsClient, Annotations, Decrypter, Encrypter, Getter,
+        Annotations, Decrypter, Encrypter, Getter, plugins::aliyun::client::AliyunKmsClient,
     };
 
     #[rstest]

--- a/confidential-data-hub/kms/src/plugins/aliyun/client/sts_token_client/credential.rs
+++ b/confidential-data-hub/kms/src/plugins/aliyun/client/sts_token_client/credential.rs
@@ -6,7 +6,7 @@
 //! Credentials to access aliyun KMS
 
 use anyhow::*;
-use base64::{engine::general_purpose::STANDARD, Engine};
+use base64::{Engine, engine::general_purpose::STANDARD};
 use openssl::hash::MessageDigest;
 use openssl::pkey::PKey;
 use openssl::sign::Signer;

--- a/confidential-data-hub/kms/src/plugins/aliyun/client/sts_token_client/mod.rs
+++ b/confidential-data-hub/kms/src/plugins/aliyun/client/sts_token_client/mod.rs
@@ -13,17 +13,17 @@ use std::{
 use anyhow::bail;
 use chrono::Utc;
 use credential::StsCredential;
-use rand::{distr::Alphanumeric, RngExt};
-use reqwest::{header::HeaderMap, ClientBuilder};
+use rand::{RngExt, distr::Alphanumeric};
+use reqwest::{ClientBuilder, header::HeaderMap};
 use serde::Deserialize;
 use serde_json::Value;
 use tokio::fs;
 use tracing::error;
 
 use crate::{
+    Annotations, ProviderSettings,
     error::{Error, Result},
     plugins::aliyun::annotations::AliSecretAnnotations,
-    Annotations, ProviderSettings,
 };
 
 #[derive(Debug, Clone)]

--- a/confidential-data-hub/kms/src/plugins/aws/annotations.rs
+++ b/confidential-data-hub/kms/src/plugins/aws/annotations.rs
@@ -47,7 +47,7 @@ pub struct AwsSecretAnnotations {
 #[cfg(test)]
 mod tests {
     use rstest::rstest;
-    use serde_json::{json, Value};
+    use serde_json::{Value, json};
 
     use super::{AwsCryptAnnotations, AwsProviderSettings, AwsSecretAnnotations};
 

--- a/confidential-data-hub/kms/src/plugins/aws/client.rs
+++ b/confidential-data-hub/kms/src/plugins/aws/client.rs
@@ -7,9 +7,9 @@ use std::env;
 
 use async_trait::async_trait;
 use aws_sdk_kms::{
+    Client as KmsClient,
     config::{BehaviorVersion, Credentials, Region},
     primitives::Blob,
-    Client as KmsClient,
 };
 use aws_sdk_secretsmanager::Client as SecretsManagerClient;
 use const_format::concatcp;

--- a/confidential-data-hub/kms/src/plugins/ehsm/client.rs
+++ b/confidential-data-hub/kms/src/plugins/ehsm/client.rs
@@ -8,8 +8,8 @@ use std::env;
 use ehsm_client::{api::KMS, client::EHSMClient};
 
 use async_trait::async_trait;
-use base64::engine::general_purpose::STANDARD;
 use base64::Engine;
+use base64::engine::general_purpose::STANDARD;
 use const_format::concatcp;
 use serde_json::Value;
 use tokio::fs;
@@ -157,7 +157,7 @@ mod tests {
     use rstest::rstest;
     use serde_json::json;
 
-    use crate::{plugins::ehsm::client::EhsmKmsClient, Decrypter, Encrypter};
+    use crate::{Decrypter, Encrypter, plugins::ehsm::client::EhsmKmsClient};
 
     #[ignore]
     #[tokio::test]

--- a/confidential-data-hub/kms/src/plugins/kbs/cc_kbc.rs
+++ b/confidential-data-hub/kms/src/plugins/kbs/cc_kbc.rs
@@ -7,9 +7,9 @@ use std::env;
 
 use async_trait::async_trait;
 use kbs_protocol::{
+    KbsClientCapabilities, ResourceUri,
     client::KbsClient as KbsProtocolClient,
     token_provider::{AATokenProvider, TokenProvider},
-    KbsClientCapabilities, ResourceUri,
 };
 use tracing::{info, warn};
 

--- a/confidential-data-hub/kms/src/plugins/kbs/mod.rs
+++ b/confidential-data-hub/kms/src/plugins/kbs/mod.rs
@@ -45,7 +45,11 @@ impl RealClient {
             #[cfg(feature = "sev")]
             "online_sev_kbc" => RealClient::Sev(sev::OnlineSevKbc::new(&params.uri).await?),
             "offline_fs_kbc" => RealClient::OfflineFs(offline_fs::OfflineFsKbc::new().await?),
-            others => return Err(Error::KbsClientError(format!("unknown kbc name {others}, only support `cc_kbc`(feature `kbs`), `online_sev_kbc` (feature `sev`) and `offline_fs_kbc`."))),
+            others => {
+                return Err(Error::KbsClientError(format!(
+                    "unknown kbc name {others}, only support `cc_kbc`(feature `kbs`), `online_sev_kbc` (feature `sev`) and `offline_fs_kbc`."
+                )));
+            }
         };
 
         Ok(c)

--- a/confidential-data-hub/kms/src/plugins/kbs/offline_fs.rs
+++ b/confidential-data-hub/kms/src/plugins/kbs/offline_fs.rs
@@ -7,7 +7,7 @@
 use std::collections::HashMap;
 
 use async_trait::async_trait;
-use base64::{engine::general_purpose::STANDARD, Engine};
+use base64::{Engine, engine::general_purpose::STANDARD};
 use resource_uri::ResourceUri;
 use tokio::fs;
 use tracing::warn;
@@ -70,7 +70,9 @@ impl OfflineFsKbc {
                 ))
             })?;
             if self.resources.insert(k.to_owned(), value).is_some() {
-                warn!("detected duplicated resource definition {k} in file {path} when initializing offline-fs-kbc");
+                warn!(
+                    "detected duplicated resource definition {k} in file {path} when initializing offline-fs-kbc"
+                );
             }
         }
         Ok(())
@@ -82,7 +84,7 @@ mod tests {
     use resource_uri::ResourceUri;
     use rstest::rstest;
 
-    use crate::plugins::kbs::{offline_fs::OfflineFsKbc, Kbc};
+    use crate::plugins::kbs::{Kbc, offline_fs::OfflineFsKbc};
 
     #[rstest]
     #[tokio::test]

--- a/confidential-data-hub/kms/src/plugins/kbs/offline_fs.rs
+++ b/confidential-data-hub/kms/src/plugins/kbs/offline_fs.rs
@@ -7,7 +7,7 @@
 use std::collections::HashMap;
 
 use async_trait::async_trait;
-use base64::{engine::general_purpose::STANDARD, Engine};
+use base64::{Engine, engine::general_purpose::STANDARD};
 use resource_uri::ResourceUri;
 use tokio::fs;
 use tracing::warn;
@@ -80,7 +80,9 @@ impl OfflineFsKbc {
                 ))
             })?;
             if self.resources.insert(k.to_owned(), value).is_some() {
-                warn!("detected duplicated resource definition {k} in file {path} when initializing offline-fs-kbc");
+                warn!(
+                    "detected duplicated resource definition {k} in file {path} when initializing offline-fs-kbc"
+                );
             }
         }
         Ok(())
@@ -92,7 +94,7 @@ mod tests {
     use resource_uri::ResourceUri;
     use rstest::rstest;
 
-    use crate::plugins::kbs::{offline_fs::OfflineFsKbc, Kbc};
+    use crate::plugins::kbs::{Kbc, offline_fs::OfflineFsKbc};
 
     #[rstest]
     #[tokio::test]

--- a/confidential-data-hub/kms/src/plugins/kbs/sev/client.rs
+++ b/confidential-data-hub/kms/src/plugins/kbs/sev/client.rs
@@ -8,11 +8,11 @@ use std::collections::HashMap;
 use std::sync::LazyLock;
 
 use async_trait::async_trait;
-use base64::{engine::general_purpose::STANDARD, Engine};
+use base64::{Engine, engine::general_purpose::STANDARD};
 use bincode::{config::legacy, decode_from_slice};
 use crypto::WrapType;
 use protos::grpc::aa::keybroker::{
-    key_broker_service_client::KeyBrokerServiceClient, OnlineSecretRequest, RequestDetails,
+    OnlineSecretRequest, RequestDetails, key_broker_service_client::KeyBrokerServiceClient,
 };
 use resource_uri::{ResourcePluginPath, ResourceUri};
 use serde::Deserialize;
@@ -21,7 +21,7 @@ use tonic::transport::Uri;
 use uuid::Uuid;
 use zeroize::Zeroizing;
 
-use crate::{plugins::kbs::Kbc, Error, Result};
+use crate::{Error, Result, plugins::kbs::Kbc};
 
 const KEYS_PATH: &str = "/sys/kernel/security/secrets/coco/1ee27366-0c87-43a6-af48-28543eaf7cb0";
 

--- a/image-rs/libs/test-utils/Cargo.toml
+++ b/image-rs/libs/test-utils/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "test-utils"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 license = "Apache-2.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/protos/Cargo.toml
+++ b/protos/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "protos"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 license = "Apache-2.0"
 
 [dependencies]


### PR DESCRIPTION
Bump `edition` from 2021 to 2024 for all 15 workspace members and adapt the code to the changes that the new edition mandates:

- `std::env::set_var`/`remove_var` are now `unsafe`, so the affected call sites (all in CDH config handling and tests) are wrapped in `unsafe` blocks. These run before any additional threads are spawned, which is the safety condition the new signature makes explicit.
- Nested `if`/`if let` chains are collapsed into let chains, which are stabilized in this edition.
- The whole workspace is reformatted with the edition's rustfmt style, which mainly reorders `use` groups so that types sort before functions. This is required to keep `cargo fmt --check` in CI green.

No functional change intended; the migration is purely mechanical.

Fixes: #1599

In later PR, I will figure out ways to avoid unsafe blocks.