### PR TITLE
attester: implement get_runtime_measurement for az-snp-vtpm

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -398,6 +398,7 @@ dependencies = [
  "az-snp-vtpm",
  "az-tdx-vtpm",
  "azure-guest-attestation-sdk",
+ "azure-tpm",
  "base64 0.22.1",
  "cfg-if",
  "clap",
@@ -868,14 +869,15 @@ dependencies = [
 [[package]]
 name = "azure-guest-attestation-sdk"
 version = "0.1.0"
-source = "git+https://github.com/Azure/azure-guest-attestation-sdk?rev=e606728446cb66d681913983cbe5563c919dd94b#e606728446cb66d681913983cbe5563c919dd94b"
+source = "git+https://github.com/Azure/azure-guest-attestation-sdk?rev=9c8344cbeeb2c7ab46c1311e983f254a69ab5eec#9c8344cbeeb2c7ab46c1311e983f254a69ab5eec"
 dependencies = [
  "aes-gcm 0.10.3",
+ "azure-tpm",
  "base64 0.22.1",
  "bitfield-struct",
  "digest 0.10.7",
  "hex",
- "rand 0.8.6",
+ "rand 0.9.4",
  "reqwest 0.12.28",
  "serde",
  "serde_json",
@@ -883,7 +885,24 @@ dependencies = [
  "sha2 0.10.9",
  "tracing",
  "tracing-subscriber",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "azure-tpm"
+version = "0.1.0"
+source = "git+https://github.com/Azure/azure-guest-attestation-sdk?rev=9c8344cbeeb2c7ab46c1311e983f254a69ab5eec#9c8344cbeeb2c7ab46c1311e983f254a69ab5eec"
+dependencies = [
+ "bitfield-struct",
+ "digest 0.10.7",
+ "hex",
+ "rand 0.9.4",
+ "serde",
+ "serde_json",
+ "sha1",
+ "sha2 0.10.9",
+ "tracing",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/attestation-agent/attester/Cargo.toml
+++ b/attestation-agent/attester/Cargo.toml
@@ -15,7 +15,8 @@ az-snp-vtpm = { version = "0.8.1", default-features = false, features = [
 az-tdx-vtpm = { version = "0.8.1", default-features = false, features = [
     "attester",
 ], optional = true }
-azure-guest-attestation-sdk = { git = "https://github.com/Azure/azure-guest-attestation-sdk", rev = "e606728446cb66d681913983cbe5563c919dd94b", optional = true }
+azure-guest-attestation-sdk = { git = "https://github.com/Azure/azure-guest-attestation-sdk", rev = "9c8344cbeeb2c7ab46c1311e983f254a69ab5eec", optional = true }
+azure-tpm = { git = "https://github.com/Azure/azure-guest-attestation-sdk", rev = "9c8344cbeeb2c7ab46c1311e983f254a69ab5eec", optional = true }
 base64.workspace = true
 clap = { workspace = true, features = ["derive"], optional = true }
 cfg-if.workspace = true
@@ -86,7 +87,7 @@ tdx-attester = ["scroll", "tsm-report", "iocuddle"]
 tdx-attest-dcap-ioctls = ["tdx-attest-rs"]
 sgx-attester = ["occlum_dcap"]
 nvidia-attester = ["nv-attestation-sdk"]
-az-snp-vtpm-attester = ["az-snp-vtpm", "pem-rfc7468"]
+az-snp-vtpm-attester = ["az-snp-vtpm", "pem-rfc7468", "azure-tpm"]
 az-tdx-vtpm-attester = [
     "az-snp-vtpm-attester",
     "az-tdx-vtpm",

--- a/attestation-agent/attester/src/az_snp_vtpm/mod.rs
+++ b/attestation-agent/attester/src/az_snp_vtpm/mod.rs
@@ -6,6 +6,7 @@
 use super::{Attester, InitDataResult, TeeEvidence};
 use anyhow::{bail, Context, Result};
 use az_snp_vtpm::{imds, is_snp_cvm, vtpm};
+use azure_tpm::{Tpm, TpmCommandExt};
 use kbs_types::HashAlgorithm;
 use serde::{Deserialize, Serialize};
 use serde_with::{base64::Base64, hex::Hex, serde_as};
@@ -141,8 +142,11 @@ impl Attester for AzSnpVtpmAttester {
         HashAlgorithm::Sha256
     }
 
-    // TODO: add get_runtime_measurement function
-    // See https://github.com/confidential-containers/guest-components/issues/1201
+    /// Read the current value of a runtime measurement register (PCR).
+    /// This is the read counterpart of [`extend_runtime_measurement`]
+    async fn get_runtime_measurement(&self, pcr_index: u64) -> Result<Vec<u8>> {
+        spawn_blocking(move || utils::read_pcr_sync(pcr_index)).await?
+    }
 }
 
 pub(crate) mod utils {
@@ -159,6 +163,22 @@ pub(crate) mod utils {
         vtpm::extend_pcr(pcr, &sha256_digest)?;
 
         Ok(())
+    }
+
+    /// Read the current SHA-256 value of PCR `pcr_index`.
+    /// This is the read counterpart of [`extend_pcr_sync`].
+    pub fn read_pcr_sync(pcr_index: u64) -> Result<Vec<u8>> {
+        if pcr_index > 23 {
+            bail!("Invalid PCR index: {pcr_index}");
+        }
+        let tpm = Tpm::open().context("open TPM device")?;
+        let (_, digest) = tpm
+            .read_pcrs_sha256(&[pcr_index as u32])
+            .with_context(|| format!("read SHA-256 PCR {pcr_index} from TPM"))?
+            .into_iter()
+            .next()
+            .context("TPM returned no value for the requested PCR")?;
+        Ok(digest)
     }
 }
 


### PR DESCRIPTION
The `az-snp-vtpm` attester implemented `extend_runtime_measurement`, `pcr_to_ccmr`,
and `ccel_hash_algorithm`, but not the read counterpart `get_runtime_measurement`
(left as a TODO pointing at this issue). The AAEL record path calls it on every
event write and during crash recovery, so it failed unconditionally on this
platform. This adds it, reading the current SHA-256 PCR bank via `vtpm::get_quote`.

## Testing
- cargo build / test / clippy -D warnings / fmt --check  (attester, az-snp-vtpm-attester feature)

Fixes #1201