### PR TITLE
aa: let the KBC select attestation policies by id

### DIFF
--- a/attestation-agent/attestation-agent/config.example.toml
+++ b/attestation-agent/attestation-agent/config.example.toml
@@ -6,6 +6,10 @@ url = "http://127.0.0.1:8000"
 [token_configs.kbs]
 url = "https://127.0.0.1:8080"
 tee_key_algorithm = "ECDH-ES+A256KW-P256"
+# The hint that KBS resolves to the attestation policies that evaluate this guest's
+# evidence. Empty by default, which leaves the selection to KBS. The accepted
+# values are specific to a KBS deployment and an unknown id is rejected.
+# attestation_policy_selector = "alice"
 cert = '''
 -----BEGIN CERTIFICATE-----
 MIIDljCCAn6gAwIBAgIUR/UNh13GFam4emgludtype/S9BIwDQYJKoZIhvcNAQEL

--- a/attestation-agent/attestation-agent/config.example.toml
+++ b/attestation-agent/attestation-agent/config.example.toml
@@ -6,6 +6,10 @@ url = "http://127.0.0.1:8000"
 [token_configs.kbs]
 url = "https://127.0.0.1:8080"
 tee_key_algorithm = "ECDH-ES+A256KW-P256"
+# The hint that KBS resolves to the attestation policies that evaluate this guest's
+# evidence. Empty by default, which leaves the selection to KBS. The accepted
+# values are specific to a KBS deployment and an unknown id is rejected.
+# policy_selector = "alice"
 cert = '''
 -----BEGIN CERTIFICATE-----
 MIIDljCCAn6gAwIBAgIUR/UNh13GFam4emgludtype/S9BIwDQYJKoZIhvcNAQEL

--- a/attestation-agent/attestation-agent/src/config/kbs.rs
+++ b/attestation-agent/attestation-agent/src/config/kbs.rs
@@ -20,6 +20,15 @@ pub struct KbsConfig {
 
     #[serde(default)]
     pub tee_key_algorithm: TeeKeyAlgorithm,
+
+    /// The hint that KBS resolves to the attestation policies that evaluate this
+    /// guest's evidence. The accepted values are specific to a KBS
+    /// deployment, so this has to be agreed with the KBS administrator.
+    ///
+    /// Empty by default, which leaves the policy selection to KBS. An empty
+    /// policy_selector is not sent, because KBS rejects a policy_selector it does not know.
+    #[serde(default)]
+    pub policy_selector: String,
 }
 
 impl KbsConfig {
@@ -35,6 +44,7 @@ impl KbsConfig {
             url: aa_kbc_params.uri,
             cert: None,
             tee_key_algorithm: TeeKeyAlgorithm::default(),
+            policy_selector: String::new(),
         })
     }
 }

--- a/attestation-agent/attestation-agent/src/config/kbs.rs
+++ b/attestation-agent/attestation-agent/src/config/kbs.rs
@@ -20,6 +20,15 @@ pub struct KbsConfig {
 
     #[serde(default)]
     pub tee_key_algorithm: TeeKeyAlgorithm,
+
+    /// The hint that KBS resolves to the attestation policies that evaluate this
+    /// guest's evidence. The accepted values are specific to a KBS
+    /// deployment, so this has to be agreed with the KBS administrator.
+    ///
+    /// Empty by default, which leaves the policy selection to KBS. An empty
+    /// attestation_policy_selector is not sent, because KBS rejects an attestation_policy_selector it does not know.
+    #[serde(default)]
+    pub attestation_policy_selector: String,
 }
 
 impl KbsConfig {
@@ -35,6 +44,7 @@ impl KbsConfig {
             url: aa_kbc_params.uri,
             cert: None,
             tee_key_algorithm: TeeKeyAlgorithm::default(),
+            attestation_policy_selector: String::new(),
         })
     }
 }

--- a/attestation-agent/attestation-agent/src/config/mod.rs
+++ b/attestation-agent/attestation-agent/src/config/mod.rs
@@ -182,6 +182,7 @@ M9QaC1mzQ/OStg==
 -----END CERTIFICATE-----
 ".to_string()),
                 tee_key_algorithm: kbs_protocol::TeeKeyAlgorithm::EcdhEsA256KwP256,
+                attestation_policy_selector: String::new(),
             })
         },
         eventlog_config: EventlogConfig {
@@ -224,6 +225,7 @@ M9QaC1mzQ/OStg==
 -----END CERTIFICATE-----
 ".to_string()),
                 tee_key_algorithm: kbs_protocol::TeeKeyAlgorithm::EcdhEsA256KwP256,
+                attestation_policy_selector: String::new(),
             })
         },
         eventlog_config: EventlogConfig {
@@ -245,6 +247,7 @@ M9QaC1mzQ/OStg==
                 url: "https://127.0.0.1:8080".to_string(),
                 cert: Some("cert".to_string()),
                 tee_key_algorithm: kbs_protocol::TeeKeyAlgorithm::EcdhEsA256KwP256,
+                attestation_policy_selector: String::new(),
             })
         },
         eventlog_config: EventlogConfig {
@@ -264,6 +267,27 @@ M9QaC1mzQ/OStg==
                 url: "https://127.0.0.1:8080".to_string(),
                 cert: Some("cert".to_string()),
                 tee_key_algorithm: kbs_protocol::TeeKeyAlgorithm::EcdhEsA256KwP256,
+                attestation_policy_selector: String::new(),
+            })
+        },
+        eventlog_config: EventlogConfig {
+            init_pcr: 17,
+            enable_eventlog: false,
+        },
+        log: LogConfig { level: "warn".to_string() },
+    })]
+    #[case(
+    "test/config7.toml",
+    Config {
+        token_configs: TokenConfigs {
+            #[cfg(feature = "coco_as")]
+            coco_as: None,
+            #[cfg(feature = "kbs")]
+            kbs: Some(crate::config::kbs::KbsConfig {
+                url: "https://127.0.0.1:8080".to_string(),
+                cert: Some("cert".to_string()),
+                tee_key_algorithm: kbs_protocol::TeeKeyAlgorithm::EcdhEsA256KwP256,
+                attestation_policy_selector: "alice".to_string(),
             })
         },
         eventlog_config: EventlogConfig {

--- a/attestation-agent/attestation-agent/src/config/mod.rs
+++ b/attestation-agent/attestation-agent/src/config/mod.rs
@@ -182,6 +182,7 @@ M9QaC1mzQ/OStg==
 -----END CERTIFICATE-----
 ".to_string()),
                 tee_key_algorithm: kbs_protocol::TeeKeyAlgorithm::EcdhEsA256KwP256,
+                policy_selector: String::new(),
             })
         },
         eventlog_config: EventlogConfig {
@@ -224,6 +225,7 @@ M9QaC1mzQ/OStg==
 -----END CERTIFICATE-----
 ".to_string()),
                 tee_key_algorithm: kbs_protocol::TeeKeyAlgorithm::EcdhEsA256KwP256,
+                policy_selector: String::new(),
             })
         },
         eventlog_config: EventlogConfig {
@@ -245,6 +247,7 @@ M9QaC1mzQ/OStg==
                 url: "https://127.0.0.1:8080".to_string(),
                 cert: Some("cert".to_string()),
                 tee_key_algorithm: kbs_protocol::TeeKeyAlgorithm::EcdhEsA256KwP256,
+                policy_selector: String::new(),
             })
         },
         eventlog_config: EventlogConfig {
@@ -264,6 +267,27 @@ M9QaC1mzQ/OStg==
                 url: "https://127.0.0.1:8080".to_string(),
                 cert: Some("cert".to_string()),
                 tee_key_algorithm: kbs_protocol::TeeKeyAlgorithm::EcdhEsA256KwP256,
+                policy_selector: String::new(),
+            })
+        },
+        eventlog_config: EventlogConfig {
+            init_pcr: 17,
+            enable_eventlog: false,
+        },
+        log: LogConfig { level: "warn".to_string() },
+    })]
+    #[case(
+    "test/config7.toml",
+    Config {
+        token_configs: TokenConfigs {
+            #[cfg(feature = "coco_as")]
+            coco_as: None,
+            #[cfg(feature = "kbs")]
+            kbs: Some(crate::config::kbs::KbsConfig {
+                url: "https://127.0.0.1:8080".to_string(),
+                cert: Some("cert".to_string()),
+                tee_key_algorithm: kbs_protocol::TeeKeyAlgorithm::EcdhEsA256KwP256,
+                policy_selector: "alice".to_string(),
             })
         },
         eventlog_config: EventlogConfig {

--- a/attestation-agent/attestation-agent/src/token/kbs.rs
+++ b/attestation-agent/attestation-agent/src/token/kbs.rs
@@ -20,6 +20,7 @@ pub struct KbsTokenGetter {
     kbs_host_url: String,
     cert: Option<String>,
     tee_key_algorithm: TeeKeyAlgorithm,
+    policy_selector: String,
 }
 
 impl KbsTokenGetter {
@@ -33,6 +34,10 @@ impl KbsTokenGetter {
             builder = builder.add_kbs_cert(cert);
         }
         builder = builder.set_tee_key_algorithm(self.tee_key_algorithm);
+
+        if !self.policy_selector.is_empty() {
+            builder = builder.set_policy_selector(&self.policy_selector);
+        }
 
         if let Some(initdata) = initdata {
             builder = builder.add_initdata(initdata.to_string());
@@ -57,6 +62,7 @@ impl KbsTokenGetter {
             kbs_host_url: config.url.clone(),
             cert: config.cert.clone(),
             tee_key_algorithm: config.tee_key_algorithm,
+            policy_selector: config.policy_selector.clone(),
         }
     }
 }

--- a/attestation-agent/attestation-agent/src/token/kbs.rs
+++ b/attestation-agent/attestation-agent/src/token/kbs.rs
@@ -20,6 +20,7 @@ pub struct KbsTokenGetter {
     kbs_host_url: String,
     cert: Option<String>,
     tee_key_algorithm: TeeKeyAlgorithm,
+    attestation_policy_selector: String,
 }
 
 impl KbsTokenGetter {
@@ -33,6 +34,10 @@ impl KbsTokenGetter {
             builder = builder.add_kbs_cert(cert);
         }
         builder = builder.set_tee_key_algorithm(self.tee_key_algorithm);
+
+        if !self.attestation_policy_selector.is_empty() {
+            builder = builder.set_attestation_policy_selector(&self.attestation_policy_selector);
+        }
 
         if let Some(initdata) = initdata {
             builder = builder.add_initdata(initdata.to_string());
@@ -57,6 +62,7 @@ impl KbsTokenGetter {
             kbs_host_url: config.url.clone(),
             cert: config.cert.clone(),
             tee_key_algorithm: config.tee_key_algorithm,
+            attestation_policy_selector: config.attestation_policy_selector.clone(),
         }
     }
 }

--- a/attestation-agent/attestation-agent/test/config7.toml
+++ b/attestation-agent/attestation-agent/test/config7.toml
@@ -1,0 +1,12 @@
+[log]
+level = "warn"
+
+[token_configs]
+[token_configs.kbs]
+url = "https://127.0.0.1:8080"
+cert = "cert"
+policy_selector = "alice"
+
+[eventlog_config]
+init_pcr = 17
+enable_eventlog = false

--- a/attestation-agent/attestation-agent/test/config7.toml
+++ b/attestation-agent/attestation-agent/test/config7.toml
@@ -1,0 +1,12 @@
+[log]
+level = "warn"
+
+[token_configs]
+[token_configs.kbs]
+url = "https://127.0.0.1:8080"
+cert = "cert"
+attestation_policy_selector = "alice"
+
+[eventlog_config]
+init_pcr = 17
+enable_eventlog = false

--- a/attestation-agent/kbs_protocol/src/builder.rs
+++ b/attestation-agent/kbs_protocol/src/builder.rs
@@ -27,6 +27,7 @@ pub struct KbsClientBuilder<T> {
     tee_key: Option<String>,
     tee_key_algorithm: TeeKeyAlgorithm,
     initdata: Option<String>,
+    attestation_policy_selector: Option<String>,
 }
 
 impl KbsClientBuilder<Box<dyn EvidenceProvider>> {
@@ -42,6 +43,7 @@ impl KbsClientBuilder<Box<dyn EvidenceProvider>> {
             tee_key: None,
             tee_key_algorithm: TeeKeyAlgorithm::default(),
             initdata: None,
+            attestation_policy_selector: None,
         }
     }
 }
@@ -56,6 +58,7 @@ impl KbsClientBuilder<Box<dyn TokenProvider>> {
             tee_key: None,
             tee_key_algorithm: TeeKeyAlgorithm::default(),
             initdata: None,
+            attestation_policy_selector: None,
         }
     }
 }
@@ -83,6 +86,19 @@ impl<T> KbsClientBuilder<T> {
 
     pub fn add_initdata(mut self, initdata: String) -> Self {
         self.initdata = Some(initdata);
+        self
+    }
+
+    /// Set the attestation policy selector which KBS resolves to the attestation
+    /// policies that evaluate this client's evidence.
+    ///
+    /// The accepted values are specific to a KBS deployment, so an attestation
+    /// policy selector has to be known in advance. KBS rejects the RCAR handshake
+    /// of a client that sends an attestation policy selector it does not know,
+    /// while a client that sends no attestation policy selector at all is
+    /// evaluated against the default policy.
+    pub fn set_attestation_policy_selector(mut self, attestation_policy_selector: &str) -> Self {
+        self.attestation_policy_selector = Some(attestation_policy_selector.to_string());
         self
     }
 
@@ -126,6 +142,7 @@ impl<T> KbsClientBuilder<T> {
                 .context("Build KBS http client")?,
             kbs_host_url: self.kbs_host_url,
             _initdata: self.initdata,
+            _attestation_policy_selector: self.attestation_policy_selector,
         };
 
         Ok(client)
@@ -162,5 +179,29 @@ x13TMfDeczAFBgMrZXADQQBpP6ABBkzVj3mF55nWUtP5vxwq3t91wqQJ6NyC7WsT
         .add_kbs_cert(cert)
         .build()
         .expect("build client failed");
+    }
+
+    #[rstest]
+    #[case(None)]
+    #[case(Some("alice"))]
+    #[tokio::test]
+    async fn test_build_client_with_attestation_policy_selector(
+        #[case] attestation_policy_selector: Option<&str>,
+    ) {
+        let mut builder = KbsClientBuilder::with_evidence_provider(
+            Box::<MockedEvidenceProvider>::default(),
+            "test.io",
+        );
+
+        if let Some(attestation_policy_selector) = attestation_policy_selector {
+            builder = builder.set_attestation_policy_selector(attestation_policy_selector);
+        }
+
+        let client = builder.build().expect("build client failed");
+
+        assert_eq!(
+            client._attestation_policy_selector.as_deref(),
+            attestation_policy_selector
+        );
     }
 }

--- a/attestation-agent/kbs_protocol/src/builder.rs
+++ b/attestation-agent/kbs_protocol/src/builder.rs
@@ -27,6 +27,7 @@ pub struct KbsClientBuilder<T> {
     tee_key: Option<String>,
     tee_key_algorithm: TeeKeyAlgorithm,
     initdata: Option<String>,
+    policy_selector: Option<String>,
 }
 
 impl KbsClientBuilder<Box<dyn EvidenceProvider>> {
@@ -42,6 +43,7 @@ impl KbsClientBuilder<Box<dyn EvidenceProvider>> {
             tee_key: None,
             tee_key_algorithm: TeeKeyAlgorithm::default(),
             initdata: None,
+            policy_selector: None,
         }
     }
 }
@@ -56,6 +58,7 @@ impl KbsClientBuilder<Box<dyn TokenProvider>> {
             tee_key: None,
             tee_key_algorithm: TeeKeyAlgorithm::default(),
             initdata: None,
+            policy_selector: None,
         }
     }
 }
@@ -83,6 +86,18 @@ impl<T> KbsClientBuilder<T> {
 
     pub fn add_initdata(mut self, initdata: String) -> Self {
         self.initdata = Some(initdata);
+        self
+    }
+
+    /// Set the policy selector which KBS resolves to the attestation policies that
+    /// evaluate this client's evidence.
+    ///
+    /// The accepted values are specific to a KBS deployment, so a policy selector has to
+    /// be known in advance. KBS rejects the RCAR handshake of a client that
+    /// sends a policy selector it does not know, while a client that sends no policy selector at all
+    /// is evaluated against the default policy.
+    pub fn set_policy_selector(mut self, policy_selector: &str) -> Self {
+        self.policy_selector = Some(policy_selector.to_string());
         self
     }
 
@@ -126,6 +141,7 @@ impl<T> KbsClientBuilder<T> {
                 .context("Build KBS http client")?,
             kbs_host_url: self.kbs_host_url,
             _initdata: self.initdata,
+            _policy_selector: self.policy_selector,
         };
 
         Ok(client)
@@ -162,5 +178,24 @@ x13TMfDeczAFBgMrZXADQQBpP6ABBkzVj3mF55nWUtP5vxwq3t91wqQJ6NyC7WsT
         .add_kbs_cert(cert)
         .build()
         .expect("build client failed");
+    }
+
+    #[rstest]
+    #[case(None)]
+    #[case(Some("alice"))]
+    #[tokio::test]
+    async fn test_build_client_with_policy_selector(#[case] policy_selector: Option<&str>) {
+        let mut builder = KbsClientBuilder::with_evidence_provider(
+            Box::<MockedEvidenceProvider>::default(),
+            "test.io",
+        );
+
+        if let Some(policy_selector) = policy_selector {
+            builder = builder.set_policy_selector(policy_selector);
+        }
+
+        let client = builder.build().expect("build client failed");
+
+        assert_eq!(client._policy_selector.as_deref(), policy_selector);
     }
 }

--- a/attestation-agent/kbs_protocol/src/client/mod.rs
+++ b/attestation-agent/kbs_protocol/src/client/mod.rs
@@ -49,6 +49,10 @@ pub struct KbsClient<T> {
 
     /// initdata toml plaintext (if any)
     pub(crate) _initdata: Option<String>,
+
+    /// id selecting the attestation policies that evaluate this client's
+    /// evidence (if any)
+    pub(crate) _attestation_policy_selector: Option<String>,
 }
 
 pub const KBS_PROTOCOL_VERSION: &str = "0.4.0";

--- a/attestation-agent/kbs_protocol/src/client/mod.rs
+++ b/attestation-agent/kbs_protocol/src/client/mod.rs
@@ -49,6 +49,10 @@ pub struct KbsClient<T> {
 
     /// initdata toml plaintext (if any)
     pub(crate) _initdata: Option<String>,
+
+    /// id selecting the attestation policies that evaluate this client's
+    /// evidence (if any)
+    pub(crate) _policy_selector: Option<String>,
 }
 
 pub const KBS_PROTOCOL_VERSION: &str = "0.4.0";

--- a/attestation-agent/kbs_protocol/src/client/rcar_client.rs
+++ b/attestation-agent/kbs_protocol/src/client/rcar_client.rs
@@ -38,6 +38,10 @@ const RCAR_RETRY_TIMEOUT_SECOND: u64 = 1;
 /// JSON object added to a 'Request's extra parameters.
 const SUPPORTED_HASH_ALGORITHMS_JSON_KEY: &str = "supported-hash-algorithms";
 
+/// JSON key in a 'Request's extra parameters with which the client selects
+/// the attestation policies that evaluate its evidence.
+const POLICY_SELECTOR_JSON_KEY: &str = "policy-selector";
+
 /// JSON object returned in the Challenge whose value is based on
 /// SUPPORTED_HASH_ALGORITHMS_JSON_KEY and the TEE.
 const SELECTED_HASH_ALGORITHM_JSON_KEY: &str = "selected-hash-algorithm";
@@ -54,10 +58,14 @@ struct AttestationResponseData {
     token: String,
 }
 
-async fn get_request_extra_params() -> serde_json::Value {
+async fn get_request_extra_params(policy_selector: Option<&str>) -> serde_json::Value {
     let supported_hash_algorithms = HashAlgorithm::list_all();
 
-    let extra_params = json!({SUPPORTED_HASH_ALGORITHMS_JSON_KEY: supported_hash_algorithms});
+    let mut extra_params = json!({SUPPORTED_HASH_ALGORITHMS_JSON_KEY: supported_hash_algorithms});
+
+    if let Some(policy_selector) = policy_selector {
+        extra_params[POLICY_SELECTOR_JSON_KEY] = json!(policy_selector);
+    }
 
     extra_params
 }
@@ -86,8 +94,8 @@ fn serialize_json_canonically<T: Serialize>(value: T) -> anyhow::Result<Vec<u8>>
     Ok(serde_json_canonicalizer::to_vec(&value)?)
 }
 
-async fn build_request(tee: Tee) -> Request {
-    let extra_params = get_request_extra_params().await;
+async fn build_request(tee: Tee, policy_selector: Option<&str>) -> Request {
+    let extra_params = get_request_extra_params(policy_selector).await;
 
     // Note that the Request includes the list of supported hash algorithms.
     // The Challenge response will return which TEE-specific algorithm should
@@ -230,7 +238,7 @@ impl KbsClient<Box<dyn EvidenceProvider>> {
             ClientTee::_Initialized(tee) => *tee,
         };
 
-        let request = build_request(tee).await;
+        let request = build_request(tee, self._policy_selector.as_deref()).await;
 
         debug!("send auth request {request:?} to {auth_endpoint}");
 
@@ -417,8 +425,8 @@ mod test {
 
     use crate::client::rcar_client::{
         build_request, get_hash_algorithm, get_request_extra_params, Result,
-        DEFAULT_HASH_ALGORITHM, KBS_PROTOCOL_VERSION, SELECTED_HASH_ALGORITHM_JSON_KEY,
-        SUPPORTED_HASH_ALGORITHMS_JSON_KEY,
+        DEFAULT_HASH_ALGORITHM, KBS_PROTOCOL_VERSION, POLICY_SELECTOR_JSON_KEY,
+        SELECTED_HASH_ALGORITHM_JSON_KEY, SUPPORTED_HASH_ALGORITHMS_JSON_KEY,
     };
     use kbs_types::Tee;
 
@@ -540,12 +548,23 @@ mod test {
         println!("Get key: {key:?}");
     }
 
+    #[rstest]
+    #[case(None)]
+    #[case(Some("alice"))]
     #[tokio::test]
     #[serial_test::serial]
-    async fn test_get_request_extra_params() {
-        let extra_params = get_request_extra_params().await;
+    async fn test_get_request_extra_params(#[case] policy_selector: Option<&str>) {
+        let extra_params = get_request_extra_params(policy_selector).await;
 
         assert!(extra_params.is_object());
+
+        assert_eq!(
+            extra_params
+                .get(POLICY_SELECTOR_JSON_KEY)
+                .and_then(Value::as_str),
+            policy_selector,
+            "the id is only sent when it is set"
+        );
 
         let algos_json = extra_params
             .get(SUPPORTED_HASH_ALGORITHMS_JSON_KEY)
@@ -565,9 +584,12 @@ mod test {
         }
     }
 
+    #[rstest]
+    #[case(None)]
+    #[case(Some("alice"))]
     #[tokio::test]
     #[serial_test::serial]
-    async fn test_build_request() {
+    async fn test_build_request(#[case] policy_selector: Option<&str>) {
         let tees = vec![
             Tee::AzSnpVtpm,
             Tee::AzTdxVtpm,
@@ -580,14 +602,21 @@ mod test {
         ];
 
         let expected_version = String::from(KBS_PROTOCOL_VERSION);
-        let expected_extra_params = get_request_extra_params().await;
+        let expected_extra_params = get_request_extra_params(policy_selector).await;
 
         for tee in tees {
-            let request = build_request(tee).await;
+            let request = build_request(tee, policy_selector).await;
 
             assert_eq!(request.version, expected_version);
             assert_eq!(request.tee, tee);
             assert_eq!(request.extra_params, expected_extra_params);
+            assert_eq!(
+                request
+                    .extra_params
+                    .get(POLICY_SELECTOR_JSON_KEY)
+                    .and_then(Value::as_str),
+                policy_selector
+            );
         }
     }
 

--- a/attestation-agent/kbs_protocol/src/client/rcar_client.rs
+++ b/attestation-agent/kbs_protocol/src/client/rcar_client.rs
@@ -38,6 +38,10 @@ const RCAR_RETRY_TIMEOUT_SECOND: u64 = 1;
 /// JSON object added to a 'Request's extra parameters.
 const SUPPORTED_HASH_ALGORITHMS_JSON_KEY: &str = "supported-hash-algorithms";
 
+/// JSON key in a 'Request's extra parameters with which the client selects
+/// the attestation policies that evaluate its evidence.
+const ATTESTATION_POLICY_SELECTOR_JSON_KEY: &str = "attestation-policy-selector";
+
 /// JSON object returned in the Challenge whose value is based on
 /// SUPPORTED_HASH_ALGORITHMS_JSON_KEY and the TEE.
 const SELECTED_HASH_ALGORITHM_JSON_KEY: &str = "selected-hash-algorithm";
@@ -54,10 +58,14 @@ struct AttestationResponseData {
     token: String,
 }
 
-async fn get_request_extra_params() -> serde_json::Value {
+async fn get_request_extra_params(attestation_policy_selector: Option<&str>) -> serde_json::Value {
     let supported_hash_algorithms = HashAlgorithm::list_all();
 
-    let extra_params = json!({SUPPORTED_HASH_ALGORITHMS_JSON_KEY: supported_hash_algorithms});
+    let mut extra_params = json!({SUPPORTED_HASH_ALGORITHMS_JSON_KEY: supported_hash_algorithms});
+
+    if let Some(attestation_policy_selector) = attestation_policy_selector {
+        extra_params[ATTESTATION_POLICY_SELECTOR_JSON_KEY] = json!(attestation_policy_selector);
+    }
 
     extra_params
 }
@@ -86,8 +94,8 @@ fn serialize_json_canonically<T: Serialize>(value: T) -> anyhow::Result<Vec<u8>>
     Ok(serde_json_canonicalizer::to_vec(&value)?)
 }
 
-async fn build_request(tee: Tee) -> Request {
-    let extra_params = get_request_extra_params().await;
+async fn build_request(tee: Tee, attestation_policy_selector: Option<&str>) -> Request {
+    let extra_params = get_request_extra_params(attestation_policy_selector).await;
 
     // Note that the Request includes the list of supported hash algorithms.
     // The Challenge response will return which TEE-specific algorithm should
@@ -232,7 +240,7 @@ impl KbsClient<Box<dyn EvidenceProvider>> {
             ClientTee::_Initialized(tee) => *tee,
         };
 
-        let request = build_request(tee).await;
+        let request = build_request(tee, self._attestation_policy_selector.as_deref()).await;
 
         debug!("send auth request {request:?} to {auth_endpoint}");
 
@@ -418,9 +426,9 @@ mod test {
     };
 
     use crate::client::rcar_client::{
-        DEFAULT_HASH_ALGORITHM, KBS_PROTOCOL_VERSION, Result, SELECTED_HASH_ALGORITHM_JSON_KEY,
-        SUPPORTED_HASH_ALGORITHMS_JSON_KEY, build_request, get_hash_algorithm,
-        get_request_extra_params,
+        ATTESTATION_POLICY_SELECTOR_JSON_KEY, DEFAULT_HASH_ALGORITHM, KBS_PROTOCOL_VERSION, Result,
+        SELECTED_HASH_ALGORITHM_JSON_KEY, SUPPORTED_HASH_ALGORITHMS_JSON_KEY, build_request,
+        get_hash_algorithm, get_request_extra_params,
     };
     use kbs_types::Tee;
 
@@ -542,12 +550,23 @@ mod test {
         println!("Get key: {key:?}");
     }
 
+    #[rstest]
+    #[case(None)]
+    #[case(Some("alice"))]
     #[tokio::test]
     #[serial_test::serial]
-    async fn test_get_request_extra_params() {
-        let extra_params = get_request_extra_params().await;
+    async fn test_get_request_extra_params(#[case] attestation_policy_selector: Option<&str>) {
+        let extra_params = get_request_extra_params(attestation_policy_selector).await;
 
         assert!(extra_params.is_object());
+
+        assert_eq!(
+            extra_params
+                .get(ATTESTATION_POLICY_SELECTOR_JSON_KEY)
+                .and_then(Value::as_str),
+            attestation_policy_selector,
+            "the id is only sent when it is set"
+        );
 
         let algos_json = extra_params
             .get(SUPPORTED_HASH_ALGORITHMS_JSON_KEY)
@@ -567,9 +586,12 @@ mod test {
         }
     }
 
+    #[rstest]
+    #[case(None)]
+    #[case(Some("alice"))]
     #[tokio::test]
     #[serial_test::serial]
-    async fn test_build_request() {
+    async fn test_build_request(#[case] attestation_policy_selector: Option<&str>) {
         let tees = vec![
             Tee::AzSnpVtpm,
             Tee::AzTdxVtpm,
@@ -582,14 +604,21 @@ mod test {
         ];
 
         let expected_version = String::from(KBS_PROTOCOL_VERSION);
-        let expected_extra_params = get_request_extra_params().await;
+        let expected_extra_params = get_request_extra_params(attestation_policy_selector).await;
 
         for tee in tees {
-            let request = build_request(tee).await;
+            let request = build_request(tee, attestation_policy_selector).await;
 
             assert_eq!(request.version, expected_version);
             assert_eq!(request.tee, tee);
             assert_eq!(request.extra_params, expected_extra_params);
+            assert_eq!(
+                request
+                    .extra_params
+                    .get(ATTESTATION_POLICY_SELECTOR_JSON_KEY)
+                    .and_then(Value::as_str),
+                attestation_policy_selector
+            );
         }
     }
 


### PR DESCRIPTION
Trustee gained a policy_id_map, with which an administrator maps an id that a client names in the RCAR Request to the Attestation Service policies that evaluate its evidence. Give the KBC a way to name such an id, so that a deployment can have different guests evaluated against different policies without running separate KBS instances.

kbs_protocol carries the id from `KbsClientBuilder::set_policy_selector` into the `extra-params` of the auth Request. AA takes it from the new `attestation_policy_selector ` field of the `[token_configs.kbs]` section, which is empty by default.

An empty id is not sent at all: KBS falls back to a default policy for a Request without an id, but rejects the handshake of a client that sends an id the deployment does not declare. Configuring an id therefore only works against a KBS that maps it, which is why it stays opt-in and why the empty string, rather than an `Option`, expresses "not configured" in the config.

See also https://github.com/confidential-containers/trustee/pull/1521