### PR TITLE
Azsnp vtpm eventlog

### DIFF
--- a/attestation-agent/attester/src/az_snp_vtpm/mod.rs
+++ b/attestation-agent/attester/src/az_snp_vtpm/mod.rs
@@ -4,6 +4,7 @@
 //
 
 use super::{Attester, InitDataResult, TeeEvidence};
+use crate::utils::read_eventlog;
 use anyhow::{bail, Context, Result};
 use az_snp_vtpm::{imds, is_snp_cvm, vtpm};
 use azure_tpm::{Tpm, TpmCommandExt};
@@ -70,6 +71,9 @@ impl From<vtpm::Quote> for TpmQuote {
 /// - `hcl_report` - Hardware Compatibility Layer report containing the
 ///    Hardware attestation report from the AMD SEV-SNP platform
 /// - `vcek` - Versioned Chip Endorsement Key certificate (DER-encoded)
+/// - `cc_eventlog` - Base64-encoded runtime eventlog (AAEL in TCG2 encoding),
+///    or `None` when no runtime eventlog has been recorded. Mirrors the shape
+///    used by the TDX attester so the verifier can consume it uniformly.
 #[serde_as]
 #[derive(Serialize, Deserialize)]
 struct Evidence {
@@ -79,6 +83,7 @@ struct Evidence {
     hcl_report: Vec<u8>,
     #[serde_as(as = "UrlSafeBase64")]
     vcek: Vec<u8>,
+    cc_eventlog: Option<String>,
 }
 
 /// Convert a PEM-encoded certificate to DER format
@@ -92,7 +97,10 @@ fn pem_to_der(pem: &str) -> Result<Vec<u8>> {
     Ok(der)
 }
 
-fn get_evidence_sync(report_data: &[u8]) -> anyhow::Result<TeeEvidence> {
+fn get_evidence_sync(
+    report_data: &[u8],
+    cc_eventlog: Option<String>,
+) -> anyhow::Result<TeeEvidence> {
     let hcl_report = vtpm::get_report_with_report_data(report_data)?;
     let tpm_quote = vtpm::get_quote(report_data)?.into();
     let certs = imds::get_certs()?;
@@ -103,6 +111,7 @@ fn get_evidence_sync(report_data: &[u8]) -> anyhow::Result<TeeEvidence> {
         tpm_quote,
         hcl_report,
         vcek,
+        cc_eventlog,
     };
 
     Ok(serde_json::to_value(&evidence)?)
@@ -111,7 +120,10 @@ fn get_evidence_sync(report_data: &[u8]) -> anyhow::Result<TeeEvidence> {
 #[async_trait::async_trait]
 impl Attester for AzSnpVtpmAttester {
     async fn get_evidence(&self, report_data: Vec<u8>) -> anyhow::Result<TeeEvidence> {
-        spawn_blocking(move || get_evidence_sync(&report_data)).await?
+        // Read the runtime eventlog (AAEL) before entering the blocking section:
+        // `read_eventlog` is async, whereas the vTPM calls below are blocking.
+        let cc_eventlog = read_eventlog().await?;
+        spawn_blocking(move || get_evidence_sync(&report_data, cc_eventlog)).await?
     }
 
     fn supports_runtime_measurement(&self) -> bool {
@@ -257,5 +269,44 @@ MIIB0zCCAXqgAwIBAgIJALg0
         };
         let json_out = serde_json::to_value(&out).unwrap();
         assert_eq!(json_out["report"], "3q2-7w==");
+    }
+
+    #[test]
+    fn test_evidence_cc_eventlog_roundtrip() {
+        // With a recorded eventlog: the field is emitted as a plain string and
+        // round-trips back unchanged.
+        let evidence = Evidence {
+            version: EVIDENCE_VERSION,
+            tpm_quote: TpmQuote {
+                signature: vec![0xde, 0xad],
+                message: vec![0xbe, 0xef],
+                pcrs: vec![vec![0x00; 32]],
+            },
+            hcl_report: vec![1, 2, 3],
+            vcek: vec![4, 5, 6],
+            cc_eventlog: Some("AAEL-base64".to_string()),
+        };
+        let value = serde_json::to_value(&evidence).unwrap();
+        assert_eq!(value["cc_eventlog"], "AAEL-base64");
+        let back: Evidence = serde_json::from_value(value).unwrap();
+        assert_eq!(back.cc_eventlog.as_deref(), Some("AAEL-base64"));
+
+        // Without an eventlog: the field serializes as JSON null and round-trips
+        // back to None (matches the TDX attester's shape).
+        let evidence_none = Evidence {
+            version: EVIDENCE_VERSION,
+            tpm_quote: TpmQuote {
+                signature: vec![],
+                message: vec![],
+                pcrs: vec![],
+            },
+            hcl_report: vec![],
+            vcek: vec![],
+            cc_eventlog: None,
+        };
+        let value_none = serde_json::to_value(&evidence_none).unwrap();
+        assert!(value_none.get("cc_eventlog").unwrap().is_null());
+        let back_none: Evidence = serde_json::from_value(value_none).unwrap();
+        assert_eq!(back_none.cc_eventlog, None);
     }
 }

--- a/attestation-agent/attester/src/az_snp_vtpm/mod.rs
+++ b/attestation-agent/attester/src/az_snp_vtpm/mod.rs
@@ -270,5 +270,4 @@ MIIB0zCCAXqgAwIBAgIJALg0
         let json_out = serde_json::to_value(&out).unwrap();
         assert_eq!(json_out["report"], "3q2-7w==");
     }
-
 }

--- a/attestation-agent/attester/src/az_snp_vtpm/mod.rs
+++ b/attestation-agent/attester/src/az_snp_vtpm/mod.rs
@@ -271,42 +271,4 @@ MIIB0zCCAXqgAwIBAgIJALg0
         assert_eq!(json_out["report"], "3q2-7w==");
     }
 
-    #[test]
-    fn test_evidence_cc_eventlog_roundtrip() {
-        // With a recorded eventlog: the field is emitted as a plain string and
-        // round-trips back unchanged.
-        let evidence = Evidence {
-            version: EVIDENCE_VERSION,
-            tpm_quote: TpmQuote {
-                signature: vec![0xde, 0xad],
-                message: vec![0xbe, 0xef],
-                pcrs: vec![vec![0x00; 32]],
-            },
-            hcl_report: vec![1, 2, 3],
-            vcek: vec![4, 5, 6],
-            cc_eventlog: Some("AAEL-base64".to_string()),
-        };
-        let value = serde_json::to_value(&evidence).unwrap();
-        assert_eq!(value["cc_eventlog"], "AAEL-base64");
-        let back: Evidence = serde_json::from_value(value).unwrap();
-        assert_eq!(back.cc_eventlog.as_deref(), Some("AAEL-base64"));
-
-        // Without an eventlog: the field serializes as JSON null and round-trips
-        // back to None (matches the TDX attester's shape).
-        let evidence_none = Evidence {
-            version: EVIDENCE_VERSION,
-            tpm_quote: TpmQuote {
-                signature: vec![],
-                message: vec![],
-                pcrs: vec![],
-            },
-            hcl_report: vec![],
-            vcek: vec![],
-            cc_eventlog: None,
-        };
-        let value_none = serde_json::to_value(&evidence_none).unwrap();
-        assert!(value_none.get("cc_eventlog").unwrap().is_null());
-        let back_none: Evidence = serde_json::from_value(value_none).unwrap();
-        assert_eq!(back_none.cc_eventlog, None);
-    }
 }

--- a/attestation-agent/attester/src/az_snp_vtpm/mod.rs
+++ b/attestation-agent/attester/src/az_snp_vtpm/mod.rs
@@ -4,8 +4,8 @@
 //
 
 use super::{Attester, InitDataResult, TeeEvidence};
-use anyhow::{Context, Result, bail};
 use crate::utils::read_eventlog;
+use anyhow::{Context, Result, bail};
 use az_snp_vtpm::{imds, is_snp_cvm, vtpm};
 use azure_tpm::{Tpm, TpmCommandExt};
 use kbs_types::HashAlgorithm;

--- a/attestation-agent/attester/src/az_snp_vtpm/mod.rs
+++ b/attestation-agent/attester/src/az_snp_vtpm/mod.rs
@@ -5,6 +5,7 @@
 
 use super::{Attester, InitDataResult, TeeEvidence};
 use anyhow::{Context, Result, bail};
+use crate::utils::read_eventlog;
 use az_snp_vtpm::{imds, is_snp_cvm, vtpm};
 use azure_tpm::{Tpm, TpmCommandExt};
 use kbs_types::HashAlgorithm;
@@ -70,6 +71,9 @@ impl From<vtpm::Quote> for TpmQuote {
 /// - `hcl_report` - Hardware Compatibility Layer report containing the
 ///    Hardware attestation report from the AMD SEV-SNP platform
 /// - `vcek` - Versioned Chip Endorsement Key certificate (DER-encoded)
+/// - `cc_eventlog` - Base64-encoded runtime eventlog (AAEL in TCG2 encoding),
+///    or `None` when no runtime eventlog has been recorded. Mirrors the shape
+///    used by the TDX attester so the verifier can consume it uniformly.
 #[serde_as]
 #[derive(Serialize, Deserialize)]
 struct Evidence {
@@ -79,6 +83,7 @@ struct Evidence {
     hcl_report: Vec<u8>,
     #[serde_as(as = "UrlSafeBase64")]
     vcek: Vec<u8>,
+    cc_eventlog: Option<String>,
 }
 
 /// Convert a PEM-encoded certificate to DER format
@@ -92,7 +97,10 @@ fn pem_to_der(pem: &str) -> Result<Vec<u8>> {
     Ok(der)
 }
 
-fn get_evidence_sync(report_data: &[u8]) -> anyhow::Result<TeeEvidence> {
+fn get_evidence_sync(
+    report_data: &[u8],
+    cc_eventlog: Option<String>,
+) -> anyhow::Result<TeeEvidence> {
     let hcl_report = vtpm::get_report_with_report_data(report_data)?;
     let tpm_quote = vtpm::get_quote(report_data)?.into();
     let certs = imds::get_certs()?;
@@ -103,6 +111,7 @@ fn get_evidence_sync(report_data: &[u8]) -> anyhow::Result<TeeEvidence> {
         tpm_quote,
         hcl_report,
         vcek,
+        cc_eventlog,
     };
 
     Ok(serde_json::to_value(&evidence)?)
@@ -111,7 +120,10 @@ fn get_evidence_sync(report_data: &[u8]) -> anyhow::Result<TeeEvidence> {
 #[async_trait::async_trait]
 impl Attester for AzSnpVtpmAttester {
     async fn get_evidence(&self, report_data: Vec<u8>) -> anyhow::Result<TeeEvidence> {
-        spawn_blocking(move || get_evidence_sync(&report_data)).await?
+        // Read the runtime eventlog (AAEL) before entering the blocking section:
+        // `read_eventlog` is async, whereas the vTPM calls below are blocking.
+        let cc_eventlog = read_eventlog().await?;
+        spawn_blocking(move || get_evidence_sync(&report_data, cc_eventlog)).await?
     }
 
     fn supports_runtime_measurement(&self) -> bool {
@@ -257,5 +269,44 @@ MIIB0zCCAXqgAwIBAgIJALg0
         };
         let json_out = serde_json::to_value(&out).unwrap();
         assert_eq!(json_out["report"], "3q2-7w==");
+    }
+
+    #[test]
+    fn test_evidence_cc_eventlog_roundtrip() {
+        // With a recorded eventlog: the field is emitted as a plain string and
+        // round-trips back unchanged.
+        let evidence = Evidence {
+            version: EVIDENCE_VERSION,
+            tpm_quote: TpmQuote {
+                signature: vec![0xde, 0xad],
+                message: vec![0xbe, 0xef],
+                pcrs: vec![vec![0x00; 32]],
+            },
+            hcl_report: vec![1, 2, 3],
+            vcek: vec![4, 5, 6],
+            cc_eventlog: Some("AAEL-base64".to_string()),
+        };
+        let value = serde_json::to_value(&evidence).unwrap();
+        assert_eq!(value["cc_eventlog"], "AAEL-base64");
+        let back: Evidence = serde_json::from_value(value).unwrap();
+        assert_eq!(back.cc_eventlog.as_deref(), Some("AAEL-base64"));
+
+        // Without an eventlog: the field serializes as JSON null and round-trips
+        // back to None (matches the TDX attester's shape).
+        let evidence_none = Evidence {
+            version: EVIDENCE_VERSION,
+            tpm_quote: TpmQuote {
+                signature: vec![],
+                message: vec![],
+                pcrs: vec![],
+            },
+            hcl_report: vec![],
+            vcek: vec![],
+            cc_eventlog: None,
+        };
+        let value_none = serde_json::to_value(&evidence_none).unwrap();
+        assert!(value_none.get("cc_eventlog").unwrap().is_null());
+        let back_none: Evidence = serde_json::from_value(value_none).unwrap();
+        assert_eq!(back_none.cc_eventlog, None);
     }
 }

--- a/attestation-agent/attester/src/utils.rs
+++ b/attestation-agent/attester/src/utils.rs
@@ -210,8 +210,31 @@ pub async fn read_eventlog() -> Result<Option<String>> {
 
 #[cfg(test)]
 mod tests {
-    use super::EL_HEADER;
+    use super::{trim_ccel, EL_HEADER};
     use std::collections::HashMap;
+
+    // Builds a minimal TCG_PCR_EVENT spec-id header (EV_NO_ACTION, sha1 digest prefix).
+    fn make_spec_id_header(event_data: &[u8]) -> Vec<u8> {
+        let mut v = vec![0u8; 4]; // pcrIndex = 0
+        v.extend_from_slice(&3u32.to_le_bytes()); // eventType = EV_NO_ACTION
+        v.extend_from_slice(&[0u8; 20]); // sha1_digest
+        v.extend_from_slice(&(event_data.len() as u32).to_le_bytes());
+        v.extend_from_slice(event_data);
+        v
+    }
+
+    // Builds a minimal TCG_PCR_EVENT2 with one SHA-256 digest.
+    fn make_sha256_event(target_mr: u32, event_data: &[u8]) -> Vec<u8> {
+        let mut v = Vec::new();
+        v.extend_from_slice(&target_mr.to_le_bytes());
+        v.extend_from_slice(&13u32.to_le_bytes()); // eventType
+        v.extend_from_slice(&1u32.to_le_bytes()); // digestCount = 1
+        v.extend_from_slice(&0x000Bu16.to_le_bytes()); // algId = SHA-256
+        v.extend_from_slice(&[0xABu8; 32]); // digest
+        v.extend_from_slice(&(event_data.len() as u32).to_le_bytes());
+        v.extend_from_slice(event_data);
+        v
+    }
 
     /// Guards the hand-computed byte offsets of the eventlog spec-id header and
     /// asserts it declares SHA-256, so the verifier parser can size the SHA-256
@@ -248,5 +271,66 @@ mod tests {
 
         // vendorInfoSize (final byte) == 0
         assert_eq!(*EL_HEADER.last().unwrap(), 0);
+    }
+
+    #[test]
+    fn trim_ccel_strips_end_flag_and_padding() {
+        let header = make_spec_id_header(&[]);
+        let event = make_sha256_event(7, &[1, 2, 3, 4]);
+        let expected: Vec<u8> = [header.as_slice(), event.as_slice()].concat();
+
+        let mut ccel = expected.clone();
+        ccel.extend_from_slice(&[0xFFu8; 8]); // end flag
+        ccel.extend_from_slice(&[0u8; 64]); // trailing padding
+
+        assert_eq!(trim_ccel(ccel).unwrap(), expected);
+    }
+
+    #[test]
+    fn trim_ccel_zero_end_flag() {
+        let header = make_spec_id_header(&[]);
+        let event = make_sha256_event(7, &[]);
+        let expected: Vec<u8> = [header.as_slice(), event.as_slice()].concat();
+
+        let mut ccel = expected.clone();
+        ccel.extend_from_slice(&[0u8; 8]); // zero end flag
+
+        assert_eq!(trim_ccel(ccel).unwrap(), expected);
+    }
+
+    #[test]
+    fn trim_ccel_no_runtime_events() {
+        let header = make_spec_id_header(&[]);
+        let mut ccel = header.clone();
+        ccel.extend_from_slice(&[0xFFu8; 8]);
+
+        assert_eq!(trim_ccel(ccel).unwrap(), header);
+    }
+
+    #[test]
+    fn trim_ccel_too_short_returns_err() {
+        assert!(trim_ccel(vec![0u8; 4]).is_err());
+    }
+
+    #[test]
+    fn trim_ccel_no_end_flag_returns_err() {
+        // header only, no end flag — loop bails on missing terminator
+        assert!(trim_ccel(make_spec_id_header(&[])).is_err());
+    }
+
+    #[test]
+    fn trim_ccel_unsupported_algorithm_returns_err() {
+        let header = make_spec_id_header(&[]);
+        let mut event = Vec::new();
+        event.extend_from_slice(&7u32.to_le_bytes()); // target_mr
+        event.extend_from_slice(&13u32.to_le_bytes()); // event_type
+        event.extend_from_slice(&1u32.to_le_bytes()); // digestCount = 1
+        event.extend_from_slice(&0x0001u16.to_le_bytes()); // algId = unknown
+        event.extend_from_slice(&[0u8; 20]); // padding (never reached)
+
+        let mut ccel = header;
+        ccel.extend_from_slice(&event);
+
+        assert!(trim_ccel(ccel).is_err());
     }
 }

--- a/attestation-agent/attester/src/utils.rs
+++ b/attestation-agent/attester/src/utils.rs
@@ -210,7 +210,7 @@ pub async fn read_eventlog() -> Result<Option<String>> {
 
 #[cfg(test)]
 mod tests {
-    use super::{trim_ccel, EL_HEADER};
+    use super::{EL_HEADER, trim_ccel};
     use std::collections::HashMap;
 
     // Builds a minimal TCG_PCR_EVENT spec-id header (EV_NO_ACTION, sha1 digest prefix).

--- a/attestation-agent/attester/src/utils.rs
+++ b/attestation-agent/attester/src/utils.rs
@@ -63,19 +63,25 @@ pub fn validate_and_pad_data(data: Vec<u8>, expected_size: usize) -> Result<Vec<
 /// The content of this HEADER is:
 ///
 /// 1. EvNoAction entry
-/// 2. Digest sizes with sha384 -> 0x30; sm3 -> 0x20;
+/// 2. Digest sizes with sha256 -> 0x20; sha384 -> 0x30; sm3 -> 0x20;
 ///
-/// The digest algorithm is determined by OVMF, and now:
+/// The digest algorithm is determined by OVMF/platform, and now:
 /// - tdx supports sha384.
 /// - csv supports sm3.
+/// - az_snp_vtpm supports sha256.
+///
+/// All three algorithms are declared so the verifier's parser can size the
+/// per-event digests of every TEE type that emits an AAEL. The TCG2 event
+/// entries are self-describing (each carries its own algorithm id), so the
+/// declaration order here does not need to match the event digest order.
 ///
 /// Let's extend it if RTMR and CCEL are brought for more TEE types.
-pub const EL_HEADER: [u8; 69] = [
+pub const EL_HEADER: [u8; 73] = [
     0x00, 0x00, 0x00, 0x00, 0x03, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x25, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x29, 0x00, 0x00, 0x00,
     0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00, 0x0C, 0x00, 0x30, 0x00,
-    0x12, 0x00, 0x20, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x03, 0x00, 0x00, 0x00, 0x0B, 0x00, 0x20, 0x00,
+    0x0C, 0x00, 0x30, 0x00, 0x12, 0x00, 0x20, 0x00, 0x00,
 ];
 
 /// End flag for eventlog
@@ -200,4 +206,47 @@ pub async fn read_eventlog() -> Result<Option<String>> {
     eventlog.extend_from_slice(&EL_END_FLAG);
 
     Ok(Some(STANDARD.encode(eventlog)))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::EL_HEADER;
+    use std::collections::HashMap;
+
+    /// Guards the hand-computed byte offsets of the eventlog spec-id header and
+    /// asserts it declares SHA-256, so the verifier parser can size the SHA-256
+    /// digests emitted by vTPM-based attesters (e.g. az_snp_vtpm) instead of
+    /// bailing on the first runtime event.
+    #[test]
+    fn test_el_header_declares_sha256() {
+        // TCG_PCR_EVENT prefix: pcrIndex(4) + eventType(4) + digest[20] + eventDataSize(4) = 32
+        assert_eq!(EL_HEADER.len(), 73);
+
+        // eventType == EV_NO_ACTION (3)
+        assert_eq!(u32::from_le_bytes(EL_HEADER[4..8].try_into().unwrap()), 3);
+
+        // eventDataSize (offset 28) counts the TCG_EfiSpecIDEvent that follows.
+        let event_data_size = u32::from_le_bytes(EL_HEADER[28..32].try_into().unwrap());
+        assert_eq!(event_data_size, 41);
+        assert_eq!(EL_HEADER.len(), 32 + event_data_size as usize);
+
+        // numberOfAlgorithms (offset 56) == 3
+        let num_algs = u32::from_le_bytes(EL_HEADER[56..60].try_into().unwrap());
+        assert_eq!(num_algs, 3);
+
+        // digestSizes entries (u16 algId + u16 digestSize) begin at offset 60.
+        let mut algs = HashMap::new();
+        for i in 0..num_algs as usize {
+            let base = 60 + i * 4;
+            let alg = u16::from_le_bytes(EL_HEADER[base..base + 2].try_into().unwrap());
+            let size = u16::from_le_bytes(EL_HEADER[base + 2..base + 4].try_into().unwrap());
+            algs.insert(alg, size);
+        }
+        assert_eq!(algs.get(&0x000B), Some(&32)); // SHA-256
+        assert_eq!(algs.get(&0x000C), Some(&48)); // SHA-384
+        assert_eq!(algs.get(&0x0012), Some(&32)); // SM3
+
+        // vendorInfoSize (final byte) == 0
+        assert_eq!(*EL_HEADER.last().unwrap(), 0);
+    }
 }


### PR DESCRIPTION
Completes the az-snp-vtpm AAEL path on top of https://github.com/confidential-containers/guest-components/pull/1603

  1. Add `cc_eventlog: Option<String>` to the az-snp-vtpm evidence, populated from
     `read_eventlog()` (mirrors the TDX/CSV attesters). Without it the recorded AAEL
     never reaches the verifier. (using current String representation, which might be change for a typed representation in issue #1551)

  2. Declare SHA-256 in the fixed `EL_HEADER` (used when no CCEL is present, e.g.
     az-snp-vtpm) so the AS eventlog parser can size SHA-256 runtime events instead of
     failing with "Missing digest size for algorithm" on the first one.

  ## Testing
  - cargo build / test / clippy -D warnings / fmt --check (attester, az-snp-vtpm-attester)
  - new unit tests: cc_eventlog serde round-trip; EL_HEADER byte-layout / SHA-256 declaration
  