### PR TITLE
chore: bump kbs-types to 0.18.0 (drop git pin)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4312,8 +4312,9 @@ dependencies = [
 
 [[package]]
 name = "kbs-types"
-version = "0.17.0"
-source = "git+https://github.com/confidential-containers/kbs-types?rev=b26f44e#b26f44e60a9d542290571c7354ed1855b279ee16"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4453d70e4a9a7db181a83661803dc296471957d16cb4ddd2af7a52d17eb234cc"
 dependencies = [
  "base64 0.22.1",
  "ear",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ hmac = "0.13.0"
 jwt-simple = { version = "0.12", default-features = false, features = [
     "pure-rust",
 ] }
-kbs-types = { git = "https://github.com/confidential-containers/kbs-types", rev = "b26f44e" }
+kbs-types = "0.18.0"
 nix = "0.31"
 openssl = "0.10"
 prost = "0.14"


### PR DESCRIPTION
kbs-types v0.18.0 has been released with the DPU TEE type (confidential-containers/kbs-types#89). This replaces the temporary git revision pin with the published crate version.

Addresses review feedback from @mythi in #1575.

Note: Cargo.lock update pending, will fix if CI flags it.

Signed-off-by: Ying Jiang <jiangying8582@163.com>
Signed-off-by: Ying Jiang <haixin.jy@alibaba-inc.com>