### PR TITLE
secret: add a keygen command

### DIFF
--- a/confidential-data-hub/docs/SEALED_SECRET.md
+++ b/confidential-data-hub/docs/SEALED_SECRET.md
@@ -180,21 +180,16 @@ This will create a sealed secret that points to the resource `secret/key/uri` in
 The secret will be validated with a public key stored in Trustee.
 The public/private keypair should be a JWK with a P256 EC key.
 
-This key should look like this.
-```json
-{
-    "kty": "EC",
-    "d": "_z0AOMG12p1lt...",
-    "use": "sig",
-    "crv": "P-256",
-    "kid": "test",
-    "x": "wjCZnuv_tLKiCt...",
-    "y": "gsSc2YE_O2kmHx...",
-    "alg": "ES256"
-}
+You can generate a keypair with the `keygen` subcommand:
+
+```bash
+cargo run -p confidential-data-hub --bin secret keygen --kid my-signing-key --output-dir ./keys
 ```
-This includes the public and private keypair. Only the public component
-needs to be provisioned to Trustee.
+
+This writes two files: `my-signing-key-private.json` (used for signing)
+and `my-signing-key-public.json` (provisioned to Trustee).
+
+Only the public component needs to be provisioned to Trustee.
 
 ### Create a Kubernetes secret
 

--- a/confidential-data-hub/hub/src/bin/secret_cli.rs
+++ b/confidential-data-hub/hub/src/bin/secret_cli.rs
@@ -4,9 +4,13 @@
 //
 
 use jose_jwk::Jwk;
+use p256::elliptic_curve::sec1::ToEncodedPoint;
 use std::{env, path::Path};
 
-use base64::{engine::general_purpose::STANDARD, Engine};
+use base64::{
+    engine::general_purpose::{STANDARD, URL_SAFE_NO_PAD},
+    Engine,
+};
 use clap::{Args, Parser, Subcommand};
 use confidential_data_hub::secret::{
     layout::{envelope::EnvelopeSecret, vault::VaultSecret},
@@ -36,6 +40,9 @@ enum Cli {
 
     /// Unseal the given secret
     Unseal(UnsealArgs),
+
+    /// Generate a P-256 EC signing keypair in JWK format
+    Keygen(KeygenArgs),
 }
 
 #[derive(Args)]
@@ -74,6 +81,18 @@ struct UnsealArgs {
     /// Skip validating the signature of the sealed secret.
     #[arg(short, long)]
     skip_verification: bool,
+}
+
+#[derive(Args)]
+#[command(author, version, about, long_about = None)]
+struct KeygenArgs {
+    /// Key ID to embed in the JWK
+    #[arg(long, default_value = "sealed-signing")]
+    kid: String,
+
+    /// Directory to write the key files to
+    #[arg(long, default_value = ".")]
+    output_dir: String,
 }
 
 #[derive(Subcommand)]
@@ -190,6 +209,9 @@ async fn main() {
         }
         Cli::Seal(seal_args) => {
             seal_secret(&seal_args).await;
+        }
+        Cli::Keygen(keygen_args) => {
+            generate_keys(&keygen_args);
         }
     }
 }
@@ -332,6 +354,78 @@ async fn seal_secret(seal_args: &SealArgs) {
         .to_signed_base64_string(signing_jwk, seal_args.signing_kid.clone())
         .expect("failed to serialize secret");
     println!("{secret_string}");
+}
+
+fn generate_keys(args: &KeygenArgs) {
+    let mut scalar_bytes = [0u8; 32];
+    rand::rng().fill(&mut scalar_bytes);
+
+    let secret_key =
+        p256::SecretKey::from_slice(&scalar_bytes).expect("Failed to generate valid P-256 key");
+    let public_key = secret_key.public_key();
+    let point = public_key.to_encoded_point(false);
+
+    let d = URL_SAFE_NO_PAD.encode(secret_key.to_bytes());
+    let x = URL_SAFE_NO_PAD.encode(
+        point
+            .x()
+            .expect("uncompressed point must have x coordinate"),
+    );
+    let y = URL_SAFE_NO_PAD.encode(
+        point
+            .y()
+            .expect("uncompressed point must have y coordinate"),
+    );
+
+    let private_jwk = serde_json::json!({
+        "kty": "EC",
+        "crv": "P-256",
+        "alg": "ES256",
+        "use": "sig",
+        "kid": args.kid,
+        "d": d,
+        "x": x,
+        "y": y,
+    });
+
+    let public_jwk = serde_json::json!({
+        "kty": "EC",
+        "crv": "P-256",
+        "alg": "ES256",
+        "use": "sig",
+        "kid": args.kid,
+        "x": x,
+        "y": y,
+    });
+
+    let output_dir = Path::new(&args.output_dir);
+    let private_path = output_dir.join(format!("{}-private.json", args.kid));
+    let public_path = output_dir.join(format!("{}-public.json", args.kid));
+
+    if private_path.exists() {
+        panic!("{:?} already exists", &private_path);
+    }
+    if public_path.exists() {
+        panic!("{:?} already exists", &public_path);
+    }
+
+    std::fs::write(
+        &private_path,
+        serde_json::to_string_pretty(&private_jwk).expect("Failed to serialize JWK") + "\n",
+    )
+    .unwrap_or_else(|e| panic!("Failed to write {}: {e}", private_path.display()));
+
+    std::fs::write(
+        &public_path,
+        serde_json::to_string_pretty(&public_jwk).expect("Failed to serialize JWK") + "\n",
+    )
+    .unwrap_or_else(|e| panic!("Failed to write {}: {e}", public_path.display()));
+
+    println!(
+        "Generated {} and {}",
+        private_path.display(),
+        public_path.display()
+    );
 }
 
 async fn handle_envelope_provider(

--- a/confidential-data-hub/hub/tests/keygen.rs
+++ b/confidential-data-hub/hub/tests/keygen.rs
@@ -1,0 +1,121 @@
+// Copyright (c) 2024 Red Hat, Inc
+//
+// SPDX-License-Identifier: Apache-2.0
+
+use assert_cmd::Command;
+use base64::{engine::general_purpose::STANDARD, Engine};
+use serde_json::Value;
+use std::collections::HashMap;
+use tempfile::TempDir;
+
+const SIGNING_CREDENTIALS_PATH: &str = "/run/confidential-containers/cdh/sealed-secret";
+
+/// End-to-end test: generate a keypair, seal a vault secret, unseal it, and
+/// verify the plaintext matches. Uses `offline_fs_kbc` with
+/// `OFFLINE_FS_KBC_EXTRA_FILE_PATH` so no writes to /etc/ are needed.
+///
+/// Must run as root (writes to /run/) — intended for CI containers.
+#[test]
+fn seal_unseal_vault_e2e() {
+    let tmp = TempDir::new().unwrap();
+    let kid = "e2e-test-key";
+    let secret_plaintext = b"super-secret-value-42";
+    let resource_path = "default/sealed-secret/e2e-test";
+    let resource_uri = format!("kbs:///{resource_path}");
+
+    // 1. Generate a signing keypair
+    Command::cargo_bin("secret")
+        .unwrap()
+        .args(["keygen", "--kid", kid, "--output-dir"])
+        .arg(tmp.path())
+        .assert()
+        .success();
+
+    let private_jwk_path = tmp.path().join(format!("{kid}-private.json"));
+    let public_jwk_path = tmp.path().join(format!("{kid}-public.json"));
+    assert!(private_jwk_path.exists());
+    assert!(public_jwk_path.exists());
+
+    // Verify key structure
+    let private_jwk: Value =
+        serde_json::from_str(&std::fs::read_to_string(&private_jwk_path).unwrap()).unwrap();
+    assert_eq!(private_jwk["kty"], "EC");
+    assert_eq!(private_jwk["crv"], "P-256");
+    assert!(private_jwk["d"].is_string(), "private key must contain d");
+
+    let public_jwk: Value =
+        serde_json::from_str(&std::fs::read_to_string(&public_jwk_path).unwrap()).unwrap();
+    assert!(public_jwk["d"].is_null(), "public key must not contain d");
+
+    // 2. Provision the secret to a temp file for offline_fs_kbc
+    let resources_path = tmp.path().join("offline-resources.json");
+    let mut resources: HashMap<String, String> = HashMap::new();
+    resources.insert(resource_path.to_string(), STANDARD.encode(secret_plaintext));
+    std::fs::write(&resources_path, serde_json::to_string(&resources).unwrap()).unwrap();
+
+    // 3. Provision the public key for signature verification
+    std::fs::create_dir_all(SIGNING_CREDENTIALS_PATH)
+        .expect("failed to create signing credentials dir (need root?)");
+    std::fs::copy(
+        &public_jwk_path,
+        format!("{SIGNING_CREDENTIALS_PATH}/{kid}"),
+    )
+    .unwrap();
+
+    // 4. Seal the vault secret
+    let seal_output = Command::cargo_bin("secret")
+        .unwrap()
+        .args([
+            "seal",
+            "--signing-kid",
+            kid,
+            "--signing-jwk-path",
+            private_jwk_path.to_str().unwrap(),
+            "vault",
+            "--resource-uri",
+            &resource_uri,
+            "--provider",
+            "kbs",
+        ])
+        .output()
+        .unwrap();
+
+    let stdout = String::from_utf8_lossy(&seal_output.stdout);
+    let stderr = String::from_utf8_lossy(&seal_output.stderr);
+    assert!(
+        seal_output.status.success(),
+        "seal failed.\nstdout: {stdout}\nstderr: {stderr}"
+    );
+
+    let sealed_secret = stdout
+        .lines()
+        .rev()
+        .find(|l| l.starts_with("sealed."))
+        .expect("seal output must contain a line starting with 'sealed.'");
+
+    // 5. Write the sealed secret to a file and unseal it
+    let sealed_path = tmp.path().join("sealed.txt");
+    std::fs::write(&sealed_path, sealed_secret).unwrap();
+
+    Command::cargo_bin("secret")
+        .unwrap()
+        .env(
+            "OFFLINE_FS_KBC_EXTRA_FILE_PATH",
+            resources_path.to_str().unwrap(),
+        )
+        .args([
+            "unseal",
+            "--file-path",
+            sealed_path.to_str().unwrap(),
+            "--aa-kbc-params",
+            "offline_fs_kbc::null",
+        ])
+        .assert()
+        .success();
+
+    // 6. Verify the unsealed secret matches the original plaintext
+    let unsealed_path = tmp.path().join("sealed.txt.unsealed");
+    assert!(unsealed_path.exists(), "unsealed file must be created");
+    let unsealed = std::fs::read(&unsealed_path).unwrap();
+    assert_eq!(unsealed, secret_plaintext);
+}


### PR DESCRIPTION
The docs in the repo don't specifically mention how to create the sealed JWK key: https://github.com/confidential-containers/guest-components/blob/main/confidential-data-hub/docs/SEALED_SECRET.md#usage-in-coco

In the official CoCo website it's even worse, as it suggests to use online tools:
"You can generate one with any tool that supports JWK, such as [mkjwk](https://mkjwk.org/)."

Let's have a command to create the keys ourselves without relying on external tools