### PR TITLE
feat(image-rs): support WASM OCI layer media types

### DIFF
--- a/image-rs/src/decoder/mod.rs
+++ b/image-rs/src/decoder/mod.rs
@@ -119,6 +119,11 @@ impl TryFrom<&str> for Compression {
             media_type_str = manifest::IMAGE_LAYER_GZIP_MEDIA_TYPE;
         }
 
+        // WASM layers are stored uncompressed as a single `module.wasm` binary.
+        if media_type_str == crate::media_type::WASM_LAYER_MEDIA_TYPE {
+            return Ok(Compression::Uncompressed);
+        }
+
         let media_type = MediaType::from(media_type_str);
 
         let decoder = match media_type {
@@ -296,6 +301,10 @@ mod tests {
             TestData {
                 media_type_str: "application/vnd.oci.image.layer.nondistributable.v1.tar+zstd",
                 result: Ok(Compression::Zstd),
+            },
+            TestData {
+                media_type_str: crate::media_type::WASM_LAYER_MEDIA_TYPE,
+                result: Ok(Compression::Uncompressed),
             },
         ];
 

--- a/image-rs/src/decrypt.rs
+++ b/image-rs/src/decrypt.rs
@@ -74,21 +74,25 @@ mod encryption {
     use ocicrypt_rs::helpers::create_decrypt_config;
     use ocicrypt_rs::spec::{
         MEDIA_TYPE_LAYER_ENC, MEDIA_TYPE_LAYER_GZIP_ENC, MEDIA_TYPE_LAYER_NON_DISTRIBUTABLE_ENC,
-        MEDIA_TYPE_LAYER_NON_DISTRIBUTABLE_GZIP_ENC,
+        MEDIA_TYPE_LAYER_NON_DISTRIBUTABLE_GZIP_ENC, MEDIA_TYPE_WASM_ENC,
     };
     use std::io::Read;
 
     impl Decryptor {
         /// Construct Decryptor from media_type.
         pub fn from_media_type(media_type: &str) -> Self {
-            let (media_type, encrypted) = match media_type {
-                MEDIA_TYPE_LAYER_ENC | MEDIA_TYPE_LAYER_NON_DISTRIBUTABLE_ENC => {
-                    (manifest::IMAGE_LAYER_MEDIA_TYPE.to_string(), true)
+            let (media_type, encrypted) = if media_type == MEDIA_TYPE_WASM_ENC {
+                (crate::media_type::WASM_LAYER_MEDIA_TYPE.to_string(), true)
+            } else {
+                match media_type {
+                    MEDIA_TYPE_LAYER_ENC | MEDIA_TYPE_LAYER_NON_DISTRIBUTABLE_ENC => {
+                        (manifest::IMAGE_LAYER_MEDIA_TYPE.to_string(), true)
+                    }
+                    MEDIA_TYPE_LAYER_GZIP_ENC | MEDIA_TYPE_LAYER_NON_DISTRIBUTABLE_GZIP_ENC => {
+                        (manifest::IMAGE_LAYER_GZIP_MEDIA_TYPE.to_string(), true)
+                    }
+                    _ => ("".to_string(), false),
                 }
-                MEDIA_TYPE_LAYER_GZIP_ENC | MEDIA_TYPE_LAYER_NON_DISTRIBUTABLE_GZIP_ENC => {
-                    (manifest::IMAGE_LAYER_GZIP_MEDIA_TYPE.to_string(), true)
-                }
-                _ => ("".to_string(), false),
             };
 
             Decryptor {
@@ -259,6 +263,13 @@ mod encryption {
                         encrypted: true,
                     },
                 },
+                TestData {
+                    media_type: MEDIA_TYPE_WASM_ENC,
+                    result: Decryptor {
+                        media_type: crate::media_type::WASM_LAYER_MEDIA_TYPE.to_string(),
+                        encrypted: true,
+                    },
+                },
             ];
 
             for (i, d) in tests.iter().enumerate() {
@@ -378,6 +389,9 @@ impl Decryptor {
     /// Construct Decryptor from media_type.
     pub fn from_media_type(media_type: &str) -> Self {
         let (media_type, encrypted) = match media_type {
+            crate::media_type::WASM_LAYER_ENC_MEDIA_TYPE => {
+                (crate::media_type::WASM_LAYER_MEDIA_TYPE.to_string(), true)
+            }
             "application/vnd.oci.image.layer.v1.tar+encrypted"
             | "application/vnd.oci.image.layer.nondistributable.v1.tar+encrypted" => {
                 (manifest::IMAGE_LAYER_MEDIA_TYPE.to_string(), true)

--- a/image-rs/src/image.rs
+++ b/image-rs/src/image.rs
@@ -21,6 +21,7 @@ use tokio::sync::RwLock;
 
 use crate::decoder::Compression;
 use crate::layer_store::LayerStore;
+use crate::media_type::is_wasm_media_type;
 use crate::meta_store::{MetaStore, METAFILE};
 use crate::pull::PullClient;
 use crate::signature::SignatureValidator;
@@ -493,6 +494,31 @@ fn create_image_meta(
 
     let diff_ids = image_data.image_config.rootfs().diff_ids();
     if diff_ids.len() != image_manifest.layers.len() {
+        // WASM images do not carry rootfs.diff_ids in the config. Populate the
+        // diff_ids with empty strings so layer digest verification is skipped.
+        if image_manifest
+            .layers
+            .iter()
+            .any(|layer| is_wasm_media_type(&layer.media_type))
+        {
+            let mut unique_layers = Vec::new();
+            let mut digests = BTreeSet::new();
+
+            for layer in image_manifest.layers.iter() {
+                if digests.contains(&layer.digest) {
+                    continue;
+                }
+
+                digests.insert(&layer.digest);
+                unique_layers.push(layer.clone());
+            }
+
+            return Ok((
+                image_data,
+                unique_layers.clone(),
+                vec![String::new(); unique_layers.len()],
+            ));
+        }
         bail!("Pulled number of layers mismatch with image config diff_ids");
     }
 

--- a/image-rs/src/lib.rs
+++ b/image-rs/src/lib.rs
@@ -11,6 +11,7 @@ pub mod decrypt;
 pub mod digest;
 pub mod image;
 pub mod layer_store;
+pub mod media_type;
 pub mod meta_store;
 pub mod pull;
 pub mod registry;

--- a/image-rs/src/media_type.rs
+++ b/image-rs/src/media_type.rs
@@ -1,0 +1,30 @@
+// Copyright (c) 2024 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+
+/// WASM layer media type. WASM layers are stored uncompressed as a single
+/// `module.wasm` binary, not as a tar archive.
+pub const WASM_LAYER_MEDIA_TYPE: &str = "application/vnd.wasm.content.layer.v1+wasm";
+
+/// Encrypted WASM layer media type.
+pub const WASM_LAYER_ENC_MEDIA_TYPE: &str = "application/vnd.wasm.content.layer.v1+wasm+encrypted";
+
+/// Whether the given media type is a WASM layer (plain or encrypted).
+pub fn is_wasm_media_type(media_type: &str) -> bool {
+    media_type == WASM_LAYER_MEDIA_TYPE || media_type == WASM_LAYER_ENC_MEDIA_TYPE
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_wasm_media_type() {
+        assert!(is_wasm_media_type(WASM_LAYER_MEDIA_TYPE));
+        assert!(is_wasm_media_type(WASM_LAYER_ENC_MEDIA_TYPE));
+        assert!(!is_wasm_media_type(
+            "application/vnd.oci.image.layer.v1.tar+gzip"
+        ));
+        assert!(!is_wasm_media_type(""));
+    }
+}

--- a/image-rs/src/pull.rs
+++ b/image-rs/src/pull.rs
@@ -19,8 +19,9 @@ use tokio_util::io::StreamReader;
 
 use crate::decoder::Compression;
 use crate::layer_store::LayerStore;
+use crate::media_type::is_wasm_media_type;
 use crate::meta_store::MetaStore;
-use crate::stream::stream_processing;
+use crate::stream::{stream_processing, wasm_stream_processing};
 use crate::{
     decoder::DecodeError,
     decrypt::{DecryptLayerError, Decryptor},
@@ -207,7 +208,9 @@ impl<'a> PullClient<'a> {
         }
 
         // uncompressed digest should equal to the diff_ids in image_config.
-        if layer_meta.uncompressed_digest != diff_id {
+        // WASM image configs do not carry rootfs.diff_ids, so an empty diff_id
+        // is tolerated (the digest is computed but not verified).
+        if !diff_id.is_empty() && layer_meta.uncompressed_digest != diff_id {
             return Err(PullLayerError::UnequalUncompressedDigest {
                 uncompressed_digest: layer_meta.uncompressed_digest,
                 diff_id,
@@ -228,9 +231,16 @@ impl<'a> PullClient<'a> {
     ) -> PullLayerResult<String> {
         let decoder = Compression::try_from(media_type)?;
         let async_decoder = decoder.async_decompress(input_reader);
-        stream_processing(async_decoder, diff_id, destination)
-            .await
-            .map_err(Into::into)
+
+        if is_wasm_media_type(media_type) {
+            wasm_stream_processing(async_decoder, diff_id, destination)
+                .await
+                .map_err(Into::into)
+        } else {
+            stream_processing(async_decoder, diff_id, destination)
+                .await
+                .map_err(Into::into)
+        }
     }
 }
 
@@ -385,6 +395,100 @@ mod tests {
                 Arc::new(RwLock::new(MetaStore::default()))
             );
         }
+    }
+
+    #[tokio::test]
+    async fn test_async_pull_wasm_layer() {
+        let image_url = "docker.io/rodneydav/wasm-addition:latest";
+        let tempdir = tempfile::tempdir().unwrap();
+        let image = Reference::try_from(image_url.to_string()).expect("create reference failed");
+        let layer_store =
+            LayerStore::new(tempdir.path().to_path_buf()).expect("create layer store failed");
+        let client_config = ClientConfig::default();
+
+        let mut client = PullClient::new(
+            image,
+            layer_store,
+            &RegistryAuth::Anonymous,
+            DEFAULT_MAX_CONCURRENT_DOWNLOAD,
+            client_config,
+        )
+        .unwrap();
+        let (image_manifest, _image_digest, _image_config, _manifest_list_digest) =
+            client.pull_manifest().await.unwrap();
+
+        // The WASM config is `{}` (2 bytes) and carries no rootfs.diff_ids,
+        // so an empty diff_id is passed for the single WASM layer.
+        assert_eq!(image_manifest.layers.len(), 1);
+        assert!(is_wasm_media_type(&image_manifest.layers[0].media_type));
+
+        // retry 3 times w/ timeout
+        let mut layer_metas = None;
+        for i in 0..3 {
+            let wait = std::time::Duration::from_secs(i * 2);
+            tokio::time::sleep(wait).await;
+
+            let diff_ids = vec![String::new(); image_manifest.layers.len()];
+            let result = client
+                .async_pull_layers(
+                    image_manifest.layers.clone(),
+                    &diff_ids,
+                    &None,
+                    Arc::new(RwLock::new(MetaStore::default())),
+                )
+                .await;
+            if let Ok(metas) = result {
+                layer_metas = Some(metas);
+                break;
+            }
+        }
+        let layer_metas = layer_metas.expect("failed to pull wasm layers");
+
+        assert_eq!(layer_metas.len(), 1);
+        let module_path = Path::new(&layer_metas[0].store_path).join("module.wasm");
+        assert!(
+            module_path.exists(),
+            "module.wasm should be written to {:?}",
+            module_path
+        );
+        assert!(!layer_metas[0].uncompressed_digest.is_empty());
+    }
+
+    #[cfg(feature = "encryption")]
+    #[tokio::test]
+    async fn test_async_pull_wasm_encrypted_media_type() {
+        let image_url = "docker.io/rodneydav/wasm-addition:encrypted";
+        let tempdir = tempfile::tempdir().unwrap();
+        let image = Reference::try_from(image_url.to_string()).expect("create reference failed");
+        let layer_store =
+            LayerStore::new(tempdir.path().to_path_buf()).expect("create layer store failed");
+        let client_config = ClientConfig::default();
+
+        let mut client = PullClient::new(
+            image,
+            layer_store,
+            &RegistryAuth::Anonymous,
+            DEFAULT_MAX_CONCURRENT_DOWNLOAD,
+            client_config,
+        )
+        .unwrap();
+        let (image_manifest, _image_digest, _image_config, _manifest_list_digest) =
+            client.pull_manifest().await.unwrap();
+
+        assert_eq!(image_manifest.layers.len(), 1);
+        let layer = &image_manifest.layers[0];
+        assert_eq!(
+            layer.media_type,
+            crate::media_type::WASM_LAYER_ENC_MEDIA_TYPE,
+            "layer media type should be the encrypted WASM media type"
+        );
+
+        let decryptor = Decryptor::from_media_type(&layer.media_type);
+        assert!(decryptor.is_encrypted());
+        assert_eq!(
+            decryptor.media_type,
+            crate::media_type::WASM_LAYER_MEDIA_TYPE
+        );
     }
 
     #[tokio::test]

--- a/image-rs/src/stream/mod.rs
+++ b/image-rs/src/stream/mod.rs
@@ -93,6 +93,44 @@ pub async fn stream_processing(
     async_processing(layer_reader, hasher, dest).await
 }
 
+/// wasm_stream_processing handles WASM layer data by writing the raw bytes
+/// directly to a `module.wasm` file instead of unpacking them as a tar
+/// archive, and returns the layer digest for verification. WASM layers are
+/// stored uncompressed as a single binary module.
+pub async fn wasm_stream_processing(
+    layer_reader: impl AsyncRead + Unpin,
+    diff_id: &str,
+    destination: &Path,
+) -> StreamResult<String> {
+    // WASM image configs do not carry rootfs.diff_ids, so `diff_id` may be
+    // empty. In that case the digest is still computed (SHA256) but is not
+    // verified against the config by the caller.
+    let hasher = if diff_id.starts_with(DIGEST_SHA256_PREFIX) {
+        LayerDigestHasher::Sha256(sha2::Sha256::new())
+    } else if diff_id.starts_with(DIGEST_SHA512_PREFIX) {
+        LayerDigestHasher::Sha512(sha2::Sha512::new())
+    } else {
+        LayerDigestHasher::Sha256(sha2::Sha256::new())
+    };
+
+    tokio::fs::create_dir_all(destination)
+        .await
+        .map_err(|source| StreamError::FailedToRollBack { source })?;
+
+    let wasm_file_path = destination.join("module.wasm");
+    let mut hash_reader = HashReader::new(layer_reader, hasher);
+    let mut wasm_file = tokio::fs::File::create(&wasm_file_path)
+        .await
+        .map_err(|source| StreamError::FailedToRollBack { source })?;
+
+    if let Err(source) = tokio::io::copy(&mut hash_reader, &mut wasm_file).await {
+        tokio::fs::remove_dir_all(destination).await.ok();
+        return Err(StreamError::FailedToRollBack { source });
+    }
+
+    Ok(hash_reader.hasher.digest_finalize())
+}
+
 async fn async_processing(
     layer_reader: impl AsyncRead + Unpin,
     hasher: LayerDigestHasher,
@@ -198,5 +236,44 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(layer_digest, layer_digest_new);
+    }
+
+    #[tokio::test]
+    async fn test_wasm_stream_processing() {
+        let data: Vec<u8> = b"\0asm\x01\0\0\0".to_vec();
+
+        let digest = sha2::Sha256::digest(data.as_slice());
+        let layer_digest = format!("{}{}", DIGEST_SHA256_PREFIX, hex::encode(digest));
+
+        let tempdir = tempfile::tempdir().unwrap();
+        let file_path = tempdir.path().join("layer0");
+
+        let layer_digest_new = wasm_stream_processing(data.as_slice(), &layer_digest, &file_path)
+            .await
+            .unwrap();
+        assert_eq!(layer_digest, layer_digest_new);
+
+        let module = tokio::fs::read(file_path.join("module.wasm"))
+            .await
+            .unwrap();
+        assert_eq!(module, data);
+    }
+
+    #[tokio::test]
+    async fn test_wasm_stream_processing_empty_diff_id() {
+        let data: Vec<u8> = b"\0asm\x01\0\0\0".to_vec();
+
+        let tempdir = tempfile::tempdir().unwrap();
+        let file_path = tempdir.path().join("layer0");
+
+        let layer_digest = wasm_stream_processing(data.as_slice(), "", &file_path)
+            .await
+            .unwrap();
+        assert!(layer_digest.starts_with(DIGEST_SHA256_PREFIX));
+
+        let module = tokio::fs::read(file_path.join("module.wasm"))
+            .await
+            .unwrap();
+        assert_eq!(module, data);
     }
 }

--- a/ocicrypt-rs/src/spec.rs
+++ b/ocicrypt-rs/src/spec.rs
@@ -14,3 +14,9 @@ pub const MEDIA_TYPE_LAYER_NON_DISTRIBUTABLE_ENC: &str =
 /// MEDIA_TYPE_LAYER_NON_DISTRIBUTABLE_GZIP_ENC is MIME type used for non distributable encrypted compressed layers.
 pub const MEDIA_TYPE_LAYER_NON_DISTRIBUTABLE_GZIP_ENC: &str =
     "application/vnd.oci.image.layer.nondistributable.v1.tar+gzip+encrypted";
+
+/// MEDIA_TYPE_WASM_LAYER is MIME type used for WASM layers.
+pub const MEDIA_TYPE_WASM_LAYER: &str = "application/vnd.wasm.content.layer.v1+wasm";
+
+/// MEDIA_TYPE_WASM_ENC is MIME type used for encrypted WASM layers.
+pub const MEDIA_TYPE_WASM_ENC: &str = "application/vnd.wasm.content.layer.v1+wasm+encrypted";


### PR DESCRIPTION
## Summary

Add support for WASM layers in OCI images. WASM layers use the `application/vnd.wasm.content.layer.v1+wasm` media type and are stored uncompressed as a single `module.wasm` binary (not a tar archive), so they must be written raw instead of tar-unpacked.

Depends on https://github.com/containers/ocicrypt/pull/147 (merged as https://github.com/containers/ocicrypt/commit/c7acda4f5ecfec23a943715b228560989e91cf2d), which added the WASM media type constants to the golang library of ocicrypt spec.

## Tests

- Unit tests for media type detection, compression mapping, decrypt mapping, and raw write path
- Integration tests pulling `docker.io/rodneydav/wasm-adoption:latest` (plain) and `:encrypted` (encrypted layer detection)