### PR TITLE
api-server-rest: remove global Mutex on Router

### DIFF
--- a/api-server-rest/src/main.rs
+++ b/api-server-rest/src/main.rs
@@ -89,7 +89,7 @@ async fn main() -> Result<()> {
     };
     let router = Router::new(aa_client, cdh_client, args.features);
 
-    let router = Arc::new(tokio::sync::Mutex::new(router));
+    let router = Arc::new(router);
 
     let api_service = make_service_fn(|conn: &AddrStream| {
         let remote_addr = conn.remote_addr();
@@ -98,7 +98,7 @@ async fn main() -> Result<()> {
         async move {
             Ok::<_, GenericError>(service_fn(move |req| {
                 let local_router = local_router.clone();
-                async move { local_router.lock().await.route(remote_addr, req).await }
+                async move { local_router.route(remote_addr, req).await }
             }))
         }
     });

--- a/api-server-rest/src/router.rs
+++ b/api-server-rest/src/router.rs
@@ -94,7 +94,7 @@ impl Router {
     }
 
     pub async fn route(
-        &mut self,
+        &self,
         remote_addr: SocketAddr,
         req: Request<Body>,
     ) -> Result<Response<Body>> {


### PR DESCRIPTION
## Summary

`main.rs` wraps Router in `Arc<tokio::sync::Mutex<Router>>`. Every request
must acquire this lock and holds it for the duration of `route()`, including
ttrpc I/O. This serializes all requests — even those targeting different
backends such as `/aa` and `/cdh`.

The fix is straightforward: `route()` performs no mutation (it only reads
fields and delegates to `&self` methods), so change `&mut self` to `&self`
and replace `Arc<Mutex<Router>>` with `Arc<Router>`.

## Why not RwLock?

The Router is initialized once at startup and never modified thereafter.
No routes are added or removed at runtime, so no synchronization is needed.
`Arc` alone suffices for shared read-only access. `RwLock` would introduce
per-read acquire/release overhead with no corresponding benefit.

`AAClient` and `CDHClient` already manage their own internal concurrency
via `RwLock` in `CachedTtrpcClient`; the outer Mutex was an oversight.