### PR TITLE
workflows: allow manually triggering secret-cli workflow

### DIFF
--- a/.github/workflows/secret_cli_release.yml
+++ b/.github/workflows/secret_cli_release.yml
@@ -4,6 +4,11 @@ on:
   release:
     types: [published]
   pull_request:
+  workflow_dispatch:
+    inputs:
+      tag:
+        required: true
+        type: string
 
 permissions:
   contents: read
@@ -12,9 +17,9 @@ jobs:
   build-and-upload:
     permissions:
       # Write scopes are only exercised by the release-only upload/publish
-      # steps below (gated on github.event_name == 'release'). On pull_request
-      # the job just builds the binary to catch breakage early; fork PRs get a
-      # read-only token regardless of what is requested here.
+      # steps below (gated on env.IS_PUBLISH). On pull_request the job just
+      # builds the binary to catch breakage early; fork PRs get a read-only
+      # token regardless of what is requested here.
       contents: write
       packages: write
     strategy:
@@ -35,6 +40,8 @@ jobs:
       CLI_FEATURES: cli,aliyun,aws,kbs
       REGISTRY: ghcr.io
       IMAGE_NAME: ${{ github.repository }}
+      IS_PUBLISH: ${{ github.event_name == 'release' || github.event_name == 'workflow_dispatch' }}
+      TAG: ${{ github.event.release.tag_name || inputs.tag }}
     steps:
     - name: Harden the runner (Audit all outbound calls)
       uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
@@ -42,7 +49,7 @@ jobs:
         egress-policy: audit
 
     - name: Log in to the Container registry
-      if: github.event_name == 'release'
+      if: env.IS_PUBLISH == 'true'
       uses: docker/login-action@371161bbe7024a29a25c5e19bfcbc0804fe9ad2c # v4.5.2
       with:
         registry: ${{ env.REGISTRY }}
@@ -50,13 +57,14 @@ jobs:
         password: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Set up ORAS
-      if: github.event_name == 'release'
+      if: env.IS_PUBLISH == 'true'
       uses: oras-project/setup-oras@1d808f7d7f6995cc68b7bf507bfe5c5446e1dc9d # v2.0.1
       with:
         version: 1.2.0
 
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
+        ref: ${{ inputs.tag || github.ref }}
         persist-credentials: false
 
     - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
@@ -88,7 +96,7 @@ jobs:
           --features "$CLI_FEATURES"
 
     - name: Package artifact
-      if: github.event_name == 'release'
+      if: env.IS_PUBLISH == 'true'
       id: package
       run: |
         name="secret-${RUST_TARGET}"
@@ -99,19 +107,17 @@ jobs:
         echo "asset=${name}.tar.gz" >> "$GITHUB_OUTPUT"
 
     - name: Upload release assets
-      if: github.event_name == 'release'
+      if: env.IS_PUBLISH == 'true'
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        TAG: ${{ github.event.release.tag_name }}
         ASSET: ${{ steps.package.outputs.asset }}
       run: |
         gh release upload "$TAG" "$ASSET" "${ASSET}.sha256" \
           --repo "$GITHUB_REPOSITORY" --clobber
 
     - name: Publish with ORAS
-      if: github.event_name == 'release'
+      if: env.IS_PUBLISH == 'true'
       env:
-        TAG: ${{ github.event.release.tag_name }}
         ASSET: ${{ steps.package.outputs.asset }}
       run: |
         image="${REGISTRY}/${IMAGE_NAME}/secret_cli"


### PR DESCRIPTION
This will allow us to trigger the release flow manually from GH. This way we don't have to wait for the next release to trigger the workflow.