### PR TITLE
coco-extension: build in pinned containers and ship 24.04 + 26.04 variants

### DIFF
--- a/.github/actions/install-nvat-sdk/action.yml
+++ b/.github/actions/install-nvat-sdk/action.yml
@@ -3,9 +3,12 @@ description: Build and install the NVIDIA Attestation SDK from source (x86_64 on
 
 inputs:
   version:
-    description: NVAT SDK version tag to checkout
+    description: >
+      NVAT SDK version tag to checkout. Defaults to the tag the
+      nv-attestation-sdk crate is pinned to, so the C++ library and the Rust
+      bindings that link it cannot drift apart.
     required: false
-    default: "2026.03.02"
+    default: ""
 
 runs:
   using: composite
@@ -15,13 +18,26 @@ runs:
       shell: bash
       env:
         NVAT_VERSION: ${{ inputs.version }}
+        CARGO_MANIFEST: ${{ github.workspace }}/attestation-agent/attester/Cargo.toml
       run: |
         export RUSTFLAGS=""
+
+        if [ -z "${NVAT_VERSION}" ]; then
+          NVAT_VERSION="$(sed -n \
+            's/^nv-attestation-sdk[[:space:]]*=.*tag[[:space:]]*=[[:space:]]*"\([^"]*\)".*/\1/p' \
+            "${CARGO_MANIFEST}")"
+          [ -n "${NVAT_VERSION}" ] || {
+            echo "failed to read the nv-attestation-sdk tag from ${CARGO_MANIFEST}" >&2
+            exit 1
+          }
+        fi
+        echo "Using NVIDIA Attestation SDK ${NVAT_VERSION}"
+
         sudo apt-get update
         sudo apt-get install -y --no-install-recommends \
           build-essential clang cmake pkg-config libclang-dev \
           libcurl4-openssl-dev libssl-dev libxml2-dev \
-          libxmlsec1-dev libxmlsec1-openssl
+          libxmlsec1-dev zlib1g-dev
 
         tmpdir="$(mktemp -d)"
         git clone --depth=1 --branch "${NVAT_VERSION}" \

--- a/.github/workflows/coco-extension-image.yml
+++ b/.github/workflows/coco-extension-image.yml
@@ -40,8 +40,10 @@ env:
   # stops baking pause into the coco extension.
   PAUSE_IMAGE_REPO: docker://registry.k8s.io/pause
   PAUSE_IMAGE_VERSION: "3.10"
-  NVAT_VERSION: "2026.03.02"
   UMOCI_VERSION: v0.6.0
+  # The C++ SDK is linked by the Rust bindings, so the two have to be the same
+  # release; the crate pin below is the single source of truth for both.
+  NVAT_CARGO_MANIFEST: attestation-agent/attester/Cargo.toml
 
 jobs:
   build:
@@ -115,9 +117,17 @@ jobs:
     - name: Install NVIDIA Attestation SDK
       if: ${{ matrix.arch == 'x86_64' }}
       run: |
+        nvat_version="$(sed -n \
+          's/^nv-attestation-sdk[[:space:]]*=.*tag[[:space:]]*=[[:space:]]*"\([^"]*\)".*/\1/p' \
+          "${NVAT_CARGO_MANIFEST}")"
+        [ -n "${nvat_version}" ] || {
+          echo "failed to read the nv-attestation-sdk tag from ${NVAT_CARGO_MANIFEST}" >&2
+          exit 1
+        }
+
         tmpdir="$(mktemp -d)"
         git clone https://github.com/NVIDIA/attestation-sdk "${tmpdir}/attestation-sdk"
-        git -C "${tmpdir}/attestation-sdk" fetch --depth=1 origin "${NVAT_VERSION}"
+        git -C "${tmpdir}/attestation-sdk" fetch --depth=1 origin "${nvat_version}"
         git -C "${tmpdir}/attestation-sdk" checkout FETCH_HEAD
         cmake -S "${tmpdir}/attestation-sdk/nv-attestation-sdk-cpp" \
           -B "${tmpdir}/attestation-sdk/nv-attestation-sdk-cpp/build" \

--- a/.github/workflows/coco-extension-image.yml
+++ b/.github/workflows/coco-extension-image.yml
@@ -8,6 +8,13 @@ name: Build and publish the CoCo guest extension image
 #   * an EROFS + dm-verity disk image (+ its dm-verity root hash), using the
 #     same layout as kata's rootfs-image-coco-extension asset.
 #
+# The payload is built inside a pinned Ubuntu container
+# (tools/coco-extension/Dockerfile.builder) rather than directly on the runner,
+# so the binaries match the guest rootfs ABI regardless of the runner image.
+# One variant is published per supported guest release, and every tag and
+# release asset is qualified with it (e.g. "<sha>-ubuntu26.04-amd64"): the
+# extension ships no libc, so a variant is only usable on a matching guest.
+#
 # On pull requests everything is built and uploaded as workflow artifacts (no
 # registry push). On pushes to main the artifacts are published to ghcr.io
 # (tagged with the commit sha and "latest") and attested. On a published
@@ -32,6 +39,8 @@ env:
   CONTAINER_IMAGE: ghcr.io/${{ github.repository }}/coco-extension
   # EROFS + dm-verity disk image flavour.
   DISK_IMAGE: ghcr.io/${{ github.repository }}/coco-extension-disk
+  # Cache for the build environments, keyed by a digest of the recipe.
+  BUILDER_IMAGE: ghcr.io/${{ github.repository }}/coco-extension-builder
   # Pause image bundled into the extension (kept in sync with kata versions.yaml).
   # This is transitional: we still unpack registry.k8s.io/pause into pause_bundle/
   # because kata's rootfs-image-coco-extension asset and components.toml contract
@@ -47,7 +56,7 @@ env:
 
 jobs:
   build:
-    name: build (${{ matrix.arch }})
+    name: build (${{ matrix.arch }}, ubuntu ${{ matrix.ubuntu }})
     permissions:
       contents: write # needed to upload disk images to the GitHub release
       packages: write
@@ -56,6 +65,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # Guest releases we publish an extension for. The per-arch entries below
+        # apply to every variant.
+        ubuntu:
+        - "24.04"
+        - "26.04"
+        arch:
+        - x86_64
+        - aarch64
+        - s390x
         include:
         - arch: x86_64
           oci_arch: amd64
@@ -79,7 +97,8 @@ jobs:
       ATTESTER: ${{ matrix.attester }}
       # "kbs" enables cc_kbc, the KBS resource provider used on every arch.
       RESOURCE_PROVIDER: kbs
-      RUST_TARGET: ${{ matrix.arch }}-unknown-linux-${{ matrix.libc }}
+      UBUNTU_VERSION: ${{ matrix.ubuntu }}
+      VARIANT: ubuntu${{ matrix.ubuntu }}
     steps:
     - name: Harden the runner (Audit all outbound calls)
       uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
@@ -90,66 +109,87 @@ jobs:
       with:
         persist-credentials: false
 
-    - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
+    # Logging in up front lets the builder cache below be reused; the payload
+    # images are pushed by the later steps with the same credentials.
+    - name: Log in to the Container registry
+      if: ${{ github.event_name != 'pull_request' }}
+      uses: docker/login-action@371161bbe7024a29a25c5e19bfcbc0804fe9ad2c # v4.5.2
       with:
-        target: ${{ env.RUST_TARGET }}
-        cache: false
-        # This action injects RUSTFLAGS="-D warnings" by default, which leaks
-        # into every cargo invocation in the job — including third-party crates
-        # built from source by the NVIDIA Attestation SDK (its vendored regorus
-        # fails on the mismatched_lifetime_syntaxes lint) and our own component
-        # build. We only want to build here, not gate on warnings, so clear it.
-        rustflags: ""
+        registry: ${{ env.REGISTRY }}
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
 
-    - name: Install build tooling
+    - name: Install host tooling for EROFS packaging
       run: |
         sudo apt-get update
         sudo apt-get install -y --no-install-recommends \
-          build-essential clang cmake pkg-config protobuf-compiler \
-          libssl-dev libtss2-dev libdevmapper-dev musl-tools \
-          cryptsetup-bin erofs-utils libclang-dev libxml2-dev parted skopeo zlib1g-dev
-        # umoci is used to unpack the pause image into an OCI runtime bundle.
-        # Prebuilt binaries exist for every architecture in the matrix.
-        sudo curl -fsSL -o /usr/local/bin/umoci \
-          "https://github.com/opencontainers/umoci/releases/download/${UMOCI_VERSION}/umoci.linux.${{ matrix.oci_arch }}"
-        sudo chmod +x /usr/local/bin/umoci
+          cryptsetup-bin erofs-utils parted
 
-    - name: Install NVIDIA Attestation SDK
-      if: ${{ matrix.arch == 'x86_64' }}
+    - name: Build or reuse the Ubuntu ${{ matrix.ubuntu }} builder image
       run: |
-        nvat_version="$(sed -n \
-          's/^nv-attestation-sdk[[:space:]]*=.*tag[[:space:]]*=[[:space:]]*"\([^"]*\)".*/\1/p' \
-          "${NVAT_CARGO_MANIFEST}")"
-        [ -n "${nvat_version}" ] || {
-          echo "failed to read the nv-attestation-sdk tag from ${NVAT_CARGO_MANIFEST}" >&2
-          exit 1
-        }
+        rust_toolchain="$(sed -n 's/^channel = "\(.*\)"/\1/p' rust-toolchain.toml)"
+        # The NVIDIA SDK is only consumed by the x86_64 attestation-agent-nv
+        # variant; an empty version skips it entirely.
+        nvat_version=""
+        if [ "${ARCH}" = "x86_64" ]; then
+          nvat_version="$(sed -n \
+            's/^nv-attestation-sdk[[:space:]]*=.*tag[[:space:]]*=[[:space:]]*"\([^"]*\)".*/\1/p' \
+            "${NVAT_CARGO_MANIFEST}")"
+          [ -n "${nvat_version}" ] || {
+            echo "failed to read the nv-attestation-sdk tag from ${NVAT_CARGO_MANIFEST}" >&2
+            exit 1
+          }
+        fi
 
-        tmpdir="$(mktemp -d)"
-        git clone https://github.com/NVIDIA/attestation-sdk "${tmpdir}/attestation-sdk"
-        git -C "${tmpdir}/attestation-sdk" fetch --depth=1 origin "${nvat_version}"
-        git -C "${tmpdir}/attestation-sdk" checkout FETCH_HEAD
-        cmake -S "${tmpdir}/attestation-sdk/nv-attestation-sdk-cpp" \
-          -B "${tmpdir}/attestation-sdk/nv-attestation-sdk-cpp/build" \
-          -DCMAKE_BUILD_TYPE=Release
-        cmake --build "${tmpdir}/attestation-sdk/nv-attestation-sdk-cpp/build" --parallel "$(nproc)"
-        sudo cmake --install "${tmpdir}/attestation-sdk/nv-attestation-sdk-cpp/build"
-        # The nv-attestation-sdk-sys build script looks for the C header at
-        # /usr/include/nvat.h, but cmake installs it under /usr/local/include.
-        # Symlink it (matches kata's coco-guest-components builder).
-        sudo mkdir -p /usr/include
-        sudo ln -sf /usr/local/include/nvat.h /usr/include/nvat.h
-        sudo ldconfig
-        rm -rf "${tmpdir}"
+        # Building the environment (notably the NVIDIA SDK) costs more than
+        # building the payload itself, so reuse a published one whenever the
+        # recipe and its pinned versions are unchanged.
+        cache_key="$( { cat tools/coco-extension/Dockerfile.builder; \
+                        echo "${UBUNTU_VERSION} ${rust_toolchain} ${UMOCI_VERSION} ${nvat_version}"; \
+                      } | sha256sum | cut -c1-12)"
+        builder="${BUILDER_IMAGE}:${VARIANT}-${{ matrix.oci_arch }}-${cache_key}"
+        echo "BUILDER=${builder}" >> "${GITHUB_ENV}"
+
+        # A miss is expected on pull requests, which cannot authenticate to pull.
+        if docker pull "${builder}"; then
+          exit 0
+        fi
+
+        docker build \
+          -f tools/coco-extension/Dockerfile.builder \
+          --build-arg "UBUNTU_VERSION=${UBUNTU_VERSION}" \
+          --build-arg "RUST_TOOLCHAIN=${rust_toolchain}" \
+          --build-arg "UMOCI_VERSION=${UMOCI_VERSION}" \
+          --build-arg "TARGETARCH=${{ matrix.oci_arch }}" \
+          --build-arg "NVAT_VERSION=${nvat_version}" \
+          -t "${builder}" \
+          tools/coco-extension
+
+        if [ "${{ github.event_name }}" != "pull_request" ]; then
+          docker push "${builder}"
+        fi
 
     - name: Assemble extension rootfs
-      run: ./tools/coco-extension/assemble-rootfs.sh
+      run: |
+        docker run --rm \
+          -v "${GITHUB_WORKSPACE}:${GITHUB_WORKSPACE}" \
+          -w "${GITHUB_WORKSPACE}" \
+          -e ARCH \
+          -e LIBC \
+          -e ATTESTER \
+          -e RESOURCE_PROVIDER \
+          -e PAUSE_IMAGE_REPO \
+          -e PAUSE_IMAGE_VERSION \
+          -e HOME=/tmp \
+          --user "$(id -u):$(id -g)" \
+          "${BUILDER}" \
+          ./tools/coco-extension/assemble-rootfs.sh
 
     - name: Build OCI container image
       run: |
         docker build \
           -f tools/coco-extension/Dockerfile \
-          -t "${CONTAINER_IMAGE}:${{ github.sha }}-${{ matrix.oci_arch }}" \
+          -t "${CONTAINER_IMAGE}:${{ github.sha }}-${VARIANT}-${{ matrix.oci_arch }}" \
           build/coco-extension-rootfs
 
     - name: Build EROFS + dm-verity disk image
@@ -160,36 +200,28 @@ jobs:
       if: ${{ github.event_name == 'pull_request' }}
       run: |
         mkdir -p build/artifacts
-        docker save "${CONTAINER_IMAGE}:${{ github.sha }}-${{ matrix.oci_arch }}" \
-          -o "build/artifacts/coco-extension-oci-${{ matrix.oci_arch }}.tar"
+        docker save "${CONTAINER_IMAGE}:${{ github.sha }}-${VARIANT}-${{ matrix.oci_arch }}" \
+          -o "build/artifacts/coco-extension-oci-${VARIANT}-${{ matrix.oci_arch }}.tar"
         cp build/coco-extension-image/kata-containers-coco-extension.img \
-          "build/artifacts/kata-containers-coco-extension-${{ matrix.oci_arch }}.img"
+          "build/artifacts/kata-containers-coco-extension-${VARIANT}-${{ matrix.oci_arch }}.img"
         if [ -f build/coco-extension-image/root_hash_coco-extension.txt ]; then
           cp build/coco-extension-image/root_hash_coco-extension.txt \
-            "build/artifacts/root_hash_coco-extension-${{ matrix.oci_arch }}.txt"
+            "build/artifacts/root_hash_coco-extension-${VARIANT}-${{ matrix.oci_arch }}.txt"
         fi
 
     - name: Upload artifacts
       if: ${{ github.event_name == 'pull_request' }}
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
-        name: coco-extension-${{ matrix.oci_arch }}
+        name: coco-extension-ubuntu${{ matrix.ubuntu }}-${{ matrix.oci_arch }}
         path: build/artifacts/
         retention-days: 15
         if-no-files-found: error
 
     # --- Push to main / release: publish to ghcr.io and attest ----------------
-    # The immutable per-arch reference is always "<sha>-<arch>"; the friendly
-    # tags (latest, or the release version) are assembled into multi-arch
-    # manifests in the publish-manifests job below.
-    - name: Log in to the Container registry
-      if: ${{ github.event_name != 'pull_request' }}
-      uses: docker/login-action@371161bbe7024a29a25c5e19bfcbc0804fe9ad2c # v4.5.2
-      with:
-        registry: ${{ env.REGISTRY }}
-        username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
-
+    # The immutable per-arch reference is always "<sha>-<variant>-<arch>"; the
+    # friendly tags (latest, or the release version) are assembled into
+    # per-variant multi-arch manifests in the publish-manifests job below.
     - uses: oras-project/setup-oras@1d808f7d7f6995cc68b7bf507bfe5c5446e1dc9d # v2.0.1
       if: ${{ github.event_name != 'pull_request' }}
       with:
@@ -199,7 +231,7 @@ jobs:
       id: publish-container
       if: ${{ github.event_name != 'pull_request' }}
       run: |
-        arch_tag="${{ github.sha }}-${{ matrix.oci_arch }}"
+        arch_tag="${{ github.sha }}-${VARIANT}-${{ matrix.oci_arch }}"
         docker push "${CONTAINER_IMAGE}:${arch_tag}"
         digest="$(docker inspect --format='{{index .RepoDigests 0}}' "${CONTAINER_IMAGE}:${arch_tag}" | cut -d'@' -f2)"
         echo "image=${CONTAINER_IMAGE}" >> "$GITHUB_OUTPUT"
@@ -210,7 +242,7 @@ jobs:
       if: ${{ github.event_name != 'pull_request' }}
       working-directory: build/coco-extension-image
       run: |
-        arch_tag="${{ github.sha }}-${{ matrix.oci_arch }}"
+        arch_tag="${{ github.sha }}-${VARIANT}-${{ matrix.oci_arch }}"
         files=(kata-containers-coco-extension.img)
         if [ -f root_hash_coco-extension.txt ]; then
           files+=(root_hash_coco-extension.txt)
@@ -247,23 +279,31 @@ jobs:
       working-directory: build/coco-extension-image
       run: |
         cp kata-containers-coco-extension.img \
-          "kata-containers-coco-extension-${{ matrix.oci_arch }}.img"
-        assets=("kata-containers-coco-extension-${{ matrix.oci_arch }}.img")
+          "kata-containers-coco-extension-${VARIANT}-${{ matrix.oci_arch }}.img"
+        assets=("kata-containers-coco-extension-${VARIANT}-${{ matrix.oci_arch }}.img")
         if [ -f root_hash_coco-extension.txt ]; then
           cp root_hash_coco-extension.txt \
-            "root_hash_coco-extension-${{ matrix.oci_arch }}.txt"
-          assets+=("root_hash_coco-extension-${{ matrix.oci_arch }}.txt")
+            "root_hash_coco-extension-${VARIANT}-${{ matrix.oci_arch }}.txt"
+          assets+=("root_hash_coco-extension-${VARIANT}-${{ matrix.oci_arch }}.txt")
         fi
         gh release upload "${RELEASE_TAG}" "${assets[@]}" --clobber
 
   publish-manifests:
-    name: publish multi-arch manifests
+    name: publish multi-arch manifests (ubuntu ${{ matrix.ubuntu }})
     if: ${{ github.event_name != 'pull_request' }}
     needs: build
     permissions:
       contents: read
       packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        ubuntu:
+        - "24.04"
+        - "26.04"
     runs-on: ubuntu-24.04
+    env:
+      VARIANT: ubuntu${{ matrix.ubuntu }}
     steps:
     - name: Harden the runner (Audit all outbound calls)
       uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
@@ -285,14 +325,14 @@ jobs:
         EXTRA_TAG: ${{ github.event_name == 'release' && github.event.release.tag_name || 'latest' }}
       run: |
         for image in "${CONTAINER_IMAGE}" "${DISK_IMAGE}"; do
-          for tag in "${{ github.sha }}" "${EXTRA_TAG}"; do
+          for tag in "${{ github.sha }}-${VARIANT}" "${EXTRA_TAG}-${VARIANT}"; do
             docker manifest create "${image}:${tag}" \
-              --amend "${image}:${{ github.sha }}-amd64" \
-              --amend "${image}:${{ github.sha }}-arm64" \
-              --amend "${image}:${{ github.sha }}-s390x"
-            docker manifest annotate --arch amd64 --os linux "${image}:${tag}" "${image}:${{ github.sha }}-amd64"
-            docker manifest annotate --arch arm64 --os linux "${image}:${tag}" "${image}:${{ github.sha }}-arm64"
-            docker manifest annotate --arch s390x --os linux "${image}:${tag}" "${image}:${{ github.sha }}-s390x"
+              --amend "${image}:${{ github.sha }}-${VARIANT}-amd64" \
+              --amend "${image}:${{ github.sha }}-${VARIANT}-arm64" \
+              --amend "${image}:${{ github.sha }}-${VARIANT}-s390x"
+            docker manifest annotate --arch amd64 --os linux "${image}:${tag}" "${image}:${{ github.sha }}-${VARIANT}-amd64"
+            docker manifest annotate --arch arm64 --os linux "${image}:${tag}" "${image}:${{ github.sha }}-${VARIANT}-arm64"
+            docker manifest annotate --arch s390x --os linux "${image}:${tag}" "${image}:${{ github.sha }}-${VARIANT}-s390x"
             docker manifest push "${image}:${tag}"
           done
         done

--- a/tools/coco-extension/Dockerfile.builder
+++ b/tools/coco-extension/Dockerfile.builder
@@ -1,0 +1,97 @@
+# Copyright (c) 2026 Confidential Containers contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Build environment for the CoCo guest extension payload, used by
+# assemble-rootfs.sh.
+#
+# The extension ships no libc of its own, so the gnu-linked binaries and the
+# bundled cryptsetup must be produced against the same Ubuntu release as the
+# guest rootfs they are mounted into. UBUNTU_VERSION selects that release, so
+# one recipe covers every variant we publish. Mirrors kata-containers'
+# coco-guest-components static-build Dockerfile.
+ARG UBUNTU_VERSION=26.04
+FROM ubuntu:${UBUNTU_VERSION}
+
+ARG RUST_TOOLCHAIN
+ARG UMOCI_VERSION=v0.6.0
+ARG TARGETARCH
+
+ENV DEBIAN_FRONTEND=noninteractive
+ENV RUSTUP_HOME=/opt/rustup
+ENV CARGO_HOME=/opt/cargo
+ENV PATH="/opt/cargo/bin:${PATH}"
+ENV LIBC=gnu
+
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+RUN mkdir -p "${RUSTUP_HOME}" "${CARGO_HOME}"
+
+RUN apt-get update && \
+	apt-get install -y --no-install-recommends \
+		binutils \
+		ca-certificates \
+		clang \
+		cmake \
+		cryptsetup-bin \
+		curl \
+		g++ \
+		gcc \
+		git \
+		libclang-dev \
+		libdevmapper-dev \
+		libssl-dev \
+		libtss2-dev \
+		make \
+		musl-tools \
+		openssl \
+		perl \
+		pkg-config \
+		protobuf-compiler \
+		skopeo && \
+	apt-get clean && rm -rf /var/lib/apt/lists/* && \
+	curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | \
+		sh -s -- -y --default-toolchain "${RUST_TOOLCHAIN}" && \
+	curl -fsSL -o /usr/local/bin/umoci \
+		"https://github.com/opencontainers/umoci/releases/download/${UMOCI_VERSION}/umoci.linux.${TARGETARCH}" && \
+	chmod +x /usr/local/bin/umoci
+
+# nv-attestation-sdk-sys looks for the C header at /usr/include/nvat.h, but
+# cmake installs it under /usr/local/include, hence the symlink below.
+ARG NVAT_VERSION
+RUN if [ "$(uname -m)" = "x86_64" ] && [ -n "${NVAT_VERSION}" ]; then \
+	apt-get update && \
+	apt-get install -y --no-install-recommends \
+		build-essential \
+		libcurl4-openssl-dev \
+		libxml2-dev \
+		libxmlsec1-dev \
+		zlib1g-dev && \
+	tmpdir="$(mktemp -d)" && \
+	git clone https://github.com/NVIDIA/attestation-sdk "${tmpdir}/attestation-sdk" && \
+	git -C "${tmpdir}/attestation-sdk" fetch --depth=1 origin "${NVAT_VERSION}" && \
+	git -C "${tmpdir}/attestation-sdk" checkout FETCH_HEAD && \
+	cmake -S "${tmpdir}/attestation-sdk/nv-attestation-sdk-cpp" \
+		-B "${tmpdir}/attestation-sdk/nv-attestation-sdk-cpp/build" \
+		-DCMAKE_BUILD_TYPE=Release && \
+	cmake --build "${tmpdir}/attestation-sdk/nv-attestation-sdk-cpp/build" --parallel "$(nproc)" && \
+	cmake --install "${tmpdir}/attestation-sdk/nv-attestation-sdk-cpp/build" && \
+	mkdir -p /usr/include && \
+	ln -sf /usr/local/include/nvat.h /usr/include/nvat.h && \
+	ldconfig && \
+	rm -rf "${tmpdir}" && \
+	apt-get clean && rm -rf /var/lib/apt/lists/*; \
+	fi
+
+RUN ARCH="$(uname -m)"; \
+	rust_arch=""; \
+	case "${ARCH}" in \
+		aarch64|x86_64|s390x) rust_arch="${ARCH}" ;; \
+		ppc64le) rust_arch="powerpc64le" ;; \
+		*) echo "Unsupported architecture: ${ARCH}" >&2; exit 1 ;; \
+	esac; \
+	rustup target add "${rust_arch}-unknown-linux-${LIBC}"
+
+# assemble-rootfs.sh runs as the invoking uid so the build artefacts stay
+# writable on the host bind mount; that uid still needs the toolchain.
+RUN chmod -R a+rwX "${RUSTUP_HOME}" "${CARGO_HOME}"

--- a/tools/coco-extension/assemble-rootfs.sh
+++ b/tools/coco-extension/assemble-rootfs.sh
@@ -12,6 +12,10 @@
 #   * packed into a "FROM scratch" OCI container image (see Dockerfile), and
 #   * turned into an EROFS + dm-verity disk image (see build-erofs-image.sh).
 #
+# The binaries and the bundled cryptsetup are linked against the host's glibc,
+# and the extension ships no libc of its own, so this script is meant to run
+# inside the builder image (Dockerfile.builder) rather than on the CI runner.
+#
 # The layout mirrors what kata-containers' kata-deploy-binaries.sh
 # (install_image_coco_extension) produces, so the resulting image is a drop-in
 # for kata's own rootfs-image-coco-extension asset:


### PR DESCRIPTION
The extension ships gnu-linked binaries and a cryptsetup binary but no libc of
its own, so its ABI is dictated by whatever userspace it was built on. Until now
that was the GitHub runner image, which tied the payload to Ubuntu 24.04 and made
the guest ABI an implicit side effect of a runner label. Bumping the guest to
26.04 was therefore not expressible without also moving CI infrastructure.

The Ubuntu release is now an explicit build argument of a builder image, and a
matrix axis, so one variant is published per supported guest release. Kata still
pins a 24.04 guest rootfs, so both are built until it moves. Runners keep their
current ubuntu-24.04 label and only need the tooling to turn the assembled rootfs
into the EROFS + dm-verity disk image.

Building the environment costs more than building the payload does, mostly the
NVIDIA SDK compile, so builder images are cached in ghcr.io under a digest of the
recipe and its pinned versions. Pull requests cannot authenticate to pull one and
fall back to building it, as they did before.

The first commit is a prerequisite: a62c7537 bumped the nv-attestation-sdk crate
to the 2026.06.09 tag, but the version CI compiles the C++ SDK from stayed at
2026.03.02, in both the coco-extension workflow and the install-nvat-sdk action.
Since these builds link the system libnvat, the bindings and the library they
bind to have been a release apart ever since. 2026.03.02 additionally fails to
compile against libxml2 2.12+, which 26.04 carries, so the 26.04 variant cannot
be built without this.

**Note: This is a preparation for switching Kata Containers rootfses images to
Ubuntu 26.04.**

## Breaking change

A variant is only usable on a matching guest, so there is no longer an
unqualified image to pull. Every tag and release asset now carries the variant,
and the tags that omitted it are gone:

| before | after |
| --- | --- |
| `<sha>-amd64` | `<sha>-ubuntu24.04-amd64` |
| `latest`, `<version>` | `latest-ubuntu24.04`, `<version>-ubuntu24.04` |
| `kata-containers-coco-extension-<arch>.img` | `kata-containers-coco-extension-ubuntu24.04-<arch>.img` |

Consumers must name the guest release they are targeting. Kata should keep
consuming the ubuntu24.04 variant until its rootfs moves, then switch tags.

## Alternatives considered

Keeping the unqualified tags as an alias for 24.04 would avoid the break, but it
makes the ABI contract invisible again: pulling `latest` onto a 26.04 guest would
silently produce a mismatch rather than a missing tag. Making the variant explicit
trades a one-time update for a failure mode that is obvious.

Moving the runners to ubuntu-26.04 instead was rejected because the runner image
is not the right knob: it would still leave the guest ABI implicit, and it cannot
express two variants at once.