### PR TITLE
ci: fix zizmor auditor-level findings and upgrade persona to auditor

### DIFF
--- a/.github/workflows/aa_basic.yml
+++ b/.github/workflows/aa_basic.yml
@@ -22,6 +22,8 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+permissions: {}
+
 jobs:
   basic_ci:
     permissions:
@@ -94,12 +96,14 @@ jobs:
         if: matrix.instance == 'ubuntu-24.04'
 
       - name: Run cargo test
+        env:
+          CARGO_TEST_OPTS: ${{ matrix.cargo_test_opts }}
         run: |
-          sudo -E PATH=$PATH -s cargo test ${{ matrix.cargo_test_opts }} -p attestation-agent -p attester -p coco_keyprovider -p kbc -p kbs_protocol -p crypto -p resource_uri
+          sudo -E PATH=${PATH} -s cargo test ${CARGO_TEST_OPTS} -p attestation-agent -p attester -p coco_keyprovider -p kbc -p kbs_protocol -p crypto -p resource_uri
 
       - name: Build and test kbs_protocol pqc-experimental feature
         run: |
-          sudo -E PATH=$PATH -s cargo test -p kbs_protocol --features pqc-experimental -- pqc
+          sudo -E PATH=${PATH} -s cargo test -p kbs_protocol --features pqc-experimental -- pqc
         if: matrix.instance == 'ubuntu-24.04'
 
       - name: Run cargo fmt check
@@ -107,4 +111,4 @@ jobs:
 
       - name: Run rust lint check
         run: |
-          sudo -E PATH=$PATH -s make lint
+          sudo -E PATH=${PATH} -s make lint

--- a/.github/workflows/aa_cc_kbc.yml
+++ b/.github/workflows/aa_cc_kbc.yml
@@ -22,6 +22,8 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+permissions: {}
+
 jobs:
   cc_kbc_ci:
     permissions:
@@ -76,11 +78,17 @@ jobs:
         if: matrix.instance == 'ubuntu-24.04'
 
       - name: Build and install with ${{ matrix.attester }} feature
+        env:
+          ATTESTER: ${{ matrix.attester }}
         run: |
-          make ATTESTER=${{ matrix.attester }} && make install
+          make ATTESTER=${ATTESTER} && make install
 
       - name: Run rust lint check
-        run: cargo clippy -p kbc --all-targets --features cc_kbc,${{ matrix.attester }},rust-crypto -- -D warnings
+        env:
+          ATTESTER: ${{ matrix.attester }}
+        run: cargo clippy -p kbc --all-targets --features cc_kbc,${ATTESTER},rust-crypto -- -D warnings
 
       - name: Run cargo test
-        run: cargo test --features cc_kbc,${{ matrix.attester }},rust-crypto -p kbc
+        env:
+          ATTESTER: ${{ matrix.attester }}
+        run: cargo test --features cc_kbc,${ATTESTER},rust-crypto -p kbc

--- a/.github/workflows/aa_crypto.yml
+++ b/.github/workflows/aa_crypto.yml
@@ -18,6 +18,8 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+permissions: {}
+
 jobs:
   crypto_ci:
     permissions:
@@ -59,7 +61,11 @@ jobs:
         run: cargo fmt -p crypto -- --check
 
       - name: Run rust lint check (${{ matrix.suites }})
-        run: cargo clippy -p crypto --no-default-features --features ${{ matrix.suites }} -- -D warnings
+        env:
+          SUITES: ${{ matrix.suites }}
+        run: cargo clippy -p crypto --no-default-features --features ${SUITES} -- -D warnings
 
       - name: Run cargo test (${{ matrix.suites }})
-        run: cargo test -p crypto --no-default-features --features ${{ matrix.suites }}
+        env:
+          SUITES: ${{ matrix.suites }}
+        run: cargo test -p crypto --no-default-features --features ${SUITES}

--- a/.github/workflows/aa_release.yml
+++ b/.github/workflows/aa_release.yml
@@ -4,6 +4,10 @@ on:
   release:
     types: [published]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 permissions:
   contents: read
 
@@ -13,8 +17,9 @@ env:
 
 jobs:
   build-and-push-images:
+    name: Build and push images
     permissions:
-      packages: write
+      packages: write # push container images to ghcr.io
     strategy:
       fail-fast: false
       matrix:
@@ -57,9 +62,10 @@ jobs:
           tags: ${{ env.IMAGE }}:${{ github.sha }}-${{ matrix.platform.arch }}
 
   merge-manifests:
+    name: Merge multi-arch manifests
     needs: build-and-push-images
     permissions:
-      packages: write
+      packages: write # push multi-arch manifest to ghcr.io
     runs-on: ubuntu-24.04
     steps:
       - name: Harden the runner (Audit all outbound calls)
@@ -78,9 +84,11 @@ jobs:
           password: ${{secrets.GITHUB_TOKEN}}
 
       - name: Create and push multi-arch manifests
+        env:
+          GIT_SHA: ${{ github.sha }}
         run: |
-          for tag in "${{ github.sha }}" latest; do
+          for tag in "${GIT_SHA}" latest; do
             docker buildx imagetools create --tag "${IMAGE}:${tag}" \
-              "${IMAGE}:${{ github.sha }}-amd64" \
-              "${IMAGE}:${{ github.sha }}-arm64"
+              "${IMAGE}:${GIT_SHA}-amd64" \
+              "${IMAGE}:${GIT_SHA}-arm64"
           done

--- a/.github/workflows/aa_sample_keyprovider.yml
+++ b/.github/workflows/aa_sample_keyprovider.yml
@@ -17,6 +17,8 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+permissions: {}
+
 jobs:
   coco_keyprovider_ci:
     permissions:

--- a/.github/workflows/aa_sev_kbc.yml
+++ b/.github/workflows/aa_sev_kbc.yml
@@ -52,13 +52,19 @@ jobs:
           components: rustfmt
 
       - name: Build and install with ${{ matrix.kbc }} feature
+        env:
+          KBC: ${{ matrix.kbc }}
         run: |
           sudo apt-get update
-          make KBC=${{ matrix.kbc }} && make install
+          make KBC=${KBC} && make install
 
       - name: Musl build with ${{ matrix.kbc }} feature
+        env:
+          KBC: ${{ matrix.kbc }}
         run: |
-          make LIBC=musl KBC=${{ matrix.kbc }}
+          make LIBC=musl KBC=${KBC}
 
       - name: Run cargo test with ${{ matrix.kbc }} feature
-        run: cargo test -p kbc --no-default-features --features ${{ matrix.kbc }},rust-crypto
+        env:
+          KBC: ${{ matrix.kbc }}
+        run: cargo test -p kbc --no-default-features --features ${KBC},rust-crypto

--- a/.github/workflows/api-server-rest-basic.yml
+++ b/.github/workflows/api-server-rest-basic.yml
@@ -22,6 +22,8 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+permissions: {}
+
 jobs:
   basic_ci:
     permissions:

--- a/.github/workflows/cdh_basic.yml
+++ b/.github/workflows/cdh_basic.yml
@@ -24,6 +24,8 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+permissions: {}
+
 jobs:
   basic_ci:
     permissions:

--- a/.github/workflows/coco-extension-image.yml
+++ b/.github/workflows/coco-extension-image.yml
@@ -30,6 +30,10 @@ on:
   release:
     types: [published]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 
@@ -59,9 +63,9 @@ jobs:
     name: build (${{ matrix.arch }}, ubuntu ${{ matrix.ubuntu }})
     permissions:
       contents: write # needed to upload disk images to the GitHub release
-      packages: write
-      id-token: write
-      attestations: write
+      packages: write # push OCI artifacts to ghcr.io
+      id-token: write # required for OIDC-based attestation signing
+      attestations: write # required to create build attestations
     strategy:
       fail-fast: false
       matrix:
@@ -119,13 +123,25 @@ jobs:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
 
-    - name: Install host tooling for EROFS packaging
+    - name: Install build tooling
+      env:
+        OCI_ARCH: ${{ matrix.oci_arch }}
       run: |
         sudo apt-get update
         sudo apt-get install -y --no-install-recommends \
-          cryptsetup-bin erofs-utils parted
+          build-essential clang cmake pkg-config protobuf-compiler \
+          libssl-dev libtss2-dev libdevmapper-dev musl-tools \
+          cryptsetup-bin erofs-utils libclang-dev libxml2-dev parted skopeo zlib1g-dev
+        # umoci is used to unpack the pause image into an OCI runtime bundle.
+        # Prebuilt binaries exist for every architecture in the matrix.
+        sudo curl -fsSL -o /usr/local/bin/umoci \
+          "https://github.com/opencontainers/umoci/releases/download/${UMOCI_VERSION}/umoci.linux.${OCI_ARCH}"
+        sudo chmod +x /usr/local/bin/umoci
 
     - name: Build or reuse the Ubuntu ${{ matrix.ubuntu }} builder image
+      env:
+        OCI_ARCH: ${{ matrix.oci_arch }}
+        EVENT_NAME: ${{ github.event_name }}
       run: |
         rust_toolchain="$(sed -n 's/^channel = "\(.*\)"/\1/p' rust-toolchain.toml)"
         # The NVIDIA SDK is only consumed by the x86_64 attestation-agent-nv
@@ -147,7 +163,7 @@ jobs:
         cache_key="$( { cat tools/coco-extension/Dockerfile.builder; \
                         echo "${UBUNTU_VERSION} ${rust_toolchain} ${UMOCI_VERSION} ${nvat_version}"; \
                       } | sha256sum | cut -c1-12)"
-        builder="${BUILDER_IMAGE}:${VARIANT}-${{ matrix.oci_arch }}-${cache_key}"
+        builder="${BUILDER_IMAGE}:${VARIANT}-${OCI_ARCH}-${cache_key}"
         echo "BUILDER=${builder}" >> "${GITHUB_ENV}"
 
         # A miss is expected on pull requests, which cannot authenticate to pull.
@@ -160,12 +176,12 @@ jobs:
           --build-arg "UBUNTU_VERSION=${UBUNTU_VERSION}" \
           --build-arg "RUST_TOOLCHAIN=${rust_toolchain}" \
           --build-arg "UMOCI_VERSION=${UMOCI_VERSION}" \
-          --build-arg "TARGETARCH=${{ matrix.oci_arch }}" \
+          --build-arg "TARGETARCH=${OCI_ARCH}" \
           --build-arg "NVAT_VERSION=${nvat_version}" \
           -t "${builder}" \
           tools/coco-extension
 
-        if [ "${{ github.event_name }}" != "pull_request" ]; then
+        if [ "${EVENT_NAME}" != "pull_request" ]; then
           docker push "${builder}"
         fi
 
@@ -186,10 +202,13 @@ jobs:
           ./tools/coco-extension/assemble-rootfs.sh
 
     - name: Build OCI container image
+      env:
+        GIT_SHA: ${{ github.sha }}
+        OCI_ARCH: ${{ matrix.oci_arch }}
       run: |
         docker build \
           -f tools/coco-extension/Dockerfile \
-          -t "${CONTAINER_IMAGE}:${{ github.sha }}-${VARIANT}-${{ matrix.oci_arch }}" \
+          -t "${CONTAINER_IMAGE}:${GIT_SHA}-${VARIANT}-${OCI_ARCH}" \
           build/coco-extension-rootfs
 
     - name: Build EROFS + dm-verity disk image
@@ -198,15 +217,18 @@ jobs:
     # --- Pull request: build only, upload artifacts, no registry push ---------
     - name: Save OCI image for artifact upload
       if: ${{ github.event_name == 'pull_request' }}
+      env:
+        GIT_SHA: ${{ github.sha }}
+        OCI_ARCH: ${{ matrix.oci_arch }}
       run: |
         mkdir -p build/artifacts
-        docker save "${CONTAINER_IMAGE}:${{ github.sha }}-${VARIANT}-${{ matrix.oci_arch }}" \
-          -o "build/artifacts/coco-extension-oci-${VARIANT}-${{ matrix.oci_arch }}.tar"
+        docker save "${CONTAINER_IMAGE}:${GIT_SHA}-${VARIANT}-${OCI_ARCH}" \
+          -o "build/artifacts/coco-extension-oci-${VARIANT}-${OCI_ARCH}.tar"
         cp build/coco-extension-image/kata-containers-coco-extension.img \
-          "build/artifacts/kata-containers-coco-extension-${VARIANT}-${{ matrix.oci_arch }}.img"
+          "build/artifacts/kata-containers-coco-extension-${VARIANT}-${OCI_ARCH}.img"
         if [ -f build/coco-extension-image/root_hash_coco-extension.txt ]; then
           cp build/coco-extension-image/root_hash_coco-extension.txt \
-            "build/artifacts/root_hash_coco-extension-${VARIANT}-${{ matrix.oci_arch }}.txt"
+            "build/artifacts/root_hash_coco-extension-${VARIANT}-${OCI_ARCH}.txt"
         fi
 
     - name: Upload artifacts
@@ -230,8 +252,11 @@ jobs:
     - name: Publish OCI container image
       id: publish-container
       if: ${{ github.event_name != 'pull_request' }}
+      env:
+        GIT_SHA: ${{ github.sha }}
+        OCI_ARCH: ${{ matrix.oci_arch }}
       run: |
-        arch_tag="${{ github.sha }}-${VARIANT}-${{ matrix.oci_arch }}"
+        arch_tag="${GIT_SHA}-${VARIANT}-${OCI_ARCH}"
         docker push "${CONTAINER_IMAGE}:${arch_tag}"
         digest="$(docker inspect --format='{{index .RepoDigests 0}}' "${CONTAINER_IMAGE}:${arch_tag}" | cut -d'@' -f2)"
         echo "image=${CONTAINER_IMAGE}" >> "$GITHUB_OUTPUT"
@@ -241,8 +266,11 @@ jobs:
       id: publish-disk
       if: ${{ github.event_name != 'pull_request' }}
       working-directory: build/coco-extension-image
+      env:
+        GIT_SHA: ${{ github.sha }}
+        OCI_ARCH: ${{ matrix.oci_arch }}
       run: |
-        arch_tag="${{ github.sha }}-${VARIANT}-${{ matrix.oci_arch }}"
+        arch_tag="${GIT_SHA}-${VARIANT}-${OCI_ARCH}"
         files=(kata-containers-coco-extension.img)
         if [ -f root_hash_coco-extension.txt ]; then
           files+=(root_hash_coco-extension.txt)
@@ -276,15 +304,16 @@ jobs:
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         RELEASE_TAG: ${{ github.event.release.tag_name }}
+        OCI_ARCH: ${{ matrix.oci_arch }}
       working-directory: build/coco-extension-image
       run: |
         cp kata-containers-coco-extension.img \
-          "kata-containers-coco-extension-${VARIANT}-${{ matrix.oci_arch }}.img"
-        assets=("kata-containers-coco-extension-${VARIANT}-${{ matrix.oci_arch }}.img")
+          "kata-containers-coco-extension-${VARIANT}-${OCI_ARCH}.img"
+        assets=("kata-containers-coco-extension-${VARIANT}-${OCI_ARCH}.img")
         if [ -f root_hash_coco-extension.txt ]; then
           cp root_hash_coco-extension.txt \
-            "root_hash_coco-extension-${VARIANT}-${{ matrix.oci_arch }}.txt"
-          assets+=("root_hash_coco-extension-${VARIANT}-${{ matrix.oci_arch }}.txt")
+            "root_hash_coco-extension-${VARIANT}-${OCI_ARCH}.txt"
+          assets+=("root_hash_coco-extension-${VARIANT}-${OCI_ARCH}.txt")
         fi
         gh release upload "${RELEASE_TAG}" "${assets[@]}" --clobber
 
@@ -294,7 +323,7 @@ jobs:
     needs: build
     permissions:
       contents: read
-      packages: write
+      packages: write # push multi-arch manifests to ghcr.io
     strategy:
       fail-fast: false
       matrix:
@@ -323,16 +352,17 @@ jobs:
         # On release: the commit sha plus the immutable release version, so
         # consumers can pin to it.
         EXTRA_TAG: ${{ github.event_name == 'release' && github.event.release.tag_name || 'latest' }}
+        GIT_SHA: ${{ github.sha }}
       run: |
         for image in "${CONTAINER_IMAGE}" "${DISK_IMAGE}"; do
-          for tag in "${{ github.sha }}-${VARIANT}" "${EXTRA_TAG}-${VARIANT}"; do
+          for tag in "${GIT_SHA}-${VARIANT}" "${EXTRA_TAG}-${VARIANT}"; do
             docker manifest create "${image}:${tag}" \
-              --amend "${image}:${{ github.sha }}-${VARIANT}-amd64" \
-              --amend "${image}:${{ github.sha }}-${VARIANT}-arm64" \
-              --amend "${image}:${{ github.sha }}-${VARIANT}-s390x"
-            docker manifest annotate --arch amd64 --os linux "${image}:${tag}" "${image}:${{ github.sha }}-${VARIANT}-amd64"
-            docker manifest annotate --arch arm64 --os linux "${image}:${tag}" "${image}:${{ github.sha }}-${VARIANT}-arm64"
-            docker manifest annotate --arch s390x --os linux "${image}:${tag}" "${image}:${{ github.sha }}-${VARIANT}-s390x"
+              --amend "${image}:${GIT_SHA}-${VARIANT}-amd64" \
+              --amend "${image}:${GIT_SHA}-${VARIANT}-arm64" \
+              --amend "${image}:${GIT_SHA}-${VARIANT}-s390x"
+            docker manifest annotate --arch amd64 --os linux "${image}:${tag}" "${image}:${GIT_SHA}-${VARIANT}-amd64"
+            docker manifest annotate --arch arm64 --os linux "${image}:${tag}" "${image}:${GIT_SHA}-${VARIANT}-arm64"
+            docker manifest annotate --arch s390x --os linux "${image}:${tag}" "${image}:${GIT_SHA}-${VARIANT}-s390x"
             docker manifest push "${image}:${tag}"
           done
         done

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -20,6 +20,10 @@ on:
   schedule:
     - cron: "0 0 * * 1"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 
@@ -28,9 +32,9 @@ jobs:
     name: Analyze
     runs-on: ubuntu-latest
     permissions:
-      actions: read
+      actions: read # required for CodeQL to enumerate workflow runs
       contents: read
-      security-events: write
+      security-events: write # required to upload SARIF results to code-scanning
 
     strategy:
       fail-fast: false

--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -1,6 +1,10 @@
 name: PR Sanity Check
 on: [pull_request]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -9,11 +9,16 @@
 name: 'Dependency Review'
 on: [pull_request]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 
 jobs:
   dependency-review:
+    name: Dependency Review
     runs-on: ubuntu-latest
     steps:
       - name: Harden the runner (Audit all outbound calls)

--- a/.github/workflows/image_rs_build.yml
+++ b/.github/workflows/image_rs_build.yml
@@ -21,6 +21,8 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+permissions: {}
+
 jobs:
   ci:
     permissions:
@@ -130,7 +132,7 @@ jobs:
           sudo -E PATH=$PATH -s cargo clean
 
       - name: Run cargo test - kata-cc (native-tls version) with keywrap-ttrpc (default) + keywrap-jwe and with signatures from XRSS registry extension
-        env:
-          AUTH_PASSWORD: ${{ secrets.SH_ICR_API_KEY }}
         run: |
           sudo -E PATH=$PATH -s cargo test -p image-rs --no-default-features --features=kata-cc-native-tls,keywrap-jwe,signature-simple-xrss
+        env:
+          AUTH_PASSWORD: ${{ secrets.SH_ICR_API_KEY }} # zizmor: ignore[secrets-outside-env]

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -7,11 +7,16 @@ on:
   pull_request:
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 
 jobs:
   checklinks:
+    name: Check links
     runs-on: ubuntu-24.04
     steps:
       - name: Harden the runner (Audit all outbound calls)

--- a/.github/workflows/ocicrypt_rs_build.yml
+++ b/.github/workflows/ocicrypt_rs_build.yml
@@ -21,6 +21,8 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+permissions: {}
+
 jobs:
   ci:
     permissions:

--- a/.github/workflows/publish-artifacts.yml
+++ b/.github/workflows/publish-artifacts.yml
@@ -5,16 +5,21 @@ on:
     branches:
     - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 permissions:
   contents: read
 
 jobs:
   publish-aa:
+    name: Publish attestation-agent
     permissions:
       contents: read
-      packages: write
-      id-token: write
-      attestations: write
+      packages: write # push OCI artifacts to ghcr.io
+      id-token: write # required for OIDC-based attestation signing
+      attestations: write # required to create build attestations
     strategy:
       matrix:
         platform: [
@@ -81,28 +86,30 @@ jobs:
         ARCH: ${{ matrix.platform.arch }}
         LIBC: ${{ matrix.platform.libc }}
       run: |
-        make ./target/$RUST_TARGET/release/attestation-agent
+        make ./target/${RUST_TARGET}/release/attestation-agent
 
     - name: Publish with ORAS
       id: publish
       env:
         OCI_ARCH: ${{ matrix.platform.arch == 'x86_64' && 'amd64' || matrix.platform.arch == 'aarch64' && 'arm64' || matrix.platform.arch == 'powerpc64le' && 'ppc64le' || matrix.platform.arch }}
+        GIT_SHA: ${{ github.sha }}
+        ARCH: ${{ matrix.platform.arch }}
       run: |
         mkdir oras
         cd oras
-        cp ../target/$RUST_TARGET/release/attestation-agent .
+        cp ../target/${RUST_TARGET}/release/attestation-agent .
         tar cJf attestation-agent.tar.xz attestation-agent
-        arch="${{ matrix.platform.arch }}"
+        arch="${ARCH}"
         # After building for target powerpc64le, tag and push the image as ppc64le to match standard arch naming.
         [ "$arch" = "powerpc64le" ] && arch="ppc64le"
-        arch_tag="${{ github.sha }}-${{ matrix.platform.tee }}_${arch}"
+        arch_tag="${GIT_SHA}-${TEE_PLATFORM}_${arch}"
         image="${REGISTRY}/${IMAGE_NAME}/attestation-agent"
-        tag="${{ github.sha }}-${{ matrix.platform.tee }}"
+        tag="${GIT_SHA}-${TEE_PLATFORM}"
         oras push "${image}:${arch_tag}" attestation-agent.tar.xz
         # We need to create the platform annotations with docker, since oras 1.2 doesn't support
         # pushing with platform yet.
         docker manifest create "${image}:${tag}" --amend "${image}:${arch_tag}"
-        docker manifest annotate --arch "$OCI_ARCH" --os linux "${image}:${tag}" "${image}:${arch_tag}"
+        docker manifest annotate --arch "${OCI_ARCH}" --os linux "${image}:${tag}" "${image}:${arch_tag}"
         docker manifest push "${image}:${tag}"
         # add image and digest to output for attestation
         echo "image=${image}" >> "$GITHUB_OUTPUT"
@@ -116,11 +123,12 @@ jobs:
         push-to-registry: true
 
   publish-cdh-and-asr:
+    name: Publish CDH and api-server-rest
     permissions:
       contents: read
-      packages: write
-      id-token: write
-      attestations: write
+      packages: write # push OCI artifacts to ghcr.io
+      id-token: write # required for OIDC-based attestation signing
+      attestations: write # required to create build attestations
     strategy:
       matrix:
         arch:
@@ -173,11 +181,13 @@ jobs:
         target: ${{ env.RUST_TARGET }}
 
     - name: Install dependencies
+      env:
+        ARCH: ${{ matrix.arch }}
       run: |
         sudo apt-get update
         sudo apt-get install -y --no-install-recommends \
           libdevmapper-dev pkg-config
-        if [ "${{ matrix.arch }}" = "powerpc64le" ]; then
+        if [ "${ARCH}" = "powerpc64le" ]; then
           sudo apt-get install -y libclang-dev cmake protobuf-compiler
         fi
 
@@ -185,34 +195,37 @@ jobs:
       env:
         ARCH: ${{ matrix.arch }}
         LIBC: ${{ matrix.libc }}
-      run: make ./target/$RUST_TARGET/release/confidential-data-hub
+      run: make ./target/${RUST_TARGET}/release/confidential-data-hub
 
     - name: Build ASR
       env:
         ARCH: ${{ matrix.arch }}
         LIBC: ${{ matrix.libc }}
-      run: make ./target/$RUST_TARGET/release/api-server-rest
+      run: make ./target/${RUST_TARGET}/release/api-server-rest
 
     - name: Publish CDH + ASR with ORAS
       id: publish
+      env:
+        GIT_SHA: ${{ github.sha }}
+        ARCH: ${{ matrix.arch }}
       run: |
-        arch="${{ matrix.arch }}"
+        arch="${ARCH}"
         # After building for target powerpc64le, tag and push the image as ppc64le to match standard arch naming.
         [ "$arch" = "powerpc64le" ] && arch="ppc64le"
-        tag="${{ github.sha }}-${arch}"
+        tag="${GIT_SHA}-${arch}"
         mkdir oras
         cd oras
-        cp ../target/$RUST_TARGET/release/{confidential-data-hub,api-server-rest} .
+        cp ../target/${RUST_TARGET}/release/{confidential-data-hub,api-server-rest} .
 
         tar cJf confidential-data-hub.tar.xz confidential-data-hub
-        image="${{ env.REGISTRY }}/$IMAGE_NAME/confidential-data-hub"
+        image="${REGISTRY}/${IMAGE_NAME}/confidential-data-hub"
         oras push "${image}:${tag}" confidential-data-hub.tar.xz
         echo "cdh-image=${image}" >> "$GITHUB_OUTPUT"
         digest="$(oras manifest fetch "${image}:${tag}" --descriptor | jq -r .digest)"
         echo "cdh-digest=${digest}" >> "$GITHUB_OUTPUT"
 
         tar cJf api-server-rest.tar.xz api-server-rest
-        image="${{ env.REGISTRY }}/$IMAGE_NAME/api-server-rest"
+        image="${REGISTRY}/${IMAGE_NAME}/api-server-rest"
         oras push "${image}:${tag}" api-server-rest.tar.xz
         echo "asr-image=${image}" >> "$GITHUB_OUTPUT"
         digest="$(oras manifest fetch "${image}:${tag}" --descriptor | jq -r .digest)"

--- a/.github/workflows/rust_stable_check.yml
+++ b/.github/workflows/rust_stable_check.yml
@@ -5,11 +5,16 @@ on:
   schedule:
     - cron: '0 3 * * 6'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 permissions:
   contents: read
 
 jobs:
   clippy:
+    name: Run clippy (${{ matrix.package }})
     strategy:
       fail-fast: false
       matrix:
@@ -62,4 +67,7 @@ jobs:
         uses: ./.github/actions/install-nvat-sdk
 
       - name: Run rust lint checks (${{matrix.package}})
-        run: cargo clippy -p ${{matrix.package}} ${{matrix.feature-parameters}} -- -D warnings
+        env:
+          PACKAGE: ${{matrix.package}}
+          FEATURE_PARAMETERS: ${{matrix.feature-parameters}}
+        run: cargo clippy -p ${PACKAGE} ${FEATURE_PARAMETERS} -- -D warnings

--- a/.github/workflows/scorecard.yaml
+++ b/.github/workflows/scorecard.yaml
@@ -11,6 +11,10 @@ on:
     branches: [ "main" ]
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 permissions: {}
 
 jobs:
@@ -20,10 +24,8 @@ jobs:
     # `publish_results: true` only works when run from the default branch. conditional can be removed if disabled.
     if: github.event.repository.default_branch == github.ref_name || github.event_name == 'pull_request'
     permissions:
-      # Needed to upload the results to code-scanning dashboard.
-      security-events: write
-      # Needed to publish results and get a badge (see publish_results below).
-      id-token: write
+      security-events: write # required to upload SARIF results to code-scanning
+      id-token: write # required to publish results and get a badge
 
     steps:
       - name: Harden the runner (Audit all outbound calls)

--- a/.github/workflows/secret_cli_release.yml
+++ b/.github/workflows/secret_cli_release.yml
@@ -10,18 +10,23 @@ on:
         required: true
         type: string
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 
 jobs:
   build-and-upload:
+    name: Build and upload secret CLI
     permissions:
       # Write scopes are only exercised by the release-only upload/publish
       # steps below (gated on env.IS_PUBLISH). On pull_request the job just
       # builds the binary to catch breakage early; fork PRs get a read-only
       # token regardless of what is requested here.
-      contents: write
-      packages: write
+      contents: write # required to upload release assets via gh release upload
+      packages: write # required to publish OCI artifact to ghcr.io
     strategy:
       fail-fast: false
       matrix:
@@ -77,11 +82,13 @@ jobs:
         cache: false
 
     - name: Install dependencies
+      env:
+        LIBC: ${{ matrix.platform.libc }}
       run: |
         sudo apt-get update
         sudo apt-get install -y --no-install-recommends \
           protobuf-compiler libclang-dev cmake pkg-config
-        if [ "${{ matrix.platform.libc }}" = "musl" ]; then
+        if [ "${LIBC}" = "musl" ]; then
           sudo apt-get install -y --no-install-recommends musl-tools
         fi
 
@@ -91,18 +98,18 @@ jobs:
           -p confidential-data-hub \
           --bin secret \
           --release \
-          --target "$RUST_TARGET" \
+          --target "${RUST_TARGET}" \
           --no-default-features \
-          --features "$CLI_FEATURES"
+          --features "${CLI_FEATURES}"
 
     - name: Package artifact
       if: env.IS_PUBLISH == 'true'
       id: package
       run: |
         name="secret-${RUST_TARGET}"
-        mkdir -p "$name"
-        cp "target/${RUST_TARGET}/release/secret" "$name/"
-        tar czf "${name}.tar.gz" "$name"
+        mkdir -p "${name}"
+        cp "target/${RUST_TARGET}/release/secret" "${name}/"
+        tar czf "${name}.tar.gz" "${name}"
         sha256sum "${name}.tar.gz" > "${name}.tar.gz.sha256"
         echo "asset=${name}.tar.gz" >> "$GITHUB_OUTPUT"
 
@@ -112,8 +119,8 @@ jobs:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         ASSET: ${{ steps.package.outputs.asset }}
       run: |
-        gh release upload "$TAG" "$ASSET" "${ASSET}.sha256" \
-          --repo "$GITHUB_REPOSITORY" --clobber
+        gh release upload "${TAG}" "${ASSET}" "${ASSET}.sha256" \
+          --repo "${GITHUB_REPOSITORY}" --clobber
 
     - name: Publish with ORAS
       if: env.IS_PUBLISH == 'true'
@@ -123,4 +130,4 @@ jobs:
         image="${REGISTRY}/${IMAGE_NAME}/secret_cli"
         oras push \
           "${image}:${TAG}-${RUST_TARGET},latest-${RUST_TARGET}" \
-          "$ASSET"
+          "${ASSET}"

--- a/.github/workflows/trustee-attester.yml
+++ b/.github/workflows/trustee-attester.yml
@@ -14,6 +14,8 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+permissions: {}
+
 jobs:
   trustee_attester_ci:
     permissions:
@@ -70,13 +72,19 @@ jobs:
           sudo apt-get install -y libdevmapper-dev
 
       - name: Run cargo build
-        run: cargo build ${{ matrix.cargo_test_opts }}
+        env:
+          CARGO_TEST_OPTS: ${{ matrix.cargo_test_opts }}
+        run: cargo build ${CARGO_TEST_OPTS}
 
       - name: Run cargo test
-        run: cargo test ${{ matrix.cargo_test_opts }}
+        env:
+          CARGO_TEST_OPTS: ${{ matrix.cargo_test_opts }}
+        run: cargo test ${CARGO_TEST_OPTS}
 
       - name: Run cargo fmt check
         run: cargo fmt --all -- --check
 
       - name: Run rust clippy
-        run: cargo clippy ${{ matrix.cargo_test_opts }}
+        env:
+          CARGO_TEST_OPTS: ${{ matrix.cargo_test_opts }}
+        run: cargo clippy ${CARGO_TEST_OPTS}

--- a/.github/workflows/vendor_release.yml
+++ b/.github/workflows/vendor_release.yml
@@ -4,10 +4,17 @@ on:
   release:
     types: [published]
 
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   generate-and-publish-vendored-code:
+    name: Generate and publish vendored code
     permissions:
-      contents: write
+      contents: write # required to upload vendored tarball via gh release upload
     runs-on: ubuntu-24.04
     steps:
       - name: Harden the runner (Audit all outbound calls)

--- a/.github/workflows/zizmor.yaml
+++ b/.github/workflows/zizmor.yaml
@@ -29,4 +29,4 @@ jobs:
       with:
         advanced-security: false
         annotations: true
-        persona: regular
+        persona: auditor


### PR DESCRIPTION
Fix all findings reported by zizmor --persona auditor across the .github/workflows/ directory, enabling the zizmor CI workflow to be upgraded from persona: regular to persona: auditor.

Changes by finding type:

template-injection (low) — aa_basic, aa_cc_kbc, aa_crypto, aa_sev_kbc, aa_release, coco-extension-image, publish-artifacts, rust_stable_check, secret_cli_release, trustee-attester:
  Move all ${{ matrix.* }} and ${{ github.sha }} template expressions
  inside run: blocks into step-level env: vars so they expand as shell
  variables instead of being interpolated directly into script text.

excessive-permissions (medium) — aa_basic, aa_cc_kbc, aa_crypto, aa_sample_keyprovider, api-server-rest-basic, cdh_basic, image_rs_build, ocicrypt_rs_build, trustee-attester, vendor_release:
  Add permissions: {} at workflow level to deny all permissions by
  default; each job already carries explicit permissions: contents: read.

undocumented-permissions (low) — aa_release, coco-extension-image, codeql, publish-artifacts, scorecard, secret_cli_release, vendor_release:
  Add inline comments to all write-level permission entries explaining
  why each elevated scope is required.

concurrency-limits (low) — aa_release, coco-extension-image, codeql, dco, dependency-review, links, publish-artifacts, rust_stable_check, scorecard, secret_cli_release, vendor_release:
  Add concurrency: blocks to all workflows that were missing them.

anonymous-definition (informational) — aa_release, dependency-review, links, publish-artifacts, rust_stable_check, secret_cli_release, vendor_release:
  Add name: fields to all unnamed job definitions.

secrets-outside-env (medium) — image_rs_build:
  Add zizmor: ignore comment; the secret is already correctly scoped
  to a step-level env: block. Moving to a dedicated GitHub environment
  would require upstream repo config changes outside this PR's scope.

Also updates zizmor.yaml to use persona: auditor now that all findings are resolved.

Verification:
  zizmor --persona auditor .
  No findings to report. Good job! (1 ignored)