### PR TITLE
aa: make lint cover all workspace packages under attestation-agent

### DIFF
--- a/attestation-agent/Makefile
+++ b/attestation-agent/Makefile
@@ -117,13 +117,34 @@ TARGET := $(TARGET_DIR)/$(BIN_NAME)
 lint: $(LINT_OPTION)
 
 lint-default:
-	cd attestation-agent && cargo clippy --features kbs,coco_as,bin,grpc,ttrpc,all-attesters
+	cargo clippy -p attestation-agent --features kbs,coco_as,bin,grpc,ttrpc,all-attesters -- -D warnings
+	cargo clippy -p attester --all-targets --features all-attesters,bin -- -D warnings
+	cargo clippy -p coco_keyprovider --all-targets -- -D warnings
+	cargo clippy -p kbc --all-targets --features cc_kbc,all-attesters,rust-crypto -- -D warnings
+	cargo clippy -p kbs_protocol --all-targets --no-default-features \
+		--features background_check,passport,rust-crypto,all-attesters,bin,aa_ttrpc -- -D warnings
+	cargo clippy -p crypto --all-targets --features rust-crypto -- -D warnings
+	cargo clippy -p resource_uri --all-targets -- -D warnings
 
 lint-s390x:
-	cd attestation-agent && cargo clippy --no-default-features --features openssl,kbs,coco_as,bin,grpc,ttrpc
+	cargo clippy -p attestation-agent --no-default-features --features openssl,kbs,coco_as,bin,grpc,ttrpc -- -D warnings
+	cargo clippy -p attester --all-targets --no-default-features --features se-attester,bin -- -D warnings
+	cargo clippy -p coco_keyprovider --all-targets -- -D warnings
+	cargo clippy -p kbc --all-targets --no-default-features --features cc_kbc,se-attester,openssl -- -D warnings
+	cargo clippy -p kbs_protocol --all-targets --no-default-features \
+		--features background_check,passport,openssl,se-attester,bin,aa_ttrpc -- -D warnings
+	cargo clippy -p crypto --all-targets --no-default-features --features openssl -- -D warnings
+	cargo clippy -p resource_uri --all-targets -- -D warnings
 
 lint-aarch64:
-	cd attestation-agent && cargo clippy --no-default-features --features openssl,rust-crypto,cca-attester,kbs,coco_as,bin,grpc,ttrpc
+	cargo clippy -p attestation-agent --no-default-features --features openssl,rust-crypto,cca-attester,kbs,coco_as,bin,grpc,ttrpc -- -D warnings
+	cargo clippy -p attester --all-targets --no-default-features --features cca-attester,bin -- -D warnings
+	cargo clippy -p coco_keyprovider --all-targets -- -D warnings
+	cargo clippy -p kbc --all-targets --no-default-features --features cc_kbc,cca-attester,rust-crypto -- -D warnings
+	cargo clippy -p kbs_protocol --all-targets --no-default-features \
+		--features background_check,passport,rust-crypto,cca-attester,bin,aa_ttrpc -- -D warnings
+	cargo clippy -p crypto --all-targets --features rust-crypto -- -D warnings
+	cargo clippy -p resource_uri --all-targets -- -D warnings
 
 install: 
 	install -D -m0755 $(TARGET) $(DESTDIR)/$(BIN_NAME)


### PR DESCRIPTION
Previously make lint only clippy'd the attestation-agent crate, so sibling crates (notably attester's evidence_getter via bin) were never linted. Clippy each package with -D warnings, and use --all-targets plus bin where binaries exist.

Note that sev parts are also included as they are in tree. I will make a separate PR to get rid of them altogether.