### PR TITLE
cdh: reduce KBS client idle connection timeout

### DIFF
--- a/attestation-agent/kbs_protocol/src/builder.rs
+++ b/attestation-agent/kbs_protocol/src/builder.rs
@@ -89,6 +89,9 @@ impl<T> KbsClientBuilder<T> {
     pub fn build(self) -> Result<KbsClient<T>> {
         let mut http_client_builder = reqwest::Client::builder()
             .cookie_store(true)
+            // KBS uses a 5-second keep-alive timeout by default.
+            // Use a shorter idle timeout to avoid reusing stale pooled connections.
+            .pool_idle_timeout(std::time::Duration::from_secs(4))
             .user_agent(format!(
                 "attestation-agent-kbs-client/{}",
                 env!("CARGO_PKG_VERSION")


### PR DESCRIPTION
KBS (Actix Web) closes idle keep-alive connections after 5 seconds by default.

This can occasionally cause ttrpc request errors due to the reuse of stale
pooled connections closed by KBS.

Configure a shorter client-side idle timeout to avoid reusing stale connections.