### PR TITLE
ci: publish CoCo extension images for pull requests

### DIFF
--- a/.github/workflows/coco-extension-image.yml
+++ b/.github/workflows/coco-extension-image.yml
@@ -15,13 +15,15 @@ name: Build and publish the CoCo guest extension image
 # release asset is qualified with it (e.g. "<sha>-ubuntu26.04-amd64"): the
 # extension ships no libc, so a variant is only usable on a matching guest.
 #
-# On pull requests everything is built and uploaded as workflow artifacts (no
-# registry push). On pushes to main the artifacts are published to ghcr.io
-# (tagged with the commit sha and "latest") and attested. On a published
-# release the same artifacts are published tagged with the release version, the
-# multi-arch manifests get the version tag, and the per-arch disk images and
-# their dm-verity root hashes are attached to the GitHub release so consumers
-# (e.g. kata-containers) can pin to a stable version.
+# On pull requests everything is built without registry credentials and
+# uploaded as workflow artifacts. A separate workflow_run publisher promotes a
+# successful build under a PR-scoped tag so consumers such as kata-containers
+# can test the proposed guest-components revision. On pushes to main the
+# artifacts are published to ghcr.io (tagged with the commit sha and "latest")
+# and attested. On a published release the same artifacts are published tagged
+# with the release version, the multi-arch manifests get the version tag, and
+# the per-arch disk images and their dm-verity root hashes are attached to the
+# GitHub release so consumers can pin to a stable version.
 on:
   pull_request:
   push:

--- a/.github/workflows/coco-extension-image.yml
+++ b/.github/workflows/coco-extension-image.yml
@@ -16,15 +16,26 @@ name: Build and publish the CoCo guest extension image
 # extension ships no libc, so a variant is only usable on a matching guest.
 #
 # On pull requests everything is built without registry credentials and
-# uploaded as workflow artifacts. A separate workflow_run publisher promotes a
-# successful build under a PR-scoped tag so consumers such as kata-containers
-# can test the proposed guest-components revision. On pushes to main the
-# artifacts are published to ghcr.io (tagged with the commit sha and "latest")
-# and attested. On a published release the same artifacts are published tagged
-# with the release version, the multi-arch manifests get the version tag, and
-# the per-arch disk images and their dm-verity root hashes are attached to the
-# GitHub release so consumers can pin to a stable version.
+# uploaded as workflow artifacts. A small workflow_run entry point calls this
+# workflow again to promote a successful build under a PR-scoped tag, so
+# consumers such as kata-containers can test the proposed guest-components
+# revision. On pushes to main the artifacts are published to ghcr.io (tagged
+# with the commit sha and "latest") and attested. On a published release the
+# same artifacts are published tagged with the release version, the multi-arch
+# manifests get the version tag, and the per-arch disk images and their
+# dm-verity root hashes are attached to the GitHub release so consumers can pin
+# to a stable version.
 on:
+  workflow_call:
+    inputs:
+      artifact_run_id:
+        description: Pull-request workflow run containing the built images
+        required: true
+        type: number
+      version:
+        description: Registry tag prefix for the promoted images
+        required: true
+        type: string
   pull_request:
   push:
     branches:
@@ -33,7 +44,7 @@ on:
     types: [published]
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || inputs.version || github.ref }}
   cancel-in-progress: true
 
 permissions:
@@ -64,6 +75,7 @@ jobs:
   build:
     name: build (${{ matrix.arch }}, ubuntu ${{ matrix.ubuntu }})
     permissions:
+      actions: read # download an unprivileged pull-request build when called
       contents: write # needed to upload disk images to the GitHub release
       packages: write # push OCI artifacts to ghcr.io
       id-token: write # required for OIDC-based attestation signing
@@ -103,6 +115,8 @@ jobs:
       ATTESTER: ${{ matrix.attester }}
       UBUNTU_VERSION: ${{ matrix.ubuntu }}
       VARIANT: ubuntu${{ matrix.ubuntu }}
+      VERSION: ${{ inputs.version || github.sha }}
+      ARTIFACT_RUN_ID: ${{ inputs.artifact_run_id }}
     steps:
     - name: Harden the runner (Audit all outbound calls)
       uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
@@ -110,13 +124,16 @@ jobs:
         egress-policy: audit
 
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      if: ${{ inputs.artifact_run_id == 0 }}
       with:
         persist-credentials: false
 
     # Logging in up front lets the builder cache below be reused; the payload
     # images are pushed by the later steps with the same credentials.
     - name: Log in to the Container registry
-      if: ${{ github.event_name != 'pull_request' }}
+      if: >-
+        github.event_name != 'pull_request' &&
+        inputs.artifact_run_id == 0
       uses: docker/login-action@371161bbe7024a29a25c5e19bfcbc0804fe9ad2c # v4.5.2
       with:
         registry: ${{ env.REGISTRY }}
@@ -124,6 +141,7 @@ jobs:
         password: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Install build tooling
+      if: ${{ inputs.artifact_run_id == 0 }}
       env:
         OCI_ARCH: ${{ matrix.oci_arch }}
       run: |
@@ -138,7 +156,14 @@ jobs:
           "https://github.com/opencontainers/umoci/releases/download/${UMOCI_VERSION}/umoci.linux.${OCI_ARCH}"
         sudo chmod +x /usr/local/bin/umoci
 
+    - name: Install artifact promotion tooling
+      if: ${{ inputs.artifact_run_id > 0 }}
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y --no-install-recommends skopeo
+
     - name: Build or reuse the Ubuntu ${{ matrix.ubuntu }} builder image
+      if: ${{ inputs.artifact_run_id == 0 }}
       env:
         OCI_ARCH: ${{ matrix.oci_arch }}
         EVENT_NAME: ${{ github.event_name }}
@@ -186,6 +211,7 @@ jobs:
         fi
 
     - name: Assemble extension rootfs
+      if: ${{ inputs.artifact_run_id == 0 }}
       run: |
         docker run --rm \
           -v "${GITHUB_WORKSPACE}:${GITHUB_WORKSPACE}" \
@@ -201,27 +227,91 @@ jobs:
           ./tools/coco-extension/assemble-rootfs.sh
 
     - name: Build OCI container image
+      if: ${{ inputs.artifact_run_id == 0 }}
       env:
-        GIT_SHA: ${{ github.sha }}
         OCI_ARCH: ${{ matrix.oci_arch }}
       run: |
         docker build \
           -f tools/coco-extension/Dockerfile \
-          -t "${CONTAINER_IMAGE}:${GIT_SHA}-${VARIANT}-${OCI_ARCH}" \
+          -t "${CONTAINER_IMAGE}:${VERSION}-${VARIANT}-${OCI_ARCH}" \
           build/coco-extension-rootfs
 
     - name: Build EROFS + dm-verity disk image
+      if: ${{ inputs.artifact_run_id == 0 }}
       run: ./tools/coco-extension/build-erofs-image.sh
+
+    # A workflow_call is the trusted half of a pull-request build. Rehydrate
+    # the exact artifacts produced without credentials by the pull_request run,
+    # then feed them into the normal publication steps below.
+    - name: Prepare pull-request artifacts for publication
+      if: ${{ inputs.artifact_run_id > 0 }}
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        OCI_ARCH: ${{ matrix.oci_arch }}
+      run: |
+        if [[ ! "${ARTIFACT_RUN_ID}" =~ ^[0-9]+$ ]]; then
+          echo "Invalid artifact workflow run ID: ${ARTIFACT_RUN_ID}" >&2
+          exit 1
+        fi
+        if [[ ! "${VERSION}" =~ ^pr-[0-9a-f]{40}$ ]]; then
+          echo "Invalid pull-request version: ${VERSION}" >&2
+          exit 1
+        fi
+
+        artifact_name="coco-extension-${VARIANT}-${OCI_ARCH}"
+        artifact_dir="${RUNNER_TEMP}/${artifact_name}"
+        mkdir -p "${artifact_dir}"
+        gh run download "${ARTIFACT_RUN_ID}" \
+          --repo "${GITHUB_REPOSITORY}" \
+          --name "${artifact_name}" \
+          --dir "${artifact_dir}"
+
+        oci_tar="${artifact_dir}/coco-extension-oci-${VARIANT}-${OCI_ARCH}.tar"
+        disk_image="${artifact_dir}/kata-containers-coco-extension-${VARIANT}-${OCI_ARCH}.img"
+        root_hash="${artifact_dir}/root_hash_coco-extension-${VARIANT}-${OCI_ARCH}.txt"
+        for file in "${oci_tar}" "${disk_image}" "${root_hash}"; do
+          if [ ! -f "${file}" ] || [ -L "${file}" ] || [ ! -s "${file}" ]; then
+            echo "Missing or invalid extension artifact: ${file}" >&2
+            exit 1
+          fi
+        done
+
+        unexpected="$(find "${artifact_dir}" -mindepth 1 -maxdepth 1 \
+          ! -name "$(basename "${oci_tar}")" \
+          ! -name "$(basename "${disk_image}")" \
+          ! -name "$(basename "${root_hash}")" -print -quit)"
+        if [ -n "${unexpected}" ]; then
+          echo "Unexpected extension artifact entry: ${unexpected}" >&2
+          exit 1
+        fi
+
+        skopeo copy \
+          "docker-archive:${oci_tar}" \
+          "docker-daemon:${CONTAINER_IMAGE}:${VERSION}-${VARIANT}-${OCI_ARCH}"
+        mkdir -p build/coco-extension-image
+        install -m 0644 "${disk_image}" \
+          build/coco-extension-image/kata-containers-coco-extension.img
+        install -m 0644 "${root_hash}" \
+          build/coco-extension-image/root_hash_coco-extension.txt
+
+    # Keep the write credential out of the job until all pull-request artifacts
+    # have been downloaded, validated, and copied into local build state.
+    - name: Log in to publish pull-request artifacts
+      if: ${{ inputs.artifact_run_id > 0 }}
+      uses: docker/login-action@371161bbe7024a29a25c5e19bfcbc0804fe9ad2c # v4.5.2
+      with:
+        registry: ${{ env.REGISTRY }}
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
 
     # --- Pull request: build only, upload artifacts, no registry push ---------
     - name: Save OCI image for artifact upload
       if: ${{ github.event_name == 'pull_request' }}
       env:
-        GIT_SHA: ${{ github.sha }}
         OCI_ARCH: ${{ matrix.oci_arch }}
       run: |
         mkdir -p build/artifacts
-        docker save "${CONTAINER_IMAGE}:${GIT_SHA}-${VARIANT}-${OCI_ARCH}" \
+        docker save "${CONTAINER_IMAGE}:${VERSION}-${VARIANT}-${OCI_ARCH}" \
           -o "build/artifacts/coco-extension-oci-${VARIANT}-${OCI_ARCH}.tar"
         cp build/coco-extension-image/kata-containers-coco-extension.img \
           "build/artifacts/kata-containers-coco-extension-${VARIANT}-${OCI_ARCH}.img"
@@ -239,10 +329,10 @@ jobs:
         retention-days: 15
         if-no-files-found: error
 
-    # --- Push to main / release: publish to ghcr.io and attest ----------------
-    # The immutable per-arch reference is always "<sha>-<variant>-<arch>"; the
-    # friendly tags (latest, or the release version) are assembled into
-    # per-variant multi-arch manifests in the publish-manifests job below.
+    # --- Publish trusted builds to ghcr.io and attest --------------------------
+    # The per-arch reference is "<version>-<variant>-<arch>". For main and
+    # releases, version is the commit SHA. A trusted workflow_call uses the
+    # PR-scoped version supplied by the workflow_run entry point.
     - uses: oras-project/setup-oras@1d808f7d7f6995cc68b7bf507bfe5c5446e1dc9d # v2.0.1
       if: ${{ github.event_name != 'pull_request' }}
       with:
@@ -252,10 +342,9 @@ jobs:
       id: publish-container
       if: ${{ github.event_name != 'pull_request' }}
       env:
-        GIT_SHA: ${{ github.sha }}
         OCI_ARCH: ${{ matrix.oci_arch }}
       run: |
-        arch_tag="${GIT_SHA}-${VARIANT}-${OCI_ARCH}"
+        arch_tag="${VERSION}-${VARIANT}-${OCI_ARCH}"
         docker push "${CONTAINER_IMAGE}:${arch_tag}"
         digest="$(docker inspect --format='{{index .RepoDigests 0}}' "${CONTAINER_IMAGE}:${arch_tag}" | cut -d'@' -f2)"
         echo "image=${CONTAINER_IMAGE}" >> "$GITHUB_OUTPUT"
@@ -266,10 +355,9 @@ jobs:
       if: ${{ github.event_name != 'pull_request' }}
       working-directory: build/coco-extension-image
       env:
-        GIT_SHA: ${{ github.sha }}
         OCI_ARCH: ${{ matrix.oci_arch }}
       run: |
-        arch_tag="${GIT_SHA}-${VARIANT}-${OCI_ARCH}"
+        arch_tag="${VERSION}-${VARIANT}-${OCI_ARCH}"
         files=(kata-containers-coco-extension.img)
         if [ -f root_hash_coco-extension.txt ]; then
           files+=(root_hash_coco-extension.txt)
@@ -332,6 +420,7 @@ jobs:
     runs-on: ubuntu-24.04
     env:
       VARIANT: ubuntu${{ matrix.ubuntu }}
+      VERSION: ${{ inputs.version || github.sha }}
     steps:
     - name: Harden the runner (Audit all outbound calls)
       uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
@@ -349,19 +438,34 @@ jobs:
       env:
         # On push to main: the commit sha plus the rolling "latest" tag.
         # On release: the commit sha plus the immutable release version, so
-        # consumers can pin to it.
-        EXTRA_TAG: ${{ github.event_name == 'release' && github.event.release.tag_name || 'latest' }}
-        GIT_SHA: ${{ github.sha }}
+        # consumers can pin to it. A workflow_call publishes only its PR-scoped
+        # version.
+        EXTRA_TAG: >-
+          ${{ github.event_name == 'release' && github.event.release.tag_name ||
+              github.event_name == 'push' && 'latest' || '' }}
       run: |
+        tags=("${VERSION}-${VARIANT}")
+        if [ -n "${EXTRA_TAG}" ]; then
+          tags+=("${EXTRA_TAG}-${VARIANT}")
+        fi
+
         for image in "${CONTAINER_IMAGE}" "${DISK_IMAGE}"; do
-          for tag in "${GIT_SHA}-${VARIANT}" "${EXTRA_TAG}-${VARIANT}"; do
+          for tag in "${tags[@]}"; do
             docker manifest create "${image}:${tag}" \
-              --amend "${image}:${GIT_SHA}-${VARIANT}-amd64" \
-              --amend "${image}:${GIT_SHA}-${VARIANT}-arm64" \
-              --amend "${image}:${GIT_SHA}-${VARIANT}-s390x"
-            docker manifest annotate --arch amd64 --os linux "${image}:${tag}" "${image}:${GIT_SHA}-${VARIANT}-amd64"
-            docker manifest annotate --arch arm64 --os linux "${image}:${tag}" "${image}:${GIT_SHA}-${VARIANT}-arm64"
-            docker manifest annotate --arch s390x --os linux "${image}:${tag}" "${image}:${GIT_SHA}-${VARIANT}-s390x"
+              --amend "${image}:${VERSION}-${VARIANT}-amd64" \
+              --amend "${image}:${VERSION}-${VARIANT}-arm64" \
+              --amend "${image}:${VERSION}-${VARIANT}-s390x"
+            docker manifest annotate --arch amd64 --os linux \
+              "${image}:${tag}" "${image}:${VERSION}-${VARIANT}-amd64"
+            docker manifest annotate --arch arm64 --os linux \
+              "${image}:${tag}" "${image}:${VERSION}-${VARIANT}-arm64"
+            docker manifest annotate --arch s390x --os linux \
+              "${image}:${tag}" "${image}:${VERSION}-${VARIANT}-s390x"
             docker manifest push "${image}:${tag}"
           done
         done
+
+        if [[ "${VERSION}" =~ ^pr-[0-9a-f]{40}$ ]]; then
+          echo "Kata versions.yaml value: ${VERSION}-${VARIANT}" \
+            >> "${GITHUB_STEP_SUMMARY}"
+        fi

--- a/.github/workflows/publish-coco-extension-pr.yml
+++ b/.github/workflows/publish-coco-extension-pr.yml
@@ -1,17 +1,9 @@
 name: Publish CoCo guest extension image for pull requests
 
-# Promote successful pull-request builds without giving untrusted build code a
-# registry credential. This privileged workflow never checks out or executes
-# pull-request code. It only copies the fixed artifacts emitted by
-# coco-extension-image.yml into PR-scoped tags:
-#
-#   pr-<head-sha>-ubuntu<release>
-#
-# Kata can use that complete tag as .externals.coco-guest-components.version.
-# Main and release tags remain writable only by their existing trusted paths.
+# A fork pull_request runs without registry credentials. After that build
+# succeeds, call the existing extension workflow in its trusted artifact-
+# promotion mode. The called workflow does not check out or execute PR code.
 on:
-  # The privileged side never checks out or executes pull-request content; it
-  # only promotes fixed-name artifacts into PR-scoped tags.
   workflow_run: # zizmor: ignore[dangerous-triggers]
     workflows:
     - Build and publish the CoCo guest extension image
@@ -24,207 +16,19 @@ concurrency:
 
 permissions: {}
 
-env:
-  REGISTRY: ghcr.io
-  CONTAINER_IMAGE: ghcr.io/${{ github.repository }}/coco-extension
-  DISK_IMAGE: ghcr.io/${{ github.repository }}/coco-extension-disk
-
 jobs:
   publish:
-    name: publish (${{ matrix.arch }}, ${{ matrix.variant }})
+    name: publish PR images
     if: >-
       github.event.workflow_run.event == 'pull_request' &&
       github.event.workflow_run.conclusion == 'success'
     permissions:
-      actions: read # download artifacts from the completed unprivileged build
+      actions: read # let the called workflow download the PR build
       contents: read # bind attestations to this repository
       packages: write # publish PR-scoped OCI artifacts to ghcr.io
       id-token: write # required for OIDC-based attestation signing
       attestations: write # create provenance for the promoted artifacts
-    runs-on: ubuntu-24.04
-    strategy:
-      fail-fast: false
-      matrix:
-        variant:
-        - ubuntu24.04
-        - ubuntu26.04
-        arch:
-        - amd64
-        - arm64
-        - s390x
-    env:
-      HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
-      RUN_ID: ${{ github.event.workflow_run.id }}
-      VARIANT: ${{ matrix.variant }}
-      OCI_ARCH: ${{ matrix.arch }}
-    steps:
-    - name: Harden the runner (Audit all outbound calls)
-      uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
-      with:
-        egress-policy: audit
-
-    - name: Validate source revision
-      run: |
-        if [[ ! "${HEAD_SHA}" =~ ^[0-9a-f]{40}$ ]]; then
-          echo "Invalid pull-request head SHA: ${HEAD_SHA}" >&2
-          exit 1
-        fi
-
-    - name: Download extension artifact
-      env:
-        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: |
-        artifact_name="coco-extension-${VARIANT}-${OCI_ARCH}"
-        artifact_dir="${RUNNER_TEMP}/${artifact_name}"
-        mkdir -p "${artifact_dir}"
-        gh run download "${RUN_ID}" \
-          --repo "${GITHUB_REPOSITORY}" \
-          --name "${artifact_name}" \
-          --dir "${artifact_dir}"
-
-    - name: Validate extension artifact
-      run: |
-        artifact_dir="${RUNNER_TEMP}/coco-extension-${VARIANT}-${OCI_ARCH}"
-        oci_tar="${artifact_dir}/coco-extension-oci-${VARIANT}-${OCI_ARCH}.tar"
-        disk_image="${artifact_dir}/kata-containers-coco-extension-${VARIANT}-${OCI_ARCH}.img"
-        root_hash="${artifact_dir}/root_hash_coco-extension-${VARIANT}-${OCI_ARCH}.txt"
-
-        for file in "${oci_tar}" "${disk_image}" "${root_hash}"; do
-          if [ ! -f "${file}" ] || [ -L "${file}" ] || [ ! -s "${file}" ]; then
-            echo "Missing or invalid extension artifact: ${file}" >&2
-            exit 1
-          fi
-        done
-
-        unexpected="$(find "${artifact_dir}" -mindepth 1 -maxdepth 1 \
-          ! -name "$(basename "${oci_tar}")" \
-          ! -name "$(basename "${disk_image}")" \
-          ! -name "$(basename "${root_hash}")" -print -quit)"
-        if [ -n "${unexpected}" ]; then
-          echo "Unexpected extension artifact entry: ${unexpected}" >&2
-          exit 1
-        fi
-
-    - name: Install publishing tools
-      run: |
-        sudo apt-get update
-        sudo apt-get install -y --no-install-recommends skopeo
-
-    - uses: oras-project/setup-oras@1d808f7d7f6995cc68b7bf507bfe5c5446e1dc9d # v2.0.1
-      with:
-        version: 1.2.0
-
-    - name: Log in to the Container registry
-      uses: docker/login-action@371161bbe7024a29a25c5e19bfcbc0804fe9ad2c # v4.5.2
-      with:
-        registry: ${{ env.REGISTRY }}
-        username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
-
-    - name: Publish PR-scoped images
-      id: publish
-      run: |
-        tag="pr-${HEAD_SHA}-${VARIANT}-${OCI_ARCH}"
-        artifact_dir="${RUNNER_TEMP}/coco-extension-${VARIANT}-${OCI_ARCH}"
-        oci_tar="${artifact_dir}/coco-extension-oci-${VARIANT}-${OCI_ARCH}.tar"
-
-        skopeo copy \
-          "docker-archive:${oci_tar}" \
-          "docker://${CONTAINER_IMAGE}:${tag}"
-        container_digest="$(skopeo inspect \
-          --format '{{.Digest}}' "docker://${CONTAINER_IMAGE}:${tag}")"
-
-        disk_dir="${RUNNER_TEMP}/coco-extension-disk-${VARIANT}-${OCI_ARCH}"
-        mkdir -p "${disk_dir}"
-        install -m 0644 \
-          "${artifact_dir}/kata-containers-coco-extension-${VARIANT}-${OCI_ARCH}.img" \
-          "${disk_dir}/kata-containers-coco-extension.img"
-        install -m 0644 \
-          "${artifact_dir}/root_hash_coco-extension-${VARIANT}-${OCI_ARCH}.txt" \
-          "${disk_dir}/root_hash_coco-extension.txt"
-
-        pushd "${disk_dir}" >/dev/null
-        oras push "${DISK_IMAGE}:${tag}" \
-          --artifact-type application/vnd.confidential-containers.coco-extension.disk \
-          kata-containers-coco-extension.img \
-          root_hash_coco-extension.txt
-        disk_digest="$(oras manifest fetch \
-          "${DISK_IMAGE}:${tag}" --descriptor | jq -r .digest)"
-        popd >/dev/null
-
-        digest_pattern='^sha256:[0-9a-f]{64}$'
-        if [[ ! "${container_digest}" =~ ${digest_pattern} ]]; then
-          echo "Invalid container image digest: ${container_digest}" >&2
-          exit 1
-        fi
-        if [[ ! "${disk_digest}" =~ ${digest_pattern} ]]; then
-          echo "Invalid disk image digest: ${disk_digest}" >&2
-          exit 1
-        fi
-
-        echo "container-digest=${container_digest}" >> "${GITHUB_OUTPUT}"
-        echo "disk-digest=${disk_digest}" >> "${GITHUB_OUTPUT}"
-
-    - name: Generate provenance for the OCI container image
-      uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4.2.2
-      with:
-        subject-name: ${{ env.CONTAINER_IMAGE }}
-        subject-digest: ${{ steps.publish.outputs.container-digest }}
-        push-to-registry: true
-
-    - name: Generate provenance for the disk image
-      uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4.2.2
-      with:
-        subject-name: ${{ env.DISK_IMAGE }}
-        subject-digest: ${{ steps.publish.outputs.disk-digest }}
-        push-to-registry: true
-
-  publish-manifests:
-    name: publish manifest (${{ matrix.variant }})
-    if: >-
-      github.event.workflow_run.event == 'pull_request' &&
-      github.event.workflow_run.conclusion == 'success'
-    needs: publish
-    permissions:
-      packages: write # publish PR-scoped multi-arch manifests to ghcr.io
-    runs-on: ubuntu-24.04
-    strategy:
-      fail-fast: false
-      matrix:
-        variant:
-        - ubuntu24.04
-        - ubuntu26.04
-    env:
-      HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
-      VARIANT: ${{ matrix.variant }}
-    steps:
-    - name: Harden the runner (Audit all outbound calls)
-      uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
-      with:
-        egress-policy: audit
-
-    - name: Log in to the Container registry
-      uses: docker/login-action@371161bbe7024a29a25c5e19bfcbc0804fe9ad2c # v4.5.2
-      with:
-        registry: ${{ env.REGISTRY }}
-        username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
-
-    - name: Assemble multi-arch manifests
-      run: |
-        tag="pr-${HEAD_SHA}-${VARIANT}"
-        for image in "${CONTAINER_IMAGE}" "${DISK_IMAGE}"; do
-          docker manifest create "${image}:${tag}" \
-            --amend "${image}:${tag}-amd64" \
-            --amend "${image}:${tag}-arm64" \
-            --amend "${image}:${tag}-s390x"
-          docker manifest annotate --arch amd64 --os linux \
-            "${image}:${tag}" "${image}:${tag}-amd64"
-          docker manifest annotate --arch arm64 --os linux \
-            "${image}:${tag}" "${image}:${tag}-arm64"
-          docker manifest annotate --arch s390x --os linux \
-            "${image}:${tag}" "${image}:${tag}-s390x"
-          docker manifest push "${image}:${tag}"
-        done
-
-        echo "Kata versions.yaml value: ${tag}" >> "${GITHUB_STEP_SUMMARY}"
+    uses: ./.github/workflows/coco-extension-image.yml
+    with:
+      artifact_run_id: ${{ github.event.workflow_run.id }}
+      version: pr-${{ github.event.workflow_run.head_sha }}

--- a/.github/workflows/publish-coco-extension-pr.yml
+++ b/.github/workflows/publish-coco-extension-pr.yml
@@ -1,0 +1,230 @@
+name: Publish CoCo guest extension image for pull requests
+
+# Promote successful pull-request builds without giving untrusted build code a
+# registry credential. This privileged workflow never checks out or executes
+# pull-request code. It only copies the fixed artifacts emitted by
+# coco-extension-image.yml into PR-scoped tags:
+#
+#   pr-<head-sha>-ubuntu<release>
+#
+# Kata can use that complete tag as .externals.coco-guest-components.version.
+# Main and release tags remain writable only by their existing trusted paths.
+on:
+  # The privileged side never checks out or executes pull-request content; it
+  # only promotes fixed-name artifacts into PR-scoped tags.
+  workflow_run: # zizmor: ignore[dangerous-triggers]
+    workflows:
+    - Build and publish the CoCo guest extension image
+    types:
+    - completed
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.workflow_run.head_sha }}
+  cancel-in-progress: false
+
+permissions: {}
+
+env:
+  REGISTRY: ghcr.io
+  CONTAINER_IMAGE: ghcr.io/${{ github.repository }}/coco-extension
+  DISK_IMAGE: ghcr.io/${{ github.repository }}/coco-extension-disk
+
+jobs:
+  publish:
+    name: publish (${{ matrix.arch }}, ${{ matrix.variant }})
+    if: >-
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success'
+    permissions:
+      actions: read # download artifacts from the completed unprivileged build
+      contents: read # bind attestations to this repository
+      packages: write # publish PR-scoped OCI artifacts to ghcr.io
+      id-token: write # required for OIDC-based attestation signing
+      attestations: write # create provenance for the promoted artifacts
+    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        variant:
+        - ubuntu24.04
+        - ubuntu26.04
+        arch:
+        - amd64
+        - arm64
+        - s390x
+    env:
+      HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+      RUN_ID: ${{ github.event.workflow_run.id }}
+      VARIANT: ${{ matrix.variant }}
+      OCI_ARCH: ${{ matrix.arch }}
+    steps:
+    - name: Harden the runner (Audit all outbound calls)
+      uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
+      with:
+        egress-policy: audit
+
+    - name: Validate source revision
+      run: |
+        if [[ ! "${HEAD_SHA}" =~ ^[0-9a-f]{40}$ ]]; then
+          echo "Invalid pull-request head SHA: ${HEAD_SHA}" >&2
+          exit 1
+        fi
+
+    - name: Download extension artifact
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        artifact_name="coco-extension-${VARIANT}-${OCI_ARCH}"
+        artifact_dir="${RUNNER_TEMP}/${artifact_name}"
+        mkdir -p "${artifact_dir}"
+        gh run download "${RUN_ID}" \
+          --repo "${GITHUB_REPOSITORY}" \
+          --name "${artifact_name}" \
+          --dir "${artifact_dir}"
+
+    - name: Validate extension artifact
+      run: |
+        artifact_dir="${RUNNER_TEMP}/coco-extension-${VARIANT}-${OCI_ARCH}"
+        oci_tar="${artifact_dir}/coco-extension-oci-${VARIANT}-${OCI_ARCH}.tar"
+        disk_image="${artifact_dir}/kata-containers-coco-extension-${VARIANT}-${OCI_ARCH}.img"
+        root_hash="${artifact_dir}/root_hash_coco-extension-${VARIANT}-${OCI_ARCH}.txt"
+
+        for file in "${oci_tar}" "${disk_image}" "${root_hash}"; do
+          if [ ! -f "${file}" ] || [ -L "${file}" ] || [ ! -s "${file}" ]; then
+            echo "Missing or invalid extension artifact: ${file}" >&2
+            exit 1
+          fi
+        done
+
+        unexpected="$(find "${artifact_dir}" -mindepth 1 -maxdepth 1 \
+          ! -name "$(basename "${oci_tar}")" \
+          ! -name "$(basename "${disk_image}")" \
+          ! -name "$(basename "${root_hash}")" -print -quit)"
+        if [ -n "${unexpected}" ]; then
+          echo "Unexpected extension artifact entry: ${unexpected}" >&2
+          exit 1
+        fi
+
+    - name: Install publishing tools
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y --no-install-recommends skopeo
+
+    - uses: oras-project/setup-oras@1d808f7d7f6995cc68b7bf507bfe5c5446e1dc9d # v2.0.1
+      with:
+        version: 1.2.0
+
+    - name: Log in to the Container registry
+      uses: docker/login-action@371161bbe7024a29a25c5e19bfcbc0804fe9ad2c # v4.5.2
+      with:
+        registry: ${{ env.REGISTRY }}
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Publish PR-scoped images
+      id: publish
+      run: |
+        tag="pr-${HEAD_SHA}-${VARIANT}-${OCI_ARCH}"
+        artifact_dir="${RUNNER_TEMP}/coco-extension-${VARIANT}-${OCI_ARCH}"
+        oci_tar="${artifact_dir}/coco-extension-oci-${VARIANT}-${OCI_ARCH}.tar"
+
+        skopeo copy \
+          "docker-archive:${oci_tar}" \
+          "docker://${CONTAINER_IMAGE}:${tag}"
+        container_digest="$(skopeo inspect \
+          --format '{{.Digest}}' "docker://${CONTAINER_IMAGE}:${tag}")"
+
+        disk_dir="${RUNNER_TEMP}/coco-extension-disk-${VARIANT}-${OCI_ARCH}"
+        mkdir -p "${disk_dir}"
+        install -m 0644 \
+          "${artifact_dir}/kata-containers-coco-extension-${VARIANT}-${OCI_ARCH}.img" \
+          "${disk_dir}/kata-containers-coco-extension.img"
+        install -m 0644 \
+          "${artifact_dir}/root_hash_coco-extension-${VARIANT}-${OCI_ARCH}.txt" \
+          "${disk_dir}/root_hash_coco-extension.txt"
+
+        pushd "${disk_dir}" >/dev/null
+        oras push "${DISK_IMAGE}:${tag}" \
+          --artifact-type application/vnd.confidential-containers.coco-extension.disk \
+          kata-containers-coco-extension.img \
+          root_hash_coco-extension.txt
+        disk_digest="$(oras manifest fetch \
+          "${DISK_IMAGE}:${tag}" --descriptor | jq -r .digest)"
+        popd >/dev/null
+
+        digest_pattern='^sha256:[0-9a-f]{64}$'
+        if [[ ! "${container_digest}" =~ ${digest_pattern} ]]; then
+          echo "Invalid container image digest: ${container_digest}" >&2
+          exit 1
+        fi
+        if [[ ! "${disk_digest}" =~ ${digest_pattern} ]]; then
+          echo "Invalid disk image digest: ${disk_digest}" >&2
+          exit 1
+        fi
+
+        echo "container-digest=${container_digest}" >> "${GITHUB_OUTPUT}"
+        echo "disk-digest=${disk_digest}" >> "${GITHUB_OUTPUT}"
+
+    - name: Generate provenance for the OCI container image
+      uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4.2.2
+      with:
+        subject-name: ${{ env.CONTAINER_IMAGE }}
+        subject-digest: ${{ steps.publish.outputs.container-digest }}
+        push-to-registry: true
+
+    - name: Generate provenance for the disk image
+      uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4.2.2
+      with:
+        subject-name: ${{ env.DISK_IMAGE }}
+        subject-digest: ${{ steps.publish.outputs.disk-digest }}
+        push-to-registry: true
+
+  publish-manifests:
+    name: publish manifest (${{ matrix.variant }})
+    if: >-
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success'
+    needs: publish
+    permissions:
+      packages: write # publish PR-scoped multi-arch manifests to ghcr.io
+    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        variant:
+        - ubuntu24.04
+        - ubuntu26.04
+    env:
+      HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+      VARIANT: ${{ matrix.variant }}
+    steps:
+    - name: Harden the runner (Audit all outbound calls)
+      uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
+      with:
+        egress-policy: audit
+
+    - name: Log in to the Container registry
+      uses: docker/login-action@371161bbe7024a29a25c5e19bfcbc0804fe9ad2c # v4.5.2
+      with:
+        registry: ${{ env.REGISTRY }}
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Assemble multi-arch manifests
+      run: |
+        tag="pr-${HEAD_SHA}-${VARIANT}"
+        for image in "${CONTAINER_IMAGE}" "${DISK_IMAGE}"; do
+          docker manifest create "${image}:${tag}" \
+            --amend "${image}:${tag}-amd64" \
+            --amend "${image}:${tag}-arm64" \
+            --amend "${image}:${tag}-s390x"
+          docker manifest annotate --arch amd64 --os linux \
+            "${image}:${tag}" "${image}:${tag}-amd64"
+          docker manifest annotate --arch arm64 --os linux \
+            "${image}:${tag}" "${image}:${tag}-arm64"
+          docker manifest annotate --arch s390x --os linux \
+            "${image}:${tag}" "${image}:${tag}-s390x"
+          docker manifest push "${image}:${tag}"
+        done
+
+        echo "Kata versions.yaml value: ${tag}" >> "${GITHUB_STEP_SUMMARY}"


### PR DESCRIPTION
## Why

Kata needs a published CoCo extension image to test a guest-components pull request before it merges. The existing pull-request workflow builds the images, but only uploads workflow artifacts; fork pull requests cannot publish directly because their `GITHUB_TOKEN` is read-only.

## How

Reuse `coco-extension-image.yml` for both normal builds and trusted pull-request artifact promotion:

- the existing `pull_request` path still builds without registry credentials and uploads its six matrix artifacts;
- a small `workflow_run` entry point calls the existing workflow with the completed run ID and a `pr-<head-sha>` version;
- the called workflow skips checkout and all PR-controlled build steps, validates and restores the artifacts, then uses the existing login, publish, attestation, release, and manifest logic;
- pull-request images are published as `pr-<head-sha>-ubuntu<release>`; and
- main, latest, and release tag behavior is unchanged.

A Kata branch can set `.externals.coco-guest-components.version` to, for example, `pr-<head-sha>-ubuntu24.04`.

The PR-scoped tags cannot replace a main or release tag. They remain in GHCR after the source PR closes; registry retention can be handled separately if their volume becomes material.

## Validation

- `actionlint` passes for the new workflow and reports only the existing custom `s390x` runner-label warning for the reused workflow.
- `zizmor --persona auditor .` reports no findings.
- The artifact contract was checked against all six outputs from successful CoCo PR workflow run 32327104540.
- A downloaded arm64 OCI archive was copied successfully with the same `skopeo` source transport used by promotion, and its disk artifacts were validated and restored under Kata's canonical filenames.
