### PR TITLE
image-rs: add opt-in anonymous fallback for rejected credentials

### DIFF
--- a/confidential-data-hub/example.config.json
+++ b/confidential-data-hub/example.config.json
@@ -24,6 +24,7 @@
         "image_security_policy_uri": "kbs:///default/security-policy/test",
         "image_security_policy": "{\"default\":[{\"type\": \"reject\"}]}",
         "authenticated_registry_credentials_uri": "kbs:///default/credential/test",
+        "anonymous_fallback_on_unauthorized": false,
         "registry_configuration_uri": "kbs:///default/registry-configuration/test",
         "registry_config": {
             "unqualified-search-registries": [

--- a/confidential-data-hub/example.config.toml
+++ b/confidential-data-hub/example.config.toml
@@ -142,6 +142,11 @@ image_security_policy_uri = "kbs:///default/security-policy/test"
 # is set, the value of the environment variable will be used.
 authenticated_registry_credentials_uri = "kbs:///default/credential/test"
 
+# Retry an image pull anonymously when the registry rejects the
+# configured credential (e.g. an expired token), so public images
+# remain pullable.
+anonymous_fallback_on_unauthorized = false
+
 # Registry configuration supports defining registry blocking, mirroring,
 # and remapping rules. This field points to a registry configuration file,
 # which can either be stored locally in the rootfs or retrieved from the KBS.

--- a/image-rs/src/builder.rs
+++ b/image-rs/src/builder.rs
@@ -89,6 +89,8 @@ impl ClientBuilder {
         String
     );
 
+    __impl_config!(anonymous_fallback_on_unauthorized, bool);
+
     __impl_config!(max_concurrent_layer_downloads_per_image, usize);
 
     #[cfg(feature = "keywrap-native")]

--- a/image-rs/src/config.rs
+++ b/image-rs/src/config.rs
@@ -130,6 +130,12 @@ pub struct ImageConfig {
     #[serde(default = "Option::default")]
     pub authenticated_registry_credentials_uri: Option<String>,
 
+    /// Retry an image pull anonymously when the registry rejects the
+    /// configured credential (e.g. an expired token), so public images
+    /// remain pullable.
+    #[serde(default)]
+    pub anonymous_fallback_on_unauthorized: bool,
+
     /// Registry configuration supports defining registry blocking, mirroring,
     /// and remapping rules. This field points to a registry configuration file,
     /// which can either be stored locally in the rootfs or retrieved from the KBS.
@@ -205,6 +211,7 @@ impl Default for ImageConfig {
             sigstore_config_uri: None,
             sigstore_config: None,
             authenticated_registry_credentials_uri: None,
+            anonymous_fallback_on_unauthorized: false,
             registry_configuration_uri: None,
             registry_config: None,
             image_pull_proxy: None,
@@ -282,6 +289,7 @@ impl ImageConfig {
             sigstore_config_uri: None,
             sigstore_config: None,
             authenticated_registry_credentials_uri: None,
+            anonymous_fallback_on_unauthorized: false,
             registry_configuration_uri: None,
             registry_config: None,
             image_pull_proxy: None,
@@ -444,6 +452,7 @@ mod tests {
             config.max_concurrent_layer_downloads_per_image,
             DEFAULT_MAX_CONCURRENT_DOWNLOAD
         );
+        assert!(!config.anonymous_fallback_on_unauthorized);
 
         let env_work_dir = "/tmp";
         let config = ImageConfig::new(PathBuf::from(env_work_dir));
@@ -458,6 +467,7 @@ mod tests {
             "default_snapshot": "overlay",
             "image_security_policy_uri": "file:///etc/image-policy.json",
             "authenticated_registry_credentials_uri": "file:///etc/image-auth.json",
+            "anonymous_fallback_on_unauthorized": true,
 	        "max_concurrent_layer_downloads_per_image": 1
         }"#;
 
@@ -483,6 +493,7 @@ mod tests {
             config.authenticated_registry_credentials_uri,
             Some("file:///etc/image-auth.json".to_string())
         );
+        assert!(config.anonymous_fallback_on_unauthorized);
 
         let invalid_config_file = tempdir.path().join("does-not-exist");
         assert!(!invalid_config_file.exists());

--- a/image-rs/src/image.rs
+++ b/image-rs/src/image.rs
@@ -5,6 +5,7 @@
 use anyhow::{bail, Context};
 use oci_client::{
     client::{Certificate, CertificateEncoding, ClientConfig, ClientProtocol},
+    errors::OciDistributionError,
     manifest::{OciDescriptor, OciImageManifest},
     secrets::RegistryAuth,
     ParseError, Reference,
@@ -292,45 +293,12 @@ impl ImageClient {
         })
     }
 
-    async fn pull_task(
-        &mut self,
-        task: ImagePullTask,
-        auth_info: &Option<&str>,
-        bundle_dir: &Path,
-        decrypt_config: &Option<&str>,
-        image_url: &str,
-    ) -> PullImageResult<ImageInfo> {
-        // Try to find a valid registry auth. Logic order
-        // 1. the input parameter
-        // 2. from self.registry_auth
-        // 3. use Anonymous auth
-        let auth = match auth_info {
-            Some(input_auth) => match input_auth.split_once(':') {
-                Some((username, password)) => {
-                    RegistryAuth::Basic(username.to_string(), password.to_string())
-                }
-                None => {
-                    return Err(PullImageError::IllegalRegistryAuth {
-                        image: image_url.into(),
-                        auth_source: format!("input `{input_auth}`"),
-                    })
-                }
-            },
-            None => match &self.registry_auth {
-                Some(registry_auth) => registry_auth
-                    .credential_for_reference(&task.image_reference)
-                    .await
-                    .map_err(|_| PullImageError::IllegalRegistryAuth {
-                        image: image_url.into(),
-                        auth_source: "auth config".into(),
-                    })?,
-                None => {
-                    info!("Use Anonymous image registry auth");
-                    RegistryAuth::Anonymous
-                }
-            },
-        };
-
+    /// Builds a PullClient for one pull task with the given auth.
+    fn new_pull_client<'a>(
+        &self,
+        task: &ImagePullTask,
+        auth: &'a RegistryAuth,
+    ) -> PullImageResult<PullClient<'a>> {
         let mut client_config = ClientConfig::default();
         if task.use_http {
             client_config.protocol = ClientProtocol::Http;
@@ -373,17 +341,77 @@ impl ImageClient {
             });
         client_config.extra_root_certificates.extend(certs);
 
-        let mut client = PullClient::new(
-            task.image_reference,
+        PullClient::new(
+            task.image_reference.clone(),
             self.layer_store.clone(),
-            &auth,
+            auth,
             self.config.max_concurrent_layer_downloads_per_image,
             client_config,
         )
-        .map_err(|source| PullImageError::Internal { source })?;
+        .map_err(|source| PullImageError::Internal { source })
+    }
 
-        let (image_manifest, image_digest, image_config, manifest_list_digest) =
-            client.pull_manifest().await?;
+    async fn pull_task(
+        &mut self,
+        task: ImagePullTask,
+        auth_info: &Option<&str>,
+        bundle_dir: &Path,
+        decrypt_config: &Option<&str>,
+        image_url: &str,
+    ) -> PullImageResult<ImageInfo> {
+        // Try to find a valid registry auth. Logic order
+        // 1. the input parameter
+        // 2. from self.registry_auth
+        // 3. use Anonymous auth
+        let auth = match auth_info {
+            Some(input_auth) => match input_auth.split_once(':') {
+                Some((username, password)) => {
+                    RegistryAuth::Basic(username.to_string(), password.to_string())
+                }
+                None => {
+                    return Err(PullImageError::IllegalRegistryAuth {
+                        image: image_url.into(),
+                        auth_source: format!("input `{input_auth}`"),
+                    })
+                }
+            },
+            None => match &self.registry_auth {
+                Some(registry_auth) => registry_auth
+                    .credential_for_reference(&task.image_reference)
+                    .await
+                    .map_err(|_| PullImageError::IllegalRegistryAuth {
+                        image: image_url.into(),
+                        auth_source: "auth config".into(),
+                    })?,
+                None => {
+                    info!("Use Anonymous image registry auth");
+                    RegistryAuth::Anonymous
+                }
+            },
+        };
+
+        let mut client = self.new_pull_client(&task, &auth)?;
+
+        let (image_manifest, image_digest, image_config, manifest_list_digest) = match client
+            .pull_manifest()
+            .await
+        {
+            // Optionally retry anonymously on a rejected credential. A fresh
+            // client is required: the old one caches the rejected credential
+            // and layer pulls would reuse it.
+            Err(PullLayerError::PullManifestError {
+                source: OciDistributionError::UnauthorizedError { .. },
+            }) if self.config.anonymous_fallback_on_unauthorized
+                && !matches!(auth, RegistryAuth::Anonymous) =>
+            {
+                warn!(
+                    "registry rejected the configured credential for {image_url}; retrying anonymously"
+                );
+                client = self.new_pull_client(&task, &RegistryAuth::Anonymous)?;
+                client.pull_manifest().await?
+            }
+            other => other?,
+        };
 
         let id = image_manifest.config.digest.clone();
 
@@ -407,7 +435,7 @@ impl ImageClient {
                     image_url,
                     &image_digest,
                     manifest_list_digest.as_deref(),
-                    &auth,
+                    client.auth,
                 )
                 .await?;
         }


### PR DESCRIPTION
## Summary

When image-rs is configured with registry credentials, a rejected credential (e.g. an expired token) will fail the image pull for public images. In a measured guest, where the credential is baked into the rootfs, one expired token will break every pull on the node.

This PR adds the `anonymous_fallback_on_unauthorized` config switch. When enabled, a pull that fails with `UnauthorizedError` under non-anonymous auth is retried once with a fresh anonymous client. This flag is disabled by default, so default behavior is unchanged, i.e. a rejected credential will fail the image pull.
