### PR TITLE
Makefile: add workspace fmt/lint/test make targets

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,8 +27,30 @@ make build-protos
 
 ## Test
 
+The workspace root and each component crate expose `make test` targets. Prefer these for
+local checks — they exercise the same feature combinations as `make lint` and component
+builds.
+
 ```bash
-# Run all tests for a single crate
+# Run tests for all components (CDH and image-rs need root; see note below)
+make test
+sudo -E PATH=$PATH make test
+
+# Run tests for a single component
+make -C attestation-agent test
+make -C confidential-data-hub test
+make -C api-server-rest test
+make -C image-rs test
+make -C ocicrypt-rs test
+
+# Attestation-agent: build/lint/test share ATTESTER and OPENSSL knobs
+make -C attestation-agent ATTESTER=all-attesters test
+make -C attestation-agent ATTESTER=tdx-attester OPENSSL=1 test   # s390x sets OPENSSL=1 by default
+```
+
+For ad-hoc single-crate or single-test runs:
+
+```bash
 cargo test -p attestation-agent
 cargo test -p confidential-data-hub
 cargo test -p image-rs
@@ -51,10 +73,27 @@ Most integration tests require root privileges, running CDH/KBS services, and pr
 ## Lint
 
 ```bash
+# Workspace-wide checks (preferred entry point)
+make fmt
+make lint
+
+# Per-component lint (same feature matrices as component test targets)
+make -C attestation-agent lint
+make -C confidential-data-hub lint
+make -C api-server-rest lint
+make -C image-rs lint
+make -C ocicrypt-rs lint
+```
+
+`attestation-agent`, `image-rs`, and `ocicrypt-rs` lint multiple feature combinations
+(including `--no-default-features` presets). `image-rs` and `ocicrypt-rs` keep mutually
+exclusive feature axes; native keywrap targets run on x86_64 only.
+
+For one-off cargo runs:
+
+```bash
 cargo fmt --check
 cargo clippy -- -D warnings
-
-# Clippy with features (CI validates multiple feature combinations)
 cargo clippy -p image-rs --features kata-cc-rustls-tls -- -D warnings
 ```
 

--- a/Makefile
+++ b/Makefile
@@ -92,5 +92,27 @@ build-protos:
   fi;
 	cargo build -p protos --features build
 
+fmt:
+	cargo fmt --all -- --check
+
+lint:
+	$(MAKE) -C $(AA) lint
+	$(MAKE) -C $(CDH) LIBC=gnu lint
+	$(MAKE) -C $(ASR) lint
+	$(MAKE) -C image-rs lint
+	$(MAKE) -C ocicrypt-rs lint
+
+# CDH and image-rs integration tests need root (loop/zfs devices, /etc fixtures).
+# sudo -E PATH=$(PATH) $(MAKE) test
+test:
+	@if [ "$$(id -u)" -ne 0 ]; then \
+		echo >&2 "note: CDH/image-rs tests need root; re-run with: sudo -E PATH=\$$PATH $(MAKE) test"; \
+	fi
+	$(MAKE) -C $(AA) test
+	$(MAKE) -C $(CDH) LIBC=gnu test
+	$(MAKE) -C $(ASR) test
+	$(MAKE) -C image-rs test
+	$(MAKE) -C ocicrypt-rs test
+
 clean:
 	rm -rf target

--- a/api-server-rest/Makefile
+++ b/api-server-rest/Makefile
@@ -73,6 +73,12 @@ build:
 
 TARGET := $(TARGET_DIR)/$(BIN_NAME)
 
+lint:
+	cargo clippy -p api-server-rest --all-targets -- -D warnings
+
+test:
+	cargo test -p api-server-rest
+
 install: 
 	install -D -m0755 $(TARGET) $(DESTDIR)/$(BIN_NAME)
 

--- a/attestation-agent/Makefile
+++ b/attestation-agent/Makefile
@@ -25,8 +25,6 @@ DESTDIR ?= $(PREFIX)/bin
 RUSTFLAGS_ARGS ?=
 binary ?=
 binary_name ?=
-ATTESTER ?=
-features ?= coco_as,kbs
 OPENSSL ?=
 
 ifeq ($(SOURCE_ARCH), ppc64le)
@@ -37,22 +35,42 @@ ifeq ($(ARCH), $(filter $(ARCH), s390x powerpc64le))
   OPENSSL=1
 endif
 
-ifeq ($(ttrpc), false)
-    binary = --bin grpc-aa
-    features += bin,grpc
-    binary_name = grpc-aa
+ifeq ($(ARCH), s390x)
+    ATTESTER ?= se-attester
+else ifeq ($(ARCH), aarch64)
+    ATTESTER ?= cca-attester
 else
-    binary = --bin ttrpc-aa
-    features += bin,ttrpc
-    binary_name = ttrpc-aa
+    ATTESTER ?= all-attesters
 endif
 
-ifdef ATTESTER
-    ifneq ($(ATTESTER), none)
-        features += $(ATTESTER)
-    endif
+ifeq ($(ttrpc), false)
+    binary = --bin grpc-aa
+    binary_name = grpc-aa
+    RPC = grpc
 else
-    features += all-attesters
+    binary = --bin ttrpc-aa
+    binary_name = ttrpc-aa
+    RPC = ttrpc
+endif
+
+ifdef OPENSSL
+    CRYPTO := openssl
+else
+    CRYPTO := rust-crypto
+endif
+
+ifeq ($(ATTESTER), none)
+    AA_FEATURES := kbs,coco_as,bin,$(RPC),$(CRYPTO)
+    AA_CHECK_FEATURES := kbs,coco_as,bin,ttrpc,grpc,$(CRYPTO)
+    ATTESTER_PKG_FEATURES := bin
+    KBC_FEATURES := cc_kbc,$(CRYPTO)
+    KBS_PROTOCOL_FEATURES := background_check,passport,$(CRYPTO),bin,aa_ttrpc,pqc-experimental
+else
+    AA_FEATURES := kbs,coco_as,bin,$(RPC),$(CRYPTO),$(ATTESTER)
+    AA_CHECK_FEATURES := kbs,coco_as,bin,ttrpc,grpc,$(CRYPTO),$(ATTESTER)
+    ATTESTER_PKG_FEATURES := $(ATTESTER),bin
+    KBC_FEATURES := cc_kbc,$(ATTESTER),$(CRYPTO)
+    KBS_PROTOCOL_FEATURES := background_check,passport,$(CRYPTO),$(ATTESTER),bin,aa_ttrpc,pqc-experimental
 endif
 
 ifeq ($(LIBC), musl)
@@ -96,55 +114,31 @@ ifneq ($(RUSTFLAGS_ARGS),)
     RUST_FLAGS := RUSTFLAGS="$(RUSTFLAGS_ARGS)"
 endif
 
-ifdef OPENSSL
-    features := $(features),openssl
-else
-    features := $(features),rust-crypto
-endif
-
-ifeq ($(ARCH), $(filter $(ARCH), s390x aarch64))
-    LINT_OPTION = lint-$(ARCH)
-else
-    LINT_OPTION = lint-default
-endif
-
 build:
-	cd attestation-agent && $(RUST_FLAGS) cargo build $(release) --no-default-features --features "$(features)" $(binary) $(LIBC_FLAG)
+	cd attestation-agent && $(RUST_FLAGS) cargo build $(release) --no-default-features --features "$(AA_FEATURES)" $(binary) $(LIBC_FLAG)
 	mv $(TARGET_DIR)/$(binary_name) $(TARGET)
 
 TARGET := $(TARGET_DIR)/$(BIN_NAME)
 
-lint: $(LINT_OPTION)
-
-lint-default:
-	cargo clippy -p attestation-agent --features kbs,coco_as,bin,grpc,ttrpc,all-attesters -- -D warnings
-	cargo clippy -p attester --all-targets --features all-attesters,bin -- -D warnings
+lint:
+	cargo clippy -p attestation-agent --all-targets --no-default-features --features "$(AA_CHECK_FEATURES)" -- -D warnings
+	cargo clippy -p attester --all-targets --no-default-features --features "$(ATTESTER_PKG_FEATURES)" -- -D warnings
 	cargo clippy -p coco_keyprovider --all-targets -- -D warnings
-	cargo clippy -p kbc --all-targets --features cc_kbc,all-attesters,rust-crypto -- -D warnings
+	cargo clippy -p kbc --all-targets --no-default-features --features "$(KBC_FEATURES)" -- -D warnings
 	cargo clippy -p kbs_protocol --all-targets --no-default-features \
-		--features background_check,passport,rust-crypto,all-attesters,bin,aa_ttrpc -- -D warnings
-	cargo clippy -p crypto --all-targets --features rust-crypto -- -D warnings
+		--features "$(KBS_PROTOCOL_FEATURES)" -- -D warnings
+	cargo clippy -p crypto --all-targets --no-default-features --features $(CRYPTO) -- -D warnings
 	cargo clippy -p resource_uri --all-targets -- -D warnings
 
-lint-s390x:
-	cargo clippy -p attestation-agent --no-default-features --features openssl,kbs,coco_as,bin,grpc,ttrpc -- -D warnings
-	cargo clippy -p attester --all-targets --no-default-features --features se-attester,bin -- -D warnings
-	cargo clippy -p coco_keyprovider --all-targets -- -D warnings
-	cargo clippy -p kbc --all-targets --no-default-features --features cc_kbc,se-attester,openssl -- -D warnings
-	cargo clippy -p kbs_protocol --all-targets --no-default-features \
-		--features background_check,passport,openssl,se-attester,bin,aa_ttrpc -- -D warnings
-	cargo clippy -p crypto --all-targets --no-default-features --features openssl -- -D warnings
-	cargo clippy -p resource_uri --all-targets -- -D warnings
-
-lint-aarch64:
-	cargo clippy -p attestation-agent --no-default-features --features openssl,rust-crypto,cca-attester,kbs,coco_as,bin,grpc,ttrpc -- -D warnings
-	cargo clippy -p attester --all-targets --no-default-features --features cca-attester,bin -- -D warnings
-	cargo clippy -p coco_keyprovider --all-targets -- -D warnings
-	cargo clippy -p kbc --all-targets --no-default-features --features cc_kbc,cca-attester,rust-crypto -- -D warnings
-	cargo clippy -p kbs_protocol --all-targets --no-default-features \
-		--features background_check,passport,rust-crypto,cca-attester,bin,aa_ttrpc -- -D warnings
-	cargo clippy -p crypto --all-targets --features rust-crypto -- -D warnings
-	cargo clippy -p resource_uri --all-targets -- -D warnings
+test:
+	cargo test -p attestation-agent --all-targets --no-default-features --features "$(AA_CHECK_FEATURES)"
+	cargo test -p attester --all-targets --no-default-features --features "$(ATTESTER_PKG_FEATURES)"
+	cargo test -p coco_keyprovider --all-targets
+	cargo test -p kbc --all-targets --no-default-features --features "$(KBC_FEATURES)"
+	cargo test -p kbs_protocol --all-targets --no-default-features \
+		--features "$(KBS_PROTOCOL_FEATURES)"
+	cargo test -p crypto --all-targets --no-default-features --features $(CRYPTO)
+	cargo test -p resource_uri --all-targets
 
 install: 
 	install -D -m0755 $(TARGET) $(DESTDIR)/$(BIN_NAME)
@@ -157,5 +151,6 @@ clean:
 
 help:
 	@echo "==========================Help========================================="
+	@echo "build/lint/test share ATTESTER and OPENSSL (ARCH picks the default attester)"
 	@echo "build: make [DEBUG=1] [LIBC=(musl)] [ARCH=(x86_64/s390x/ppc64le)] [OPENSSL=1] [ATTESTER=all-attesters]"
 	@echo "install: make install [DESTDIR=/path/to/target] [LIBC=(musl)]"

--- a/confidential-data-hub/Makefile
+++ b/confidential-data-hub/Makefile
@@ -108,6 +108,13 @@ build:
 
 TARGET := $(TARGET_DIR)/$(BIN_NAME)
 
+lint:
+	cargo clippy -p kms -p confidential-data-hub -- -D warnings
+	cargo clippy -p kms -p confidential-data-hub --all-targets --features aws -- -D warnings
+
+test:
+	cargo test --features kbs,aliyun,bin -p kms -p confidential-data-hub -- --nocapture
+
 install: 
 	install -D -m0755 $(TARGET) $(DESTDIR)/$(BIN_NAME)
 

--- a/image-rs/Makefile
+++ b/image-rs/Makefile
@@ -1,0 +1,24 @@
+ARCH=$(shell uname -m)
+
+.PHONY: lint build test
+
+lint:
+	cargo clippy -p image-rs --all-targets --features=default -- -D warnings
+	cargo clippy -p image-rs --all-targets --no-default-features --features=kata-cc-rustls-tls -- -D warnings
+	cargo clippy -p image-rs --all-targets --no-default-features --features=kata-cc-native-tls -- -D warnings
+ifeq ($(ARCH),x86_64)
+	cargo clippy -p image-rs --all-targets --no-default-features --features=keywrap-native -- -D warnings
+endif
+
+build:
+	cargo build -p image-rs --features default
+
+test:
+	cargo test -p image-rs --features default
+	cargo test -p image-rs --no-default-features --features=encryption-ring,keywrap-grpc,signature-cosign-rustls,signature-simple,kbs,oci-client/rustls-tls,keywrap-jwe
+	cargo test -p image-rs --no-default-features --features=encryption-openssl,keywrap-grpc,signature-cosign-native,signature-simple,kbs,oci-client/native-tls,keywrap-jwe
+	cargo test -p image-rs --no-default-features --features=kata-cc-rustls-tls,keywrap-jwe
+	cargo test -p image-rs --no-default-features --features=kata-cc-native-tls,keywrap-jwe,signature-simple-xrss
+ifeq ($(ARCH),x86_64)
+	cargo test -p image-rs --no-default-features --features=keywrap-native
+endif

--- a/ocicrypt-rs/Makefile
+++ b/ocicrypt-rs/Makefile
@@ -1,0 +1,36 @@
+ARCH=$(shell uname -m)
+
+.PHONY: lint build test
+
+# keywrap-keyprovider-native pulls kbc/sgx-attester; only compile it on x86_64.
+lint:
+ifeq ($(ARCH),x86_64)
+	cargo clippy -p ocicrypt-rs --all-targets --all-features -- -D warnings
+else
+	cargo clippy -p ocicrypt-rs --all-targets \
+		--features async-io,block-cipher-ring,keywrap-keyprovider-grpc,keywrap-keyprovider-ttrpc \
+		-- -D warnings
+endif
+
+build:
+ifeq ($(ARCH),x86_64)
+	cargo build -p ocicrypt-rs --all-features
+endif
+	cargo build -p ocicrypt-rs --no-default-features
+	cargo build -p ocicrypt-rs --no-default-features --features=block-cipher-openssl
+	cargo build -p ocicrypt-rs --no-default-features --features=block-cipher-ring
+	cargo build -p ocicrypt-rs --no-default-features --features=keywrap-jwe
+	cargo build -p ocicrypt-rs --no-default-features --features=keywrap-keyprovider
+
+test: build
+ifeq ($(ARCH),x86_64)
+	cargo test -p ocicrypt-rs --all-features
+endif
+	cargo test -p ocicrypt-rs --no-default-features
+	cargo test -p ocicrypt-rs --no-default-features --features=keywrap-jwe
+	cargo test -p ocicrypt-rs --no-default-features --features=keywrap-keyprovider-cmd
+	cargo test -p ocicrypt-rs --no-default-features --features=keywrap-keyprovider-grpc
+	cargo test -p ocicrypt-rs --no-default-features --features=keywrap-keyprovider-ttrpc
+ifeq ($(ARCH),x86_64)
+	cargo test -p ocicrypt-rs --no-default-features --features=keywrap-keyprovider-native
+endif


### PR DESCRIPTION
## Summary

Split from #1670. Local lint/test today uses different feature knobs than build (especially in attestation-agent), so `make ATTESTER=… test` does not always check what we ship.

Helped with [Cursor](https://cursor.com)