### PR TITLE
KBC: drop unused registry APIs and wire offline_fs into native

### DIFF
--- a/attestation-agent/kbc/Cargo.toml
+++ b/attestation-agent/kbc/Cargo.toml
@@ -16,7 +16,6 @@ resource_uri.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 strum.workspace = true
-url.workspace = true
 zeroize.workspace = true
 
 [dev-dependencies]
@@ -26,7 +25,7 @@ rstest.workspace = true
 [build-dependencies]
 
 [features]
-default = ["sample_kbc", "rust-crypto"]
+default = ["rust-crypto"]
 
 cc_kbc = ["kbs_protocol/background_check"]
 all-attesters = ["kbs_protocol?/all-attesters"]
@@ -39,9 +38,6 @@ snp-attester = ["kbs_protocol/snp-attester"]
 cca-attester = ["kbs_protocol/cca-attester"]
 se-attester = ["kbs_protocol/se-attester"]
 tpm-attester = ["kbs_protocol/tpm-attester"]
-
-sample_kbc = []
-offline_fs_kbc = []
 
 # Either `rust-crypto` or `openssl` should be enabled to work as underlying crypto module
 rust-crypto = ["crypto/rust-crypto", "kbs_protocol?/rust-crypto"]

--- a/attestation-agent/kbc/src/cc_kbc/mod.rs
+++ b/attestation-agent/kbc/src/cc_kbc/mod.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-use crate::{KbcCheckInfo, KbcInterface};
+use crate::KbcInterface;
 use crypto::{WrapType, decrypt};
 use kbs_protocol::{
     KbsClientBuilder, KbsClientCapabilities,
@@ -19,16 +19,11 @@ use resource_uri::ResourceUri;
 use zeroize::Zeroizing;
 
 pub struct Kbc {
-    token: Option<String>,
     kbs_client: KbsClient<Box<dyn EvidenceProvider>>,
 }
 
 #[async_trait]
 impl KbcInterface for Kbc {
-    fn check(&self) -> Result<KbcCheckInfo> {
-        Err(anyhow!("Check API of this KBC is unimplemented."))
-    }
-
     async fn decrypt_payload(&mut self, annotation_packet: AnnotationPacket) -> Result<Vec<u8>> {
         let key_data = self.kbs_client.get_resource(annotation_packet.kid).await?;
         let key = Zeroizing::new(key_data);
@@ -56,9 +51,6 @@ impl Kbc {
             &kbs_uri,
         )
         .build()?;
-        Ok(Kbc {
-            token: None,
-            kbs_client,
-        })
+        Ok(Kbc { kbs_client })
     }
 }

--- a/attestation-agent/kbc/src/lib.rs
+++ b/attestation-agent/kbc/src/lib.rs
@@ -6,35 +6,23 @@
 #[macro_use]
 extern crate strum;
 
-use std::collections::HashMap;
-
 use anyhow::*;
 use async_trait::async_trait;
 use resource_uri::ResourceUri;
-use serde::{Deserialize, Serialize};
 
 pub use self::annotation_packet::AnnotationPacket;
 
-// Add your specific kbc declaration here.
-// For example: "pub mod sample_kbc;"
-#[allow(dead_code)]
 #[cfg(feature = "cc_kbc")]
 pub mod cc_kbc;
 
-#[cfg(feature = "offline_fs_kbc")]
 pub mod offline_fs_kbc;
-
-#[cfg(feature = "sample_kbc")]
 pub mod sample_kbc;
 
 pub mod annotation_packet;
 
-// KbcInterface is a standard interface that all KBC modules need to implement.
+/// KbcInterface is a standard interface that all KBC modules need to implement.
 #[async_trait]
 pub trait KbcInterface: Send {
-    /// Get information about KBC plugin.
-    fn check(&self) -> Result<KbcCheckInfo>;
-
     /// Decrypt module specific encrypted payload into plaintext in asynchronous mode.
     /// The reason why this interface consumes the [`AnnotationPacket`] instead of simply
     /// return the key by key id is that some potential KBCs which use specific KMS can not
@@ -45,85 +33,6 @@ pub trait KbcInterface: Send {
     async fn get_resource(&mut self, _resource_uri: ResourceUri) -> Result<Vec<u8>> {
         bail!("Get Resource API of this KBC is unimplement!")
     }
-}
-
-/// A container type for [KbcInterface] trait objects.
-pub type KbcInstance = Box<dyn KbcInterface + Sync + Send>;
-
-/// Status information about KBC modules.
-pub struct KbcCheckInfo {
-    pub kbs_info: HashMap<String, String>,
-    // In the future, more KBC status fields will be expanded here.
-}
-
-type KbcInstantiateFunc = Box<dyn Fn(String) -> KbcInstance + Send + Sync>;
-
-/// A container type to host all registered KBC modules.
-pub struct KbcModuleList {
-    mod_list: HashMap<String, KbcInstantiateFunc>,
-}
-
-impl Default for KbcModuleList {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl KbcModuleList {
-    /// Create a new [KbcModuleList] and register all known KBC modules.
-    pub fn new() -> KbcModuleList {
-        #[allow(unused_mut)]
-        let mut mod_list = HashMap::new();
-
-        #[cfg(feature = "sample_kbc")]
-        {
-            let instantiate_func: KbcInstantiateFunc = Box::new(|kbs_uri: String| -> KbcInstance {
-                Box::new(sample_kbc::SampleKbc::new(kbs_uri))
-            });
-            mod_list.insert("sample_kbc".to_string(), instantiate_func);
-        }
-
-        #[cfg(feature = "cc_kbc")]
-        {
-            let instantiate_func: KbcInstantiateFunc = Box::new(|kbs_uri: String| -> KbcInstance {
-                Box::new(cc_kbc::Kbc::new(kbs_uri).unwrap())
-            });
-            mod_list.insert("cc_kbc".to_string(), instantiate_func);
-        }
-
-        #[cfg(feature = "offline_fs_kbc")]
-        {
-            let instantiate_func: KbcInstantiateFunc = Box::new(|_: String| -> KbcInstance {
-                Box::new(offline_fs_kbc::OfflineFsKbc::new())
-            });
-            mod_list.insert("offline_fs_kbc".to_string(), instantiate_func);
-        }
-
-        KbcModuleList { mod_list }
-    }
-
-    /// Get initialization function for a KBC module.
-    pub fn get_func(&self, kbc_name: &str) -> Result<&KbcInstantiateFunc> {
-        let instantiate_func: &KbcInstantiateFunc =
-            self.mod_list.get(kbc_name).ok_or_else(|| {
-                anyhow!(
-                    "AA does not support the given KBC module! Module: {}",
-                    kbc_name
-                )
-            })?;
-        Ok(instantiate_func)
-    }
-
-    pub fn names(&self) -> Vec<String> {
-        self.mod_list.keys().cloned().collect()
-    }
-}
-
-/// Descriptor for resources managed by attestation agent.
-#[derive(Serialize, Deserialize, Debug)]
-pub struct ResourceDescription {
-    name: String,
-    optional: HashMap<String, String>,
 }
 
 pub mod tests {

--- a/attestation-agent/kbc/src/offline_fs_kbc/mod.rs
+++ b/attestation-agent/kbc/src/offline_fs_kbc/mod.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-use crate::{KbcCheckInfo, KbcInterface};
+use crate::KbcInterface;
 
 pub mod common;
 use common::*;
@@ -13,7 +13,6 @@ use async_trait::async_trait;
 use base64::Engine;
 use crypto::WrapType;
 use resource_uri::{ResourcePluginPath, ResourceUri};
-use std::collections::HashMap;
 use zeroize::Zeroizing;
 
 use super::AnnotationPacket;
@@ -22,8 +21,6 @@ const KEYS_PATH: &str = "/etc/aa-offline_fs_kbc-keys.json";
 const RESOURCES_PATH: &str = "/etc/aa-offline_fs_kbc-resources.json";
 
 pub struct OfflineFsKbc {
-    // KBS info for compatibility; unused
-    kbs_info: HashMap<String, String>,
     // Stored keys, loaded from file system; load might fail
     keys: Result<Keys>,
     // Stored resources, loaded from file system; load might fail
@@ -32,12 +29,6 @@ pub struct OfflineFsKbc {
 
 #[async_trait]
 impl KbcInterface for OfflineFsKbc {
-    fn check(&self) -> Result<KbcCheckInfo> {
-        Ok(KbcCheckInfo {
-            kbs_info: self.kbs_info.clone(),
-        })
-    }
-
     async fn decrypt_payload(&mut self, annotation_packet: AnnotationPacket) -> Result<Vec<u8>> {
         let key = self.get_key(&annotation_packet.kid.resource_path()).await?;
         let wrap_type = WrapType::try_from(&annotation_packet.wrap_type[..])?;
@@ -68,7 +59,6 @@ impl OfflineFsKbc {
     #[allow(clippy::new_without_default)]
     pub fn new() -> OfflineFsKbc {
         OfflineFsKbc {
-            kbs_info: HashMap::new(),
             keys: load_keys(KEYS_PATH).map_err(|e| anyhow!("Failed to load keys: {}", e)),
             resources: load_resources(RESOURCES_PATH)
                 .map_err(|e| anyhow!("Failed to load resources: {}", e)),
@@ -99,7 +89,6 @@ mod tests {
     #[tokio::test]
     async fn test_get_key() {
         let mut kbc = OfflineFsKbc {
-            kbs_info: HashMap::new(),
             keys: Ok([(KID.to_string(), KEY.to_vec())].iter().cloned().collect()),
             resources: Ok([].iter().cloned().collect()),
         };
@@ -110,7 +99,6 @@ mod tests {
 
     fn kbc_instance() -> OfflineFsKbc {
         OfflineFsKbc {
-            kbs_info: HashMap::new(),
             keys: Err(anyhow!("no keys")),
             resources: Ok([
                 (

--- a/attestation-agent/kbc/src/sample_kbc/mod.rs
+++ b/attestation-agent/kbc/src/sample_kbc/mod.rs
@@ -3,15 +3,13 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-use crate::{KbcCheckInfo, KbcInterface};
+use crate::KbcInterface;
 use base64::Engine;
 use crypto::{WrapType, decrypt};
 
 use anyhow::*;
 use async_trait::async_trait;
 use resource_uri::{ResourcePluginPath, ResourceUri};
-use std::collections::HashMap;
-use zeroize::Zeroizing;
 
 use super::AnnotationPacket;
 
@@ -53,22 +51,14 @@ pub enum ResourceType {
     Credential,
 }
 
-pub struct SampleKbc {
-    kbs_info: HashMap<String, String>,
-}
+pub struct SampleKbc;
 
 // As a KBS client for attestation-agent,
 // it must implement KbcInterface trait.
 #[async_trait]
 impl KbcInterface for SampleKbc {
-    fn check(&self) -> Result<KbcCheckInfo> {
-        Ok(KbcCheckInfo {
-            kbs_info: self.kbs_info.clone(),
-        })
-    }
-
     async fn decrypt_payload(&mut self, annotation_packet: AnnotationPacket) -> Result<Vec<u8>> {
-        let key = Zeroizing::new(HARDCODED_KEY.to_vec());
+        let key = zeroize::Zeroizing::new(HARDCODED_KEY.to_vec());
         let engine = base64::engine::general_purpose::STANDARD;
         let plain_text = decrypt(
             key,
@@ -100,9 +90,7 @@ impl KbcInterface for SampleKbc {
 }
 
 impl SampleKbc {
-    pub fn new(kbs_uri: String) -> SampleKbc {
-        let mut kbs_info: HashMap<String, String> = HashMap::new();
-        kbs_info.insert("kbs_uri".to_string(), kbs_uri);
-        SampleKbc { kbs_info }
+    pub fn new(_kbs_uri: String) -> SampleKbc {
+        SampleKbc
     }
 }

--- a/image-rs/Cargo.toml
+++ b/image-rs/Cargo.toml
@@ -122,7 +122,6 @@ keywrap-grpc = ["ocicrypt-rs/keywrap-keyprovider-grpc", "tonic", "protos/grpc"]
 keywrap-native = [
     "ocicrypt-rs/keywrap-keyprovider-native",
     "kbc/cc_kbc",
-    "kbc/sample_kbc",
     "kbc/sgx-attester",
     "resource_uri",
 ]

--- a/image-rs/src/resource/kbs/native.rs
+++ b/image-rs/src/resource/kbs/native.rs
@@ -7,7 +7,9 @@
 
 use anyhow::*;
 use async_trait::async_trait;
-use kbc::{cc_kbc::Kbc as CcKbc, sample_kbc::SampleKbc, KbcInterface};
+use kbc::{
+    cc_kbc::Kbc as CcKbc, offline_fs_kbc::OfflineFsKbc, sample_kbc::SampleKbc, KbcInterface,
+};
 use resource_uri::ResourceUri;
 use tokio::sync::Mutex;
 
@@ -15,6 +17,7 @@ use super::Client;
 
 enum Kbc {
     Sample(SampleKbc),
+    OfflineFs(OfflineFsKbc),
     Cc(CcKbc),
 }
 
@@ -28,13 +31,20 @@ impl Native {
             bail!("aa_kbc_params: missing KBC name");
         }
 
-        if kbs_uri.is_empty() {
-            bail!("aa_kbc_params: missing KBS URI");
-        }
-
         let inner = match kbc_name {
-            "cc_kbc" => Kbc::Cc(CcKbc::new(kbs_uri.to_owned())?),
-            "sample_kbc" => Kbc::Sample(SampleKbc::new(kbs_uri.to_owned())),
+            "cc_kbc" => {
+                if kbs_uri.is_empty() {
+                    bail!("aa_kbc_params: missing KBS URI");
+                }
+                Kbc::Cc(CcKbc::new(kbs_uri.to_owned())?)
+            }
+            "sample_kbc" => {
+                if kbs_uri.is_empty() {
+                    bail!("aa_kbc_params: missing KBS URI");
+                }
+                Kbc::Sample(SampleKbc::new(kbs_uri.to_owned()))
+            }
+            "offline_fs_kbc" => Kbc::OfflineFs(OfflineFsKbc::new()),
             other => bail!("Unsupported KBC {other}"),
         };
 
@@ -50,6 +60,7 @@ impl Client for Native {
             ResourceUri::try_from(resource_path).map_err(|e| anyhow!("parse ResourceUri: {e}"))?;
         let resource = match *self.inner.lock().await {
             Kbc::Sample(ref mut inner) => inner.get_resource(url).await?,
+            Kbc::OfflineFs(ref mut inner) => inner.get_resource(url).await?,
             Kbc::Cc(ref mut inner) => inner.get_resource(url).await?,
         };
         Ok(resource)

--- a/ocicrypt-rs/Cargo.toml
+++ b/ocicrypt-rs/Cargo.toml
@@ -100,7 +100,6 @@ keywrap-keyprovider-native = [
     "zeroize",
     "kbc/cc_kbc",
     "kbc/rust-crypto",
-    "kbc/sample_kbc",
     "kbc/sgx-attester",
     "resource_uri",
 ]

--- a/ocicrypt-rs/src/keywrap/keyprovider/native.rs
+++ b/ocicrypt-rs/src/keywrap/keyprovider/native.rs
@@ -6,11 +6,15 @@
 use std::sync::{Arc, LazyLock};
 
 use anyhow::*;
-use kbc::{cc_kbc::Kbc as CcKbc, sample_kbc::SampleKbc, AnnotationPacket, KbcInterface};
+use kbc::{
+    cc_kbc::Kbc as CcKbc, offline_fs_kbc::OfflineFsKbc, sample_kbc::SampleKbc, AnnotationPacket,
+    KbcInterface,
+};
 use tokio::sync::RwLock;
 
 pub enum Kbc {
     Sample(SampleKbc),
+    OfflineFs(OfflineFsKbc),
     Cc(CcKbc),
 }
 
@@ -21,6 +25,7 @@ async fn initialize_channel(kbs_addr: &str, kbc: &str) -> Result<()> {
     let channel = match kbc {
         "cc_kbc" => Kbc::Cc(CcKbc::new(kbs_addr.to_owned())?),
         "sample_kbc" => Kbc::Sample(SampleKbc::new(kbs_addr.to_owned())),
+        "offline_fs_kbc" => Kbc::OfflineFs(OfflineFsKbc::new()),
         other => bail!("Unsupported KBC {other}"),
     };
 
@@ -47,6 +52,7 @@ pub async fn decrypt_image_layer_annotation(
         let writer = writer.as_mut().expect("unexpected uninitialized.");
         match writer {
             Kbc::Sample(inner) => inner.decrypt_payload(annotation_packet).await,
+            Kbc::OfflineFs(inner) => inner.decrypt_payload(annotation_packet).await,
             Kbc::Cc(inner) => inner.decrypt_payload(annotation_packet).await,
         }
     }?;


### PR DESCRIPTION
## Summary

Split from #1670. After AA moved secret handling to CDH, KBC still carried a plugin-registry API that nothing calls anymore. Removes that dead surface and routes native keywrap through offline_fs_kbc, which tests and local workflows already depend on.

Helped with [Cursor](https://cursor.com)