### PR TITLE
image-rs: fix --no-default-features builds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3860,13 +3860,12 @@ dependencies = [
  "devicemapper",
  "filetime",
  "flate2",
- "futures",
  "futures-util",
  "hex",
  "kbc",
  "loopdev",
  "nix 0.31.3",
- "oci-client 0.16.1",
+ "oci-client 0.17.0",
  "oci-spec 0.10.0",
  "ocicrypt-rs",
  "pathrs",
@@ -4320,7 +4319,6 @@ dependencies = [
  "serde_json",
  "strum 0.28.0",
  "tokio",
- "url",
  "zeroize",
 ]
 
@@ -5051,8 +5049,9 @@ dependencies = [
 
 [[package]]
 name = "oci-client"
-version = "0.16.1"
-source = "git+https://github.com/oras-project/rust-oci-client?rev=83092a67ebcaeed832eae090895a1c178d867344#83092a67ebcaeed832eae090895a1c178d867344"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5261a7fb43d9c53b8e63e6d5e86860719dad253d015d022066c72d585125aed8"
 dependencies = [
  "bytes",
  "chrono",

--- a/image-rs/Cargo.toml
+++ b/image-rs/Cargo.toml
@@ -22,13 +22,12 @@ cfg-if.workspace = true
 devicemapper = { version = "0.34.6", optional = true }
 filetime = "0.2"
 flate2 = "1.1"
-futures = { version = "0.3.32", optional = true }
 futures-util = "0.3"
 hex.workspace = true
 kbc = { path = "../attestation-agent/kbc", default-features = false, optional = true }
 loopdev = { git = "https://github.com/mdaffin/loopdev", rev = "c9f91e8f0326ce8a3364ac911e81eb32328a5f27" }
 nix = { workspace = true, features = ["mount", "fs"] }
-oci-client = { git = "https://github.com/oras-project/rust-oci-client", rev = "83092a67ebcaeed832eae090895a1c178d867344", default-features = false, optional = true }
+oci-client = { version = "0.17.0", default-features = false }
 oci-spec = "0.10.0"
 ocicrypt-rs = { path = "../ocicrypt-rs", default-features = false, features = [
     "async-io",
@@ -48,7 +47,7 @@ strum_macros = "0.28"
 astral-tokio-tar = "0.6.2"
 thiserror.workspace = true
 tokio.workspace = true
-tokio-util = "0.7.18"
+tokio-util = { version = "0.7.18", features = ["io-util"] }
 toml.workspace = true
 tonic = { workspace = true, optional = true }
 tracing.workspace = true
@@ -136,12 +135,7 @@ keywrap-ttrpc = [
 keywrap-jwe = ["ocicrypt-rs/keywrap-jwe"]
 
 signature = []
-signature-cosign = [
-    "signature",
-    "futures",
-    "sigstore/registry",
-    "sigstore/cosign",
-]
+signature-cosign = ["signature", "sigstore/registry", "sigstore/cosign"]
 signature-cosign-rustls = [
     "signature-cosign",
     "sigstore/rustls-tls",

--- a/image-rs/src/image.rs
+++ b/image-rs/src/image.rs
@@ -76,7 +76,6 @@ pub enum PullImageError {
         source: anyhow::Error,
     },
 
-    #[cfg(feature = "signature")]
     #[error("Image policy rejected: {0}")]
     SignatureValidationFailed(#[from] SignatureError),
 
@@ -400,7 +399,6 @@ impl ImageClient {
             }
         }
 
-        #[cfg(feature = "signature")]
         if let Some(signature_validator) = &self.signature_validator {
             signature_validator
                 .check_image_signature(

--- a/image-rs/src/lib.rs
+++ b/image-rs/src/lib.rs
@@ -15,7 +15,6 @@ pub mod meta_store;
 pub mod pull;
 pub mod registry;
 pub mod resource;
-#[cfg(feature = "signature")]
 pub mod signature;
 pub mod snapshots;
 pub mod stream;

--- a/image-rs/src/signature/mod.rs
+++ b/image-rs/src/signature/mod.rs
@@ -60,9 +60,9 @@ pub enum SignatureError {
 pub struct SignatureValidator {
     policy: Policy,
 
-    resource_provider: Arc<ResourceProvider>,
+    _resource_provider: Arc<ResourceProvider>,
 
-    proxy_config: Option<ProxyConfig>,
+    _proxy_config: Option<ProxyConfig>,
 
     #[cfg(feature = "signature-simple")]
     simple_signing_sigstore_config: Option<policy::SigstoreConfig>,
@@ -160,9 +160,9 @@ impl SignatureValidator {
         policy: &[u8],
         _simple_signing_sigstore_config: Option<Vec<u8>>,
         workdir: &Path,
-        proxy_config: Option<ProxyConfig>,
-        certificates: Vec<String>,
-        resource_provider: Arc<ResourceProvider>,
+        _proxy_config: Option<ProxyConfig>,
+        _certificates: Vec<String>,
+        _resource_provider: Arc<ResourceProvider>,
     ) -> SignatureResult<Self> {
         let policy: Policy =
             serde_json::from_slice(policy).map_err(|_| SignatureError::InvalidPolicyFile)?;
@@ -190,7 +190,7 @@ impl SignatureValidator {
         };
 
         #[cfg(feature = "signature-cosign")]
-        let certificates = certificates
+        let certificates = _certificates
             .into_iter()
             .map(|pem| pem.into_bytes())
             .map(|data| sigstore::registry::Certificate {
@@ -201,8 +201,9 @@ impl SignatureValidator {
 
         Ok(Self {
             policy,
-            resource_provider,
-            proxy_config,
+            _resource_provider,
+            _proxy_config,
+            #[cfg(feature = "signature-cosign")]
             certificates,
             #[cfg(feature = "signature-simple")]
             simple_signing_sigstore_config,

--- a/image-rs/src/signature/policy/cosign/mod.rs
+++ b/image-rs/src/signature/policy/cosign/mod.rs
@@ -40,11 +40,11 @@ impl SignatureValidator {
     ) -> Result<()> {
         parameter
             .check_image_signature(
-                self.resource_provider.clone(),
+                self._resource_provider.clone(),
                 image,
                 auth,
                 self.certificates.iter().collect(),
-                self.proxy_config.as_ref(),
+                self._proxy_config.as_ref(),
             )
             .await
     }
@@ -53,7 +53,7 @@ impl SignatureValidator {
 impl CosignParameters {
     async fn check_image_signature(
         &self,
-        resource_provider: Arc<ResourceProvider>,
+        _resource_provider: Arc<ResourceProvider>,
         image: &Image,
         auth: &RegistryAuth,
         certificates: Vec<&Certificate>,
@@ -65,7 +65,7 @@ impl CosignParameters {
         // Get the public key
         let key = match (&self.key_data, &self.key_path) {
             (None, None) => bail!("Neither keyPath nor keyData is specified."),
-            (None, Some(key_path)) => resource_provider.get_resource(key_path).await?,
+            (None, Some(key_path)) => _resource_provider.get_resource(key_path).await?,
             (Some(key_data), None) => key_data.as_bytes().to_vec(),
             (Some(_), Some(_)) => bail!("Both keyPath and keyData are specified."),
         };
@@ -313,9 +313,9 @@ mod tests {
         image
             .set_manifest_digest(image_digest)
             .expect("Set manifest digest failed.");
-        let resource_provider = ResourceProvider::default();
+        let _resource_provider = ResourceProvider::default();
 
-        let key = resource_provider
+        let key = _resource_provider
             .get_resource(parameter.key_path.as_ref().unwrap())
             .await
             .unwrap();
@@ -435,10 +435,10 @@ mod tests {
             .expect("Set manifest digest failed.");
 
         if let PolicyReqType::Cosign(scheme) = policy_requirement {
-            let resource_provider = ResourceProvider::default();
+            let _resource_provider = ResourceProvider::default();
             let res = scheme
                 .check_image_signature(
-                    Arc::new(resource_provider),
+                    Arc::new(_resource_provider),
                     &image,
                     &oci_client::secrets::RegistryAuth::Anonymous,
                     vec![],

--- a/image-rs/src/signature/policy/simple/mod.rs
+++ b/image-rs/src/signature/policy/simple/mod.rs
@@ -79,7 +79,7 @@ impl SignatureValidator {
             (Some(_), Some(_)) => bail!("Both keyPath and keyData specified."),
             (None, Some(key_data)) => base64::engine::general_purpose::STANDARD.decode(key_data)?,
             (Some(key_path), None) => self
-                .resource_provider
+                ._resource_provider
                 .get_resource(key_path)
                 .await
                 .map_err(|e| {

--- a/image-rs/src/stream/unpack.rs
+++ b/image-rs/src/stream/unpack.rs
@@ -4,7 +4,7 @@
 
 use anyhow::{anyhow, bail, Context, Result};
 use filetime::FileTime;
-use futures::StreamExt;
+use futures_util::StreamExt;
 use nix::libc;
 use nix::libc::timeval;
 use pathrs::{flags::OpenFlags, InodeType, Root};


### PR DESCRIPTION
## Summary

Split from #1670. Several always-on image-rs modules still depended on optional crates/features that `--no-default-features` builds drop, so minimal feature sets did not type-check. Fixes the dependency graph so those builds match what the code actually imports.

Helped with [Cursor](https://cursor.com)