### PR TITLE
ocicrypt-rs: make RPIT captures explicit

### DIFF
--- a/ocicrypt-rs/src/encryption.rs
+++ b/ocicrypt-rs/src/encryption.rs
@@ -211,7 +211,7 @@ pub fn encrypt_layer<'a, R: 'a + Read>(
     annotations: Option<&BTreeMap<String, String>>,
     digest: &str,
 ) -> Result<(
-    Option<impl Read + EncryptionFinalizer + 'a>,
+    Option<impl Read + EncryptionFinalizer + 'a + use<'a, R>>,
     EncLayerFinalizer,
 )> {
     let mut encrypted = false;
@@ -254,7 +254,7 @@ pub fn decrypt_layer<R: Read>(
     layer_reader: R,
     annotations: Option<&BTreeMap<String, String>>,
     unwrap_only: bool,
-) -> Result<(Option<impl Read>, String)> {
+) -> Result<(Option<impl Read + use<R>>, String)> {
     let priv_opts_data = decrypt_layer_key_opts_data(dc, annotations)?;
     let annotations = annotations.unwrap_or(&DEFAULT_ANNOTATION_MAP);
     let pub_opts_data = get_layer_pub_opts(annotations)?;
@@ -284,7 +284,7 @@ pub fn async_decrypt_layer<R: tokio::io::AsyncRead + Send>(
     layer_reader: R,
     annotations: Option<&BTreeMap<String, String>>,
     priv_opts_data: &[u8],
-) -> Result<(impl tokio::io::AsyncRead + Send, String)> {
+) -> Result<(impl tokio::io::AsyncRead + Send + use<R>, String)> {
     let annotations = annotations.unwrap_or(&DEFAULT_ANNOTATION_MAP);
     let pub_opts_data = get_layer_pub_opts(annotations)?;
     let pub_opts: PublicLayerBlockCipherOptions = serde_json::from_slice(&pub_opts_data)?;


### PR DESCRIPTION
Make the return-position impl Trait (RPIT) capture sets explicit for the synchronous and asynchronous layer readers before migrating to edition 2024.

The opaque return types capture only the input reader type R and, for encrypt_layer, its existing 'a lifetime. Configuration, annotations, key-option data, and digest inputs are used only to construct owned cipher state and are not borrowed by the returned readers. Precise use<...> bounds preserve this contract under Rust 2024's broader RPIT capture rules.

These changes can be generated with:

    cargo fix --edition --allow-dirty -p ocicrypt-rs --lib \
        --no-default-features \
        --features async-io,block-cipher-openssl

Commit message was proof-read by Copilot but the changes are from a manual cargo fix