### PR TITLE
Improve image-rs logging for signed images

### DIFF
--- a/confidential-data-hub/hub/src/error.rs
+++ b/confidential-data-hub/hub/src/error.rs
@@ -16,7 +16,7 @@ pub enum Error {
         source: kms::Error,
     },
 
-    #[error("Get Resource failed")]
+    #[error("Get Resource failed: {source}")]
     GetResource {
         #[source]
         source: kms::Error,
@@ -55,7 +55,7 @@ mod tests {
 
     #[rstest]
     #[case(Error::KbsClient { source: kms::Error::KbsClientError("details".into()) }, "kbs client initialization failed")]
-    #[case(Error::GetResource { source: kms::Error::KbsClientError("details".into()) }, "Get Resource failed")]
+    #[case(Error::GetResource { source: kms::Error::KbsClientError("details".into()) }, "Get Resource failed: Kbs client error: details")]
     #[case(
         Error::UnsealSecret(secret::SecretError::VersionError),
         "Unseal Secret failed"

--- a/image-rs/src/signature/mod.rs
+++ b/image-rs/src/signature/mod.rs
@@ -33,7 +33,7 @@ pub enum SignatureError {
     #[error("Illegal image digest: {0}")]
     IllegalImageDigest(String),
 
-    #[error("Denied by policy: {source}")]
+    #[error("Denied by policy: {source:#}")]
     DeniedByPolicy {
         #[source]
         source: anyhow::Error,


### PR DESCRIPTION
Two little tweaks to expose more information when an image signature fails. Previously you would get something like `Error: Image policy rejected: Denied by policy: rejected by sigstoreSigned rule` regardless of whether the policy failed or a resource required to fulfill the policy was unavailable. This should help distinguish those cases. 

There shouldn't be any risk of revealing secret stuff in the log here.