### PR TITLE
attestation-agent: add unit tests for lib, initdata, aa_kbc_params, token, eventlog

### DIFF
--- a/attestation-agent/attestation-agent/src/config/aa_kbc_params.rs
+++ b/attestation-agent/attestation-agent/src/config/aa_kbc_params.rs
@@ -12,6 +12,7 @@ pub enum ParamError {
     MissingInCmdline,
 }
 
+#[derive(Debug)]
 pub struct AaKbcParams {
     pub kbc: String,
     pub uri: String,
@@ -78,5 +79,54 @@ impl AaKbcParams {
             .strip_prefix("agent.aa_kbc_params=")
             .expect("must have a prefix");
         Ok(value.into())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rstest::rstest;
+
+    #[rstest]
+    #[case("offline_fs_kbc::http://127.0.0.1:8080", "offline_fs_kbc", "http://127.0.0.1:8080")]
+    #[case("cc_kbc::https://kbs.example.com", "cc_kbc", "https://kbs.example.com")]
+    #[case("null_kbc::", "null_kbc", "")]
+    fn test_try_from_valid_params(
+        #[case] input: &str,
+        #[case] expected_kbc: &str,
+        #[case] expected_uri: &str,
+    ) {
+        let params = AaKbcParams::try_from(input.to_string())
+            .expect("should parse successfully");
+        assert_eq!(params.kbc, expected_kbc);
+        assert_eq!(params.uri, expected_uri);
+    }
+
+    #[rstest]
+    #[case("no_separator_at_all")]
+    #[case("one:colon")]
+    #[case("a::b::c")]
+    fn test_try_from_invalid_format_returns_error(#[case] input: &str) {
+        let err = AaKbcParams::try_from(input.to_string())
+            .expect_err("expected error for invalid input");
+        assert!(matches!(err, ParamError::IllegalFormat(_)));
+    }
+
+    #[test]
+    fn test_default_kbc_is_offline_fs() {
+        let params = AaKbcParams::default();
+        assert_eq!(params.kbc, "offline_fs_kbc");
+        assert_eq!(params.uri, "");
+    }
+
+    // AaKbcParams::new() reads AA_KBC_PARAMS from env when present.
+    // This covers the get_value() → env branch that TryFrom tests don't reach.
+    #[test]
+    fn test_new_reads_from_env() {
+        std::env::set_var("AA_KBC_PARAMS", "cc_kbc::https://kbs.example.com");
+        let params = AaKbcParams::new().expect("new() failed");
+        std::env::remove_var("AA_KBC_PARAMS");
+        assert_eq!(params.kbc, "cc_kbc");
+        assert_eq!(params.uri, "https://kbs.example.com");
     }
 }

--- a/attestation-agent/attestation-agent/src/eventlog/mod.rs
+++ b/attestation-agent/attestation-agent/src/eventlog/mod.rs
@@ -375,13 +375,12 @@ mod tests {
         assert_eq!(std::fs::read(&log_path).unwrap(), b"01AB456789");
     }
 
-    #[test]
-    fn test_content() {
-        let a_str = "hello";
-        let _: Content = a_str.try_into().unwrap();
-        let b_str = "hello\nworld";
-        let content: Result<Content, _> = b_str.try_into();
-        assert!(content.is_err());
+    #[rstest]
+    #[case("hello world", true)]
+    #[case("has\nnewline", false)]
+    fn test_content(#[case] s: &str, #[case] valid: bool) {
+        let result: Result<Content, _> = s.try_into();
+        assert_eq!(result.is_ok(), valid);
     }
 
     /// The eventlog will influence the underlying hardware
@@ -532,5 +531,56 @@ mod tests {
             .unwrap();
         drop(eventlog);
         std::fs::remove_file(EVENTLOG_PATH).unwrap();
+    }
+
+    // Event::new and Event::try_from: valid parses + newline rejection.
+    #[rstest]
+    #[case("domain operation content", "domain", "operation", "content", true)]
+    #[case("d o c with spaces", "d", "o", "c with spaces", true)]
+    #[case("no_spaces_at_all", "", "", "", false)]
+    #[case("only_one space", "", "", "", false)]
+    fn test_event_parse(
+        #[case] input: &str,
+        #[case] domain: &str,
+        #[case] operation: &str,
+        #[case] content: &str,
+        #[case] valid: bool,
+    ) {
+        let result: Result<Event, _> = input.try_into();
+        if valid {
+            let event = result.expect("should parse");
+            assert_eq!(event.domain, domain);
+            assert_eq!(event.operation, operation);
+            assert_eq!(event.content.0, content);
+            // Display must round-trip
+            assert_eq!(event.to_string(), input);
+        } else {
+            assert!(result.is_err());
+        }
+    }
+
+    // Event::new is the constructor path (domain/operation/content args directly),
+    // distinct from Event::try_from which parses a single space-delimited string.
+    #[test]
+    fn test_event_new_constructs_correctly() {
+        let event = Event::new("dom", "op", "cnt").expect("Event::new failed");
+        assert_eq!(event.to_string(), "dom op cnt");
+    }
+
+    // WAL cache: absent path returns Ok(None); truncated file (< 8 bytes for
+    // the offset field) returns Err.
+    #[test]
+    fn test_wal_cache_absent_returns_none() {
+        let tmp = tempfile::tempdir().unwrap();
+        let result = EventLog::read_wal_cache_from(&tmp.path().join("wal"), 32);
+        assert!(result.unwrap().is_none());
+    }
+
+    #[test]
+    fn test_wal_cache_truncated_returns_err() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("wal");
+        std::fs::write(&path, b"abc").unwrap(); // 3 bytes < 8-byte offset field
+        assert!(EventLog::read_wal_cache_from(&path, 32).is_err());
     }
 }

--- a/attestation-agent/attestation-agent/src/initdata.rs
+++ b/attestation-agent/attestation-agent/src/initdata.rs
@@ -27,3 +27,64 @@ impl Initdata {
         Ok((initdata, digest))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rstest::rstest;
+
+    // One case per supported algorithm; each case checks parsing, digest
+    // length, determinism, and data extraction in a single pass.
+    #[rstest]
+    #[case(
+        "sha256",
+        concat!(
+            "version = \"0.1.0\"\n",
+            "algorithm = \"sha256\"\n",
+            "\n[data]\n",
+            "key1 = \"value1\"\n",
+            "key2 = \"value2\"\n",
+        ),
+        32,  // SHA-256 produces 32 bytes
+        Some(("key1", "value1"))
+    )]
+    #[case(
+        "sha384",
+        concat!(
+            "version = \"0.1.0\"\n",
+            "algorithm = \"sha384\"\n",
+            "\n[data]\n",
+            "foo = \"bar\"\n",
+        ),
+        48,  // SHA-384 produces 48 bytes
+        None
+    )]
+    fn test_parse_and_get_digest(
+        #[case] _label: &str,
+        #[case] toml: &str,
+        #[case] expected_digest_len: usize,
+        #[case] expected_data_entry: Option<(&str, &str)>,
+    ) {
+        let (initdata, digest) = Initdata::parse_and_get_digest(toml)
+            .expect("parse_and_get_digest failed");
+
+        assert_eq!(initdata.version, "0.1.0");
+        assert_eq!(digest.len(), expected_digest_len);
+
+        // digest is deterministic: a second call on the same input matches
+        let (_, digest2) = Initdata::parse_and_get_digest(toml).unwrap();
+        assert_eq!(digest, digest2);
+
+        if let Some((key, val)) = expected_data_entry {
+            assert_eq!(initdata.data.get(key).map(String::as_str), Some(val));
+        }
+    }
+
+    #[rstest]
+    #[case("this is not valid toml :::")]
+    #[case("version = \"0.1.0\"\n[data]\nkey = \"val\"\n")]  // missing algorithm
+    #[case("version = \"0.1.0\"\nalgorithm = \"md5\"\n[data]\n")]  // unsupported algorithm
+    fn test_parse_and_get_digest_invalid(#[case] toml: &str) {
+        assert!(Initdata::parse_and_get_digest(toml).is_err());
+    }
+}

--- a/attestation-agent/attestation-agent/src/lib.rs
+++ b/attestation-agent/attestation-agent/src/lib.rs
@@ -278,3 +278,73 @@ impl AttestationAPIs for AttestationAgent {
         self.additional_attesters.keys().cloned().collect()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use attester::InitDataResult;
+    use kbs_types::Tee;
+
+    fn aa() -> AttestationAgent {
+        AttestationAgent::new(Config::default()).expect("failed to create AttestationAgent")
+    }
+
+    // On a developer laptop (no real TEE) the attester detection falls through
+    // to the Sample attester.
+    #[test]
+    fn test_get_tee_type_returns_sample_on_non_tee_host() {
+        assert_eq!(aa().get_tee_type(), Tee::Sample);
+    }
+
+    #[test]
+    fn test_get_additional_tees_is_empty_without_extra_devices() {
+        assert!(aa().get_additional_tees().is_empty());
+    }
+
+    // get_evidence: output is valid JSON with the fields the SampleAttester contract
+    // requires. This also guards the `.to_string().into_bytes()` serialisation path.
+    #[tokio::test]
+    async fn test_get_evidence_returns_valid_json_for_sample_attester() {
+        let evidence = aa()
+            .get_evidence(b"report_data")
+            .await
+            .expect("get_evidence failed");
+        let parsed: serde_json::Value =
+            serde_json::from_slice(&evidence).expect("evidence is not valid JSON");
+        assert!(parsed.get("svn").is_some(), "evidence missing `svn` field");
+        assert!(parsed.get("report_data").is_some(), "evidence missing `report_data` field");
+    }
+
+    // get_additional_evidence: no additional attesters on a dev host → empty vec,
+    // exercising the early-return branch.
+    #[tokio::test]
+    async fn test_get_additional_evidence_empty_without_extra_attesters() {
+        let evidence = aa()
+            .get_additional_evidence(b"runtime_data")
+            .await
+            .expect("get_additional_evidence failed");
+        assert!(evidence.is_empty());
+    }
+
+    // bind_init_data: SampleAttester always returns Unsupported,
+    // confirming the delegation contract.
+    #[tokio::test]
+    async fn test_bind_init_data_returns_unsupported_for_sample_attester() {
+        let result = aa()
+            .bind_init_data(b"digest")
+            .await
+            .expect("bind_init_data should not error");
+        assert!(matches!(result, InitDataResult::Unsupported));
+    }
+
+    // extend_runtime_measurement: self.eventlog is None until init() is called,
+    // so NotEnabled is returned before the PCR index or attester are consulted.
+    #[tokio::test]
+    async fn test_extend_runtime_measurement_not_enabled_without_init() {
+        let result = aa()
+            .extend_runtime_measurement("dom", "op", "cnt", None)
+            .await
+            .expect("extend_runtime_measurement failed");
+        assert!(matches!(result, RuntimeMeasurement::NotEnabled));
+    }
+}

--- a/attestation-agent/attestation-agent/src/token/mod.rs
+++ b/attestation-agent/attestation-agent/src/token/mod.rs
@@ -27,3 +27,20 @@ pub enum TokenType {
     #[strum(serialize = "coco_as")]
     CoCoAS,
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rstest::rstest;
+    use std::str::FromStr;
+
+    // Unknown, empty, and wrong-case strings must all be rejected regardless
+    // of which token features are compiled in. strum is case-sensitive by default.
+    #[rstest]
+    #[case("unknown_type")]
+    #[case("")]
+    #[case("KBS")]  // wrong case
+    fn test_invalid_token_type_rejected(#[case] s: &str) {
+        assert!(TokenType::from_str(s).is_err());
+    }
+}


### PR DESCRIPTION
Cover locally-runnable branches across five source files — no TEE hardware, KBS endpoint, or privileged paths required.

**Changes:**

- `lib.rs`: TEE type detection, `get_evidence` JSON shape, `bind_init_data` Unsupported result, and `extend_runtime_measurement` NotEnabled before `init()`.
- `initdata.rs`: sha256/sha384 parse-and-digest round-trips (length, determinism, data extraction) and invalid-input rejection (bad TOML, missing algorithm, unsupported algorithm).
- `config/aa_kbc_params.rs`: `TryFrom` valid/invalid cases, `Default` value, env-var read path; also adds `#[derive(Debug)]` to `AaKbcParams` (required by `expect_err()`).
- `token/mod.rs`: unknown, empty, and wrong-case strings rejected by `TokenType::from_str`.
- `eventlog/mod.rs`: consolidate existing `test_content` into a two-case rstest table; add `test_event_parse` (4-case rstest with Display round-trip), `test_event_new_constructs_correctly`, and two WAL-cache tests (absent path → `Ok(None)`, truncated file → `Err`).

**Coverage improvement** (measured with `cargo llvm-cov`):

| File | Before | After |
|---|---|---|
| `token/mod.rs` | 0% | 100% |
| `initdata.rs` | 0% | 100% |
| `lib.rs` | 0% | 75.8% |
| `config/aa_kbc_params.rs` | 0% | 70.4% |
| `eventlog/mod.rs` | pre-existing | +3.5pp |
| **crate total** | ~47.7% | ~51.6% |

All 43 tests pass with default features; `aa_kbc_params` tests pass with `--features kbs`.

Assisted-by: Bob <bob@ibm.com>