### PR TITLE
Improve secret-cli packaging 

### DIFF
--- a/.github/workflows/secret_cli_release.yml
+++ b/.github/workflows/secret_cli_release.yml
@@ -18,14 +18,10 @@ permissions:
   contents: read
 
 jobs:
-  build-and-upload:
-    name: Build and upload secret CLI
+  build-and-publish:
+    name: Build and publish secret CLI
     permissions:
-      # Write scopes are only exercised by the release-only upload/publish
-      # steps below (gated on env.IS_PUBLISH). On pull_request the job just
-      # builds the binary to catch breakage early; fork PRs get a read-only
-      # token regardless of what is requested here.
-      contents: write # required to upload release assets via gh release upload
+      # Write only used for releases, when the binary is pushed to ghcr
       packages: write # required to publish OCI artifact to ghcr.io
     strategy:
       fail-fast: false
@@ -40,8 +36,8 @@ jobs:
     runs-on: ${{ matrix.platform.runner }}
     env:
       RUST_TARGET: ${{ matrix.platform.arch }}-unknown-linux-${{ matrix.platform.libc }}
-      # KMS providers bundled into the released binary. Building all of them
-      # into one artifact keeps the released tool provider-agnostic.
+      OCI_ARCH: ${{ matrix.platform.arch == 'x86_64' && 'amd64' || 'arm64' }}
+      # Build all KMS providers
       CLI_FEATURES: cli,aliyun,aws,kbs
       REGISTRY: ghcr.io
       IMAGE_NAME: ${{ github.repository }}
@@ -65,7 +61,7 @@ jobs:
       if: env.IS_PUBLISH == 'true'
       uses: oras-project/setup-oras@1d808f7d7f6995cc68b7bf507bfe5c5446e1dc9d # v2.0.1
       with:
-        version: 1.2.0
+        version: 1.3.3
 
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
@@ -102,32 +98,50 @@ jobs:
           --no-default-features \
           --features "${CLI_FEATURES}"
 
-    - name: Package artifact
-      if: env.IS_PUBLISH == 'true'
-      id: package
-      run: |
-        name="secret-${RUST_TARGET}"
-        mkdir -p "${name}"
-        cp "target/${RUST_TARGET}/release/secret" "${name}/"
-        tar czf "${name}.tar.gz" "${name}"
-        sha256sum "${name}.tar.gz" > "${name}.tar.gz.sha256"
-        echo "asset=${name}.tar.gz" >> "$GITHUB_OUTPUT"
-
-    - name: Upload release assets
-      if: env.IS_PUBLISH == 'true'
-      env:
-        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        ASSET: ${{ steps.package.outputs.asset }}
-      run: |
-        gh release upload "${TAG}" "${ASSET}" "${ASSET}.sha256" \
-          --repo "${GITHUB_REPOSITORY}" --clobber
-
     - name: Publish with ORAS
       if: env.IS_PUBLISH == 'true'
-      env:
-        ASSET: ${{ steps.package.outputs.asset }}
       run: |
-        image="${REGISTRY}/${IMAGE_NAME}/secret_cli"
+        image="${REGISTRY}/${IMAGE_NAME}/secret-cli"
         oras push \
-          "${image}:${TAG}-${RUST_TARGET},latest-${RUST_TARGET}" \
-          "${ASSET}"
+          --artifact-type application/vnd.confidential-containers.secret-cli \
+          --artifact-platform "linux/${OCI_ARCH}" \
+          "${image}:${TAG}-${RUST_TARGET}" \
+          "target/${RUST_TARGET}/release/secret"
+
+  publish-manifest:
+    name: Publish multi-arch manifest
+    needs: build-and-publish
+    if: github.event_name == 'release' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-24.04
+    permissions:
+      packages: write # required to push the multi-arch index to ghcr.io
+    env:
+      REGISTRY: ghcr.io
+      IMAGE_NAME: ${{ github.repository }}
+      TAG: ${{ github.event.release.tag_name || inputs.tag }}
+    steps:
+    - name: Harden the runner (Audit all outbound calls)
+      uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
+      with:
+        egress-policy: audit
+
+    - name: Log in to the Container registry
+      uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+      with:
+        registry: ${{ env.REGISTRY }}
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Set up ORAS
+      uses: oras-project/setup-oras@1d808f7d7f6995cc68b7bf507bfe5c5446e1dc9d # v2.0.1
+      with:
+        version: 1.3.3
+
+    - name: Assemble and push multi-arch index
+      run: |
+        image="${REGISTRY}/${IMAGE_NAME}/secret-cli"
+        oras manifest index create \
+          --artifact-type application/vnd.confidential-containers.secret-cli \
+          "${image}:${TAG},latest" \
+          "${TAG}-x86_64-unknown-linux-musl" \
+          "${TAG}-aarch64-unknown-linux-musl"

--- a/confidential-data-hub/docs/SEALED_SECRET.md
+++ b/confidential-data-hub/docs/SEALED_SECRET.md
@@ -14,17 +14,12 @@ You can use the secret cli tool to generate a sealed secret.
 
 ### Prebuilt binary (recommended)
 
-Each [GitHub release](https://github.com/confidential-containers/guest-components/releases)
-ships the `secret` CLI as a prebuilt artifact with all KMS providers bundled,
-so you do not need a Rust toolchain. Download the tarball matching your
-platform, verify it, and extract the binary:
+Pull the secret cli for the latest release for ARM or x86.
 
 ```bash
-# Pick the asset for your platform, e.g. secret-x86_64-unknown-linux-musl.tar.gz
-ASSET=secret-x86_64-unknown-linux-musl.tar.gz
-sha256sum -c "${ASSET}.sha256"
-tar xzf "$ASSET"
-./secret-x86_64-unknown-linux-musl/secret --help
+oras pull ghcr.io/confidential-containers/guest-components/secret-cli:latest
+chmod +x secret
+./secret --help
 ```
 
 ### Build from source

--- a/confidential-data-hub/docs/kms-providers/alibaba.md
+++ b/confidential-data-hub/docs/kms-providers/alibaba.md
@@ -116,9 +116,9 @@ nc8BTncWI0KGWIzTQasuSEye50R6gc9wZCGIElmhWcu3NYk=
 ```
 - `plaintext`: The file whose content will be sealed.
 
-A prebuilt `secret` CLI (with all KMS providers bundled) is available from the
-[GitHub releases](https://github.com/confidential-containers/guest-components/releases);
-using it lets you skip the build-from-source step below.
+A prebuilt `secret` CLI (with all KMS providers bundled) is available as an
+OCI artifact on `ghcr.io` (see [SEALED_SECRET.md](../SEALED_SECRET.md)); pulling
+it with ORAS lets you skip the build-from-source step below.
 
 Then, let's 
 ```bash
@@ -131,9 +131,9 @@ CLIENT_KEY_FILE_PATH=$(pwd)/ClientKeyContent.json
 
 git clone https://github.com/confidential-containers/guest-components.git && cd guest-components
 
-cargo build --bin secret_cli --release --features "aliyun"
+cargo build --bin secret --release --features "aliyun"
 
-target/release/secret_cli seal --file-path ../plaintext \
+target/release/secret seal --file-path ../plaintext \
     envelope --key-id $KEY_ID ali \
     --password-file-path $CLIENT_KEY_PASSWORD_FILE_PATH \
     --cert-path $CERT_PATH \

--- a/confidential-data-hub/hub/Cargo.toml
+++ b/confidential-data-hub/hub/Cargo.toml
@@ -108,5 +108,5 @@ bin = ["clap", "shadow-rs", "tracing-subscriber"]
 ttrpc = ["dep:ttrpc", "tokio/signal", "protos/ttrpc"]
 grpc = ["prost", "tonic", "tokio/signal", "protos/grpc"]
 
-# for secret_cli
+# for the `secret` CLI
 cli = ["clap/derive", "tokio/rt-multi-thread", "tokio/sync", "tokio/macros"]

--- a/confidential-data-hub/hub/src/secret/tests/test_hsm_secrets.rs
+++ b/confidential-data-hub/hub/src/secret/tests/test_hsm_secrets.rs
@@ -52,8 +52,8 @@ fn key_lifetime(base_dir: &str, key_id: &str, sub_cmd: Vec<&str>) {
         .write_all(&secret)
         .expect("write 'secret_file' fail");
 
-    // seal secret with 'secret_cli'
-    let seal_secret_output = Command::cargo_bin("secret_cli")
+    // seal secret with 'secret'
+    let seal_secret_output = Command::cargo_bin("secret")
         .expect("init 'cargo_bin' fail")
         .arg("seal")
         .arg("envelope")
@@ -70,8 +70,8 @@ fn key_lifetime(base_dir: &str, key_id: &str, sub_cmd: Vec<&str>) {
 
     assert!(seal_secret_output.status.success());
 
-    // unseal secret with 'secret_cli'
-    let unseal_secret_output = Command::cargo_bin("secret_cli")
+    // unseal secret with 'secret'
+    let unseal_secret_output = Command::cargo_bin("secret")
         .expect("init 'cargo_bin' fail")
         .arg("unseal")
         .args(["--file-path", &sealed_secret_file_path])

--- a/confidential-data-hub/kms/src/plugins/aws/client.rs
+++ b/confidential-data-hub/kms/src/plugins/aws/client.rs
@@ -44,7 +44,7 @@ pub struct AwsKmsClient {
 
 impl AwsKmsClient {
     /// Build a client from a region and explicit static credentials. This is the
-    /// entry point used on the user/encryptor side (e.g. by `secret_cli`).
+    /// entry point used on the user/encryptor side (e.g. by the `secret` CLI).
     pub fn new(
         region: &str,
         access_key_id: &str,


### PR DESCRIPTION
We have a number of little issues with how we release the secret-cli.

First, make sure that the artifact just contains the binary. Previously,
we were releasing a tarred directory containing the binary. There is no
need for that.

Next, let's make it a multi-arch image and make the tags a little
simpler (just use `latest` or the release version).

Next, let's not add these artifacts to the release. We don't add any of
our other binaries to the release. No need for this one, which is one of
the least prominent.

Finally, let's rename the package (on ghcr) from secret_cli to
secret-cli. This is more consistent with our other packages.

It turns out the name of the binary is actually just `secret` (not `secret-cli`).
Update the docs and the source in a few places to be more consistent.
We can discuss renaming the tool, but for now let's keep it as is.