### PR TITLE
Fortanix ccm_kbc and ccm_as integration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -35,7 +35,7 @@ version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "cipher 0.4.4",
  "cpufeatures 0.2.17",
 ]
@@ -355,15 +355,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
+name = "attestation"
+version = "0.1.0"
+source = "git+https://github.com/fortanix/attestation.git?rev=fade7bf57c93fefaeaca77fe453b87a7909c9cd4#fade7bf57c93fefaeaca77fe453b87a7909c9cd4"
+dependencies = [
+ "b64-ct",
+ "der 0.7.10",
+ "iocuddle 0.1.1",
+ "log 0.4.29",
+ "mbedtls",
+ "nvml-wrapper",
+ "once_cell",
+ "pkix",
+ "serde",
+ "sgx-isa",
+ "sgx_pkix",
+ "tdx-ql",
+ "thiserror 1.0.69",
+ "yasna 0.3.2",
+]
+
+[[package]]
 name = "attestation-agent"
 version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "attestation",
  "attester",
  "base64 0.23.1",
  "byteorder",
  "clap",
+ "client",
  "config",
  "const_format",
  "crypto",
@@ -387,6 +410,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "ttrpc",
+ "x509-cert",
 ]
 
 [[package]]
@@ -400,7 +424,7 @@ dependencies = [
  "azure-guest-attestation-sdk",
  "azure-tpm",
  "base64 0.23.1",
- "cfg-if",
+ "cfg-if 1.0.4",
  "clap",
  "codicon",
  "crypto",
@@ -513,10 +537,10 @@ dependencies = [
  "fastrand",
  "http 1.4.0",
  "http-body 1.0.1",
- "percent-encoding",
+ "percent-encoding 2.3.2",
  "pin-project-lite",
  "tracing",
- "uuid",
+ "uuid 1.26.0",
 ]
 
 [[package]]
@@ -587,9 +611,9 @@ dependencies = [
  "hmac 0.13.0",
  "http 0.2.12",
  "http 1.4.0",
- "percent-encoding",
+ "percent-encoding 2.3.2",
  "sha2 0.11.0",
- "time",
+ "time 0.3.47",
  "tracing",
 ]
 
@@ -619,7 +643,7 @@ dependencies = [
  "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
- "percent-encoding",
+ "percent-encoding 2.3.2",
  "pin-project-lite",
  "pin-utils",
  "tracing",
@@ -756,7 +780,7 @@ dependencies = [
  "pin-utils",
  "ryu",
  "serde",
- "time",
+ "time 0.3.47",
  "tokio",
  "tokio-util",
 ]
@@ -791,8 +815,8 @@ dependencies = [
  "itoa",
  "matchit",
  "memchr",
- "mime",
- "percent-encoding",
+ "mime 0.3.17",
+ "percent-encoding 2.3.2",
  "pin-project-lite",
  "serde_core",
  "sync_wrapper",
@@ -812,7 +836,7 @@ dependencies = [
  "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
- "mime",
+ "mime 0.3.17",
  "pin-project-lite",
  "sync_wrapper",
  "tower-layer",
@@ -907,10 +931,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "b64-ct"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41dd1e07aafe656df62d40e74d4627a0cce26da43b0bec233ac1305207a5a768"
+
+[[package]]
 name = "base16ct"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
+
+[[package]]
+name = "base64"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "489d6c0ed21b11d038c31b6ceccca973e65d73ba3bd8ecb9a2babf5546164643"
+dependencies = [
+ "byteorder",
+ "safemem",
+]
+
+[[package]]
+name = "base64"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b25d992356d2eb0ed82172f5248873db5560c4721f564b13cb5193bda5e668e"
+dependencies = [
+ "byteorder",
+]
 
 [[package]]
 name = "base64"
@@ -1018,6 +1067,29 @@ dependencies = [
 
 [[package]]
 name = "bindgen"
+version = "0.65.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfdf7b466f9a4903edc73f95d6d2bcd5baf8ae620638762244d3f60143643cc5"
+dependencies = [
+ "bitflags 1.3.2",
+ "cexpr",
+ "clang-sys",
+ "lazy_static",
+ "lazycell",
+ "log 0.4.29",
+ "peeking_take_while",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash 1.1.0",
+ "shlex",
+ "syn 2.0.117",
+ "which 4.4.2",
+]
+
+[[package]]
+name = "bindgen"
 version = "0.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f49d8fed880d473ea71efb9bf597651e77201bdd4893efe54c9e5d65ae04ce6f"
@@ -1026,7 +1098,7 @@ dependencies = [
  "cexpr",
  "clang-sys",
  "itertools 0.13.0",
- "log",
+ "log 0.4.29",
  "prettyplease",
  "proc-macro2",
  "quote",
@@ -1046,7 +1118,7 @@ dependencies = [
  "cexpr",
  "clang-sys",
  "itertools 0.13.0",
- "log",
+ "log 0.4.29",
  "prettyplease",
  "proc-macro2",
  "quote",
@@ -1061,6 +1133,18 @@ name = "binstring"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0669d5a35b64fdb5ab7fb19cae13148b6b5cbdf4b8247faf54ece47f699c8cef"
+
+[[package]]
+name = "bit-vec"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f59bbe95d4e52a6398ec21238d31577f2b28a9d86807f06ca59d191d8440d0bb"
+
+[[package]]
+name = "bit-vec"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
 
 [[package]]
 name = "bitfield"
@@ -1236,7 +1320,7 @@ dependencies = [
  "hyper-rustls",
  "hyper-util",
  "hyperlocal",
- "log",
+ "log 0.4.29",
  "num",
  "pin-project-lite",
  "rand 0.10.2",
@@ -1248,13 +1332,13 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "thiserror 2.0.20",
- "time",
+ "time 0.3.47",
  "tokio",
  "tokio-stream",
  "tokio-util",
  "tonic",
  "tower-service",
- "url",
+ "url 2.5.8",
  "winapi",
 ]
 
@@ -1283,7 +1367,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_repr",
- "time",
+ "time 0.3.47",
 ]
 
 [[package]]
@@ -1428,6 +1512,12 @@ dependencies = [
 
 [[package]]
 name = "cfg-if"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
+
+[[package]]
+name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
@@ -1444,7 +1534,7 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "cpufeatures 0.3.0",
  "rand_core 0.10.1",
 ]
@@ -1564,6 +1654,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
+name = "client"
+version = "0.1.0"
+source = "git+https://github.com/fortanix/attestation.git?rev=fade7bf57c93fefaeaca77fe453b87a7909c9cd4#fade7bf57c93fefaeaca77fe453b87a7909c9cd4"
+dependencies = [
+ "attestation",
+ "der 0.7.10",
+ "em-node-agent-client",
+ "env_logger",
+ "ftx-cert-build",
+ "hyper 0.10.16",
+ "log 0.4.29",
+ "mbedtls",
+ "pkix",
+ "thiserror 1.0.69",
+ "tokio",
+ "vsock",
+]
+
+[[package]]
 name = "cmac"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1610,7 +1719,7 @@ dependencies = [
  "clap",
  "ctr 0.10.1",
  "daemonize",
- "futures",
+ "futures 0.3.34",
  "jwt-simple",
  "protos",
  "rand 0.10.2",
@@ -1625,7 +1734,7 @@ dependencies = [
  "tonic",
  "tracing",
  "tracing-subscriber",
- "uuid",
+ "uuid 1.26.0",
 ]
 
 [[package]]
@@ -1688,7 +1797,7 @@ dependencies = [
  "async-trait",
  "attestation-agent",
  "base64 0.23.1",
- "cfg-if",
+ "cfg-if 1.0.4",
  "clap",
  "config",
  "const_format",
@@ -1718,7 +1827,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "ttrpc",
- "uuid",
+ "uuid 1.26.0",
  "which 8.0.6",
  "zeroize",
 ]
@@ -1826,9 +1935,9 @@ version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ddef33a339a91ea89fb53151bd0a4689cfce27055c291dfa69945475d22c747"
 dependencies = [
- "percent-encoding",
- "time",
- "version_check",
+ "percent-encoding 2.3.2",
+ "time 0.3.47",
+ "version_check 0.9.5",
 ]
 
 [[package]]
@@ -1839,15 +1948,15 @@ checksum = "15b2c103cf610ec6cae3da84a766285b42fd16aad564758459e6ecf128c75206"
 dependencies = [
  "cookie",
  "document-features",
- "idna",
+ "idna 1.1.0",
  "indexmap 2.14.0",
- "log",
+ "log 0.4.29",
  "publicsuffix",
  "serde",
  "serde_derive",
  "serde_json",
- "time",
- "url",
+ "time 0.3.47",
+ "url 2.5.8",
 ]
 
 [[package]]
@@ -1913,7 +2022,7 @@ version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
 ]
 
 [[package]]
@@ -2103,7 +2212,7 @@ dependencies = [
  "hyper-tls 0.5.0",
  "iocuddle 0.1.1",
  "libc",
- "log",
+ "log 0.4.29",
  "openssl",
  "openssl-sys",
  "rand 0.8.6",
@@ -2194,7 +2303,7 @@ version = "4.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "cpufeatures 0.2.17",
  "curve25519-dalek-derive",
  "digest 0.10.7",
@@ -2444,10 +2553,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d95021344f9715868259d6b500aa0fb2a3b53c39b5c88fc45814355e53ce83a"
 dependencies = [
  "bitflags 2.13.1",
- "cfg-if",
+ "cfg-if 1.0.4",
  "devicemapper-sys",
  "env_logger",
- "log",
+ "log 0.4.29",
  "nix 0.31.3",
  "rand 0.10.2",
  "retry",
@@ -2730,12 +2839,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "em-node-agent-client"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df22360a06e34189c0899e6fc1814a9ff0869bd973d3a65c97287b5c4e910364"
+dependencies = [
+ "base64 0.10.1",
+ "chrono",
+ "futures 0.1.31",
+ "hyper 0.10.16",
+ "lazy_static",
+ "log 0.3.9",
+ "mime 0.2.6",
+ "serde",
+ "serde_derive",
+ "serde_ignored",
+ "serde_json",
+ "url 1.7.2",
+ "uuid 0.6.5",
+]
+
+[[package]]
 name = "encoding_rs"
 version = "0.8.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
 ]
 
 [[package]]
@@ -2776,7 +2906,7 @@ version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32e90c2accc4b07a8456ea0debdc2e7587bdd890680d71173a15d4ae604f6eef"
 dependencies = [
- "log",
+ "log 0.4.29",
  "regex",
 ]
 
@@ -2790,7 +2920,7 @@ dependencies = [
  "anstyle",
  "env_filter",
  "jiff",
- "log",
+ "log 0.4.29",
 ]
 
 [[package]]
@@ -2847,7 +2977,7 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de48cc4d1c1d97a20fd819def54b890cadde72ed3ad0c614822a0a433361be96"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "windows-sys 0.61.2",
 ]
 
@@ -2891,7 +3021,7 @@ version = "0.2.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "libc",
 ]
 
@@ -2969,7 +3099,7 @@ version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
- "percent-encoding",
+ "percent-encoding 2.3.2",
 ]
 
 [[package]]
@@ -2979,10 +3109,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
+name = "ftx-cert-build"
+version = "0.1.0"
+source = "git+https://github.com/fortanix/ftx-cert-build.git#e1b4a4312785e0be6aed5d9a6664d65386ea4314"
+dependencies = [
+ "chrono",
+ "mbedtls",
+ "pkix",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "fuchsia-cprng"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
+
+[[package]]
 name = "funty"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
+
+[[package]]
+name = "futures"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a471a38ef8ed83cd6e40aa59c1ffe17db6855c18e3604d9c4ed8c08ebc28678"
 
 [[package]]
 name = "futures"
@@ -3085,7 +3238,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
- "version_check",
+ "version_check 0.9.5",
  "zeroize",
 ]
 
@@ -3105,10 +3258,10 @@ version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "js-sys",
  "libc",
- "wasi",
+ "wasi 0.11.1+wasi-snapshot-preview1",
  "wasm-bindgen",
 ]
 
@@ -3118,7 +3271,7 @@ version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
@@ -3130,7 +3283,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "js-sys",
  "libc",
  "r-efi 6.0.0",
@@ -3180,8 +3333,8 @@ dependencies = [
  "bitflags 2.13.1",
  "libc",
  "libgit2-sys",
- "log",
- "url",
+ "log 0.4.29",
+ "url 2.5.8",
 ]
 
 [[package]]
@@ -3245,7 +3398,7 @@ version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "crunchy",
  "zerocopy",
 ]
@@ -3309,6 +3462,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e17592d60ebacc7d5e169f4663c5f84f9161cc90328abcfe8456f41e4dfcb284"
 
 [[package]]
 name = "hex"
@@ -3470,6 +3629,25 @@ dependencies = [
 
 [[package]]
 name = "hyper"
+version = "0.10.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a0652d9a2609a968c14be1a9ea00bf4b1d64e2e1f53a1b51b6fff3a6e829273"
+dependencies = [
+ "base64 0.9.3",
+ "httparse",
+ "language-tags",
+ "log 0.3.9",
+ "mime 0.2.6",
+ "num_cpus",
+ "time 0.1.45",
+ "traitobject",
+ "typeable",
+ "unicase 1.4.2",
+ "url 1.7.2",
+]
+
+[[package]]
+name = "hyper"
 version = "0.14.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41dfc780fdec9373c01bae43289ea34c972e40ee3c9f6b3c8801a35f35586ce7"
@@ -3603,7 +3781,7 @@ dependencies = [
  "hyper 1.9.0",
  "ipnet",
  "libc",
- "percent-encoding",
+ "percent-encoding 2.3.2",
  "pin-project-lite",
  "socket2 0.6.3",
  "tokio",
@@ -3636,7 +3814,7 @@ dependencies = [
  "core-foundation-sys",
  "iana-time-zone-haiku",
  "js-sys",
- "log",
+ "log 0.4.29",
  "wasm-bindgen",
  "windows-core",
 ]
@@ -3755,6 +3933,17 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38f09e0f0b1fb55fdee1f17470ad800da77af5186a1a76c026b679358b7e844e"
+dependencies = [
+ "matches",
+ "unicode-bidi",
+ "unicode-normalization",
+]
+
+[[package]]
+name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
@@ -3783,7 +3972,7 @@ dependencies = [
  "async-compression",
  "async-trait",
  "base64 0.23.1",
- "cfg-if",
+ "cfg-if 1.0.4",
  "criterion",
  "devicemapper",
  "filetime",
@@ -3822,7 +4011,7 @@ dependencies = [
  "tonic",
  "tracing",
  "ttrpc",
- "url",
+ "url 2.5.8",
  "walkdir",
  "xattr",
  "zstd",
@@ -3953,7 +4142,7 @@ checksum = "f00b5dbd620d61dfdcb6007c9c1f6054ebd75319f163d886a9055cec1155073d"
 dependencies = [
  "jiff-static",
  "jiff-tzdb-platform",
- "log",
+ "log 0.4.29",
  "portable-atomic",
  "portable-atomic-util",
  "serde_core",
@@ -3992,11 +4181,11 @@ version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "combine",
  "jni-macros",
  "jni-sys",
- "log",
+ "log 0.4.29",
  "simd_cesu8",
  "thiserror 2.0.20",
  "walkdir",
@@ -4110,7 +4299,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 2.0.20",
- "time",
+ "time 0.3.47",
 ]
 
 [[package]]
@@ -4119,7 +4308,7 @@ version = "0.3.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67df7112613f8bfd9150013a0314e196f4800d3201ae742489d999db2f979f08"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "futures-util",
  "once_cell",
  "wasm-bindgen",
@@ -4145,11 +4334,11 @@ dependencies = [
  "base64 0.13.1",
  "bitflags 1.3.2",
  "generic-array 0.14.7",
- "num-bigint",
+ "num-bigint 0.4.6",
  "serde",
  "serde_json",
  "thiserror 1.0.69",
- "yasna",
+ "yasna 0.4.0",
  "zeroize",
 ]
 
@@ -4224,7 +4413,7 @@ version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6e3919bbaa2945715f0bb6d3934a173d1e9a59ac23767fbaaef277265a7411b"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "ecdsa",
  "elliptic-curve",
  "once_cell",
@@ -4299,7 +4488,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "ttrpc",
- "url",
+ "url 2.5.8",
  "zeroize",
 ]
 
@@ -4318,7 +4507,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e24a010dd405bd7ed803e5253182815b41bf2e6a80cc3bfc066658e03a198aa"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "cpufeatures 0.3.0",
 ]
 
@@ -4365,7 +4554,9 @@ dependencies = [
  "tonic",
  "tonic-build",
  "tracing",
- "url",
+ "ttrpc",
+ "url 2.5.8",
+ "uuid 1.26.0",
 ]
 
 [[package]]
@@ -4382,6 +4573,12 @@ name = "konst_macro_rules"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4933f3f57a8e9d9da04db23fb153356ecaf00cbd14aee46279c33dc80925c37"
+
+[[package]]
+name = "language-tags"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a91d884b6667cd606bb5a69aa0c99ba811a115fc68915e7056ec08a46e93199a"
 
 [[package]]
 name = "lazy_static"
@@ -4434,7 +4631,7 @@ version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "windows-link",
 ]
 
@@ -4500,6 +4697,15 @@ dependencies = [
 
 [[package]]
 name = "log"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e19e8d5c34a3e0e2223db8e060f9e8264aeeb5c5fc64a4ee9965c062211c024b"
+dependencies = [
+ "log 0.4.29",
+]
+
+[[package]]
+name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
@@ -4530,10 +4736,63 @@ dependencies = [
 ]
 
 [[package]]
+name = "matches"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2532096657941c2fea9c289d370a250971c689d4f143798ff67113ec042024a5"
+
+[[package]]
 name = "matchit"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
+
+[[package]]
+name = "mbedtls"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "632b09ec03d9faf449ab6d33993c30fc85584dcf550cd6e28f00b619589118dd"
+dependencies = [
+ "bitflags 1.3.2",
+ "byteorder",
+ "cc",
+ "cfg-if 1.0.4",
+ "mbedtls-platform-support",
+ "mbedtls-sys-auto",
+ "rs-libc",
+ "rustc_version",
+ "serde",
+ "serde_derive",
+ "yasna 0.2.2",
+]
+
+[[package]]
+name = "mbedtls-platform-support"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "844620df168baa0a4fd1ddde9805080fc3eed92c118707e1e3129598db260c94"
+dependencies = [
+ "cc",
+ "cfg-if 1.0.4",
+ "chrono",
+ "mbedtls-sys-auto",
+]
+
+[[package]]
+name = "mbedtls-sys-auto"
+version = "2.28.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fdbd15978db1dec7592cf8864094bcf6f7a101d7f84af15c2423967079982c1"
+dependencies = [
+ "bindgen 0.65.1",
+ "cc",
+ "cfg-if 1.0.4",
+ "cmake",
+ "lazy_static",
+ "libc",
+ "quote",
+ "syn 1.0.109",
+]
 
 [[package]]
 name = "mbox"
@@ -4551,7 +4810,7 @@ version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "digest 0.10.7",
 ]
 
@@ -4581,6 +4840,15 @@ dependencies = [
 
 [[package]]
 name = "mime"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba626b8a6de5da682e1caa06bdb42a335aee5a84db8e5046a3e8ab17ba0a3ae0"
+dependencies = [
+ "log 0.3.9",
+]
+
+[[package]]
+name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
@@ -4591,8 +4859,8 @@ version = "2.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
 dependencies = [
- "mime",
- "unicase",
+ "mime 0.3.17",
+ "unicase 2.9.0",
 ]
 
 [[package]]
@@ -4618,7 +4886,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
- "wasi",
+ "wasi 0.11.1+wasi-snapshot-preview1",
  "windows-sys 0.61.2",
 ]
 
@@ -4682,7 +4950,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
 dependencies = [
  "libc",
- "log",
+ "log 0.4.29",
  "openssl",
  "openssl-probe 0.2.1",
  "openssl-sys",
@@ -4699,10 +4967,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "598beaf3cc6fdd9a5dfb1630c2800c7acd31df7aaf0f565796fba2b53ca1af1b"
 dependencies = [
  "bitflags 1.3.2",
- "cfg-if",
+ "cfg-if 1.0.4",
  "libc",
  "memoffset 0.7.1",
  "pin-utils",
+]
+
+[[package]]
+name = "nix"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
+dependencies = [
+ "bitflags 2.13.1",
+ "cfg-if 1.0.4",
+ "cfg_aliases",
+ "libc",
 ]
 
 [[package]]
@@ -4712,7 +4992,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
 dependencies = [
  "bitflags 2.13.1",
- "cfg-if",
+ "cfg-if 1.0.4",
  "cfg_aliases",
  "libc",
  "memoffset 0.9.1",
@@ -4752,11 +5032,22 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
 dependencies = [
- "num-bigint",
+ "num-bigint 0.4.6",
  "num-complex",
  "num-integer",
  "num-iter",
  "num-rational",
+ "num-traits",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "090c7f9998ee0ff65aa5b723e4009f7b217707f1fb5ea551329cc4d6231fb304"
+dependencies = [
+ "autocfg",
+ "num-integer",
  "num-traits",
 ]
 
@@ -4839,7 +5130,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
 dependencies = [
- "num-bigint",
+ "num-bigint 0.4.6",
  "num-integer",
  "num-traits",
 ]
@@ -4852,6 +5143,16 @@ checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
  "libm",
+]
+
+[[package]]
+name = "num_cpus"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
+dependencies = [
+ "hermit-abi",
+ "libc",
 ]
 
 [[package]]
@@ -4892,6 +5193,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "nvml-wrapper"
+version = "0.10.0"
+source = "git+https://github.com/fortanix/nvml-wrapper.git#eb4ee5e5d3650787fa29aac21c5c8ef2da888003"
+dependencies = [
+ "bitflags 2.13.1",
+ "libloading",
+ "nvml-wrapper-sys",
+ "static_assertions",
+ "thiserror 1.0.69",
+ "wrapcenum-derive",
+]
+
+[[package]]
+name = "nvml-wrapper-sys"
+version = "0.8.0"
+source = "git+https://github.com/fortanix/nvml-wrapper.git#eb4ee5e5d3650787fa29aac21c5c8ef2da888003"
+dependencies = [
+ "libloading",
+]
+
+[[package]]
 name = "oauth2"
 version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4908,7 +5230,7 @@ dependencies = [
  "serde_path_to_error",
  "sha2 0.10.9",
  "thiserror 1.0.69",
- "url",
+ "url 2.5.8",
 ]
 
 [[package]]
@@ -4943,7 +5265,7 @@ name = "occlum_dcap"
 version = "0.1.0"
 source = "git+https://github.com/occlum/occlum?tag=v0.29.7#b5a32a8d8a81de2458c2b0d06b07ddce6fd10a44"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "libc",
  "sgx_types",
 ]
@@ -4971,7 +5293,7 @@ dependencies = [
  "thiserror 2.0.20",
  "tokio",
  "tracing",
- "unicase",
+ "unicase 2.9.0",
 ]
 
 [[package]]
@@ -4998,7 +5320,7 @@ dependencies = [
  "thiserror 2.0.20",
  "tokio",
  "tracing",
- "unicase",
+ "unicase 2.9.0",
 ]
 
 [[package]]
@@ -5062,7 +5384,7 @@ dependencies = [
  "async-trait",
  "base64 0.23.1",
  "base64-serde",
- "cfg-if",
+ "cfg-if 1.0.4",
  "crypto",
  "ctr 0.10.1",
  "ctrlc",
@@ -5142,7 +5464,7 @@ dependencies = [
  "hmac 0.12.1",
  "http 1.4.0",
  "itertools 0.10.5",
- "log",
+ "log 0.4.29",
  "oauth2",
  "p256",
  "p384",
@@ -5157,7 +5479,7 @@ dependencies = [
  "sha2 0.10.9",
  "subtle",
  "thiserror 1.0.69",
- "url",
+ "url 2.5.8",
 ]
 
 [[package]]
@@ -5167,7 +5489,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77823a27f0babb03091cb9ed9ef80af3b39dbc82f97e8fa530374b7dafd87a45"
 dependencies = [
  "bitflags 2.13.1",
- "cfg-if",
+ "cfg-if 1.0.4",
  "foreign-types",
  "libc",
  "openssl-macros",
@@ -5314,7 +5636,7 @@ version = "0.9.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "libc",
  "redox_syscall",
  "smallvec",
@@ -5424,6 +5746,12 @@ checksum = "a6305423e0e7738146434843d1694d621cce767262b2a86910beab705e4493d9"
 dependencies = [
  "base64ct",
 ]
+
+[[package]]
+name = "percent-encoding"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31010dd2e1ac33d5b46a5b413495239882813e0369f8ed8a5e266f173602f831"
 
 [[package]]
 name = "percent-encoding"
@@ -5537,7 +5865,7 @@ dependencies = [
  "hkdf",
  "idea",
  "k256",
- "log",
+ "log 0.4.29",
  "md-5",
  "memchr",
  "nom 8.0.0",
@@ -5730,6 +6058,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
+name = "pkix"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c7f38ec00527d35a3af30f5234b147d0651da8ff8fdef7c3969506a6ceb5ec6"
+dependencies = [
+ "b64-ct",
+ "bit-vec 0.6.3",
+ "bitflags 1.3.2",
+ "chrono",
+ "lazy_static",
+ "num-bigint 0.2.6",
+ "num-integer",
+ "yasna 0.3.2",
+]
+
+[[package]]
 name = "plotters"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5774,7 +6118,7 @@ version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "cpufeatures 0.2.17",
  "opaque-debug",
  "universal-hash 0.5.1",
@@ -5945,7 +6289,7 @@ dependencies = [
  "bytes",
  "heck 0.3.3",
  "itertools 0.10.5",
- "log",
+ "log 0.4.29",
  "multimap 0.8.3",
  "petgraph 0.5.1",
  "prost 0.8.0",
@@ -5962,7 +6306,7 @@ checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
  "heck 0.5.0",
  "itertools 0.14.0",
- "log",
+ "log 0.4.29",
  "multimap 0.10.1",
  "petgraph 0.8.3",
  "prettyplease",
@@ -6054,7 +6398,7 @@ checksum = "b4aeaa1f2460f1d348eeaeed86aea999ce98c1bded6f089ff8514c9d9dbdc973"
 dependencies = [
  "anyhow",
  "indexmap 2.14.0",
- "log",
+ "log 0.4.29",
  "protobuf",
  "protobuf-support",
  "tempfile",
@@ -6097,7 +6441,7 @@ version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f42ea446cab60335f76979ec15e12619a2165b5ae2c12166bef27d283a9fadf"
 dependencies = [
- "idna",
+ "idna 1.1.0",
  "psl-types",
 ]
 
@@ -6109,7 +6453,7 @@ checksum = "7c3a14896dfa883796f1cb410461aef38810ea05f2b2c33c5aded3649095fdad"
 dependencies = [
  "bitflags 2.13.1",
  "memchr",
- "unicase",
+ "unicase 2.9.0",
 ]
 
 [[package]]
@@ -6120,6 +6464,12 @@ checksum = "50793def1b900256624a709439404384204a5dc3a6ec580281bfaac35e882e90"
 dependencies = [
  "pulldown-cmark",
 ]
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quinn"
@@ -6207,6 +6557,19 @@ checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
+dependencies = [
+ "fuchsia-cprng",
+ "libc",
+ "rand_core 0.3.2",
+ "rdrand 0.4.0",
+ "winapi",
+]
+
+[[package]]
+name = "rand"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
@@ -6259,6 +6622,21 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96f815e01bbd9678b50d927f79aa1cf3ffdfdb1b9787317c1284dadb894ad0e8"
+dependencies = [
+ "rand_core 0.4.3",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e5937858e6fd18cd595d558f90bb5de3b72ae23f9e3763af0e805949b04ef60"
+
+[[package]]
+name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
@@ -6308,6 +6686,15 @@ checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
+]
+
+[[package]]
+name = "rdrand"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
+dependencies = [
+ "rand_core 0.3.2",
 ]
 
 [[package]]
@@ -6436,10 +6823,10 @@ dependencies = [
  "hyper-tls 0.6.0",
  "hyper-util",
  "js-sys",
- "log",
+ "log 0.4.29",
  "mime_guess",
  "native-tls",
- "percent-encoding",
+ "percent-encoding 2.3.2",
  "pin-project-lite",
  "quinn",
  "rustls",
@@ -6456,7 +6843,7 @@ dependencies = [
  "tower",
  "tower-http",
  "tower-service",
- "url",
+ "url 2.5.8",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "wasm-streams 0.4.2",
@@ -6484,9 +6871,9 @@ dependencies = [
  "hyper-tls 0.6.0",
  "hyper-util",
  "js-sys",
- "log",
+ "log 0.4.29",
  "native-tls",
- "percent-encoding",
+ "percent-encoding 2.3.2",
  "pin-project-lite",
  "quinn",
  "rustls",
@@ -6503,7 +6890,7 @@ dependencies = [
  "tower",
  "tower-http",
  "tower-service",
- "url",
+ "url 2.5.8",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "wasm-streams 0.5.0",
@@ -6518,7 +6905,7 @@ dependencies = [
  "rstest",
  "serde",
  "serde_json",
- "url",
+ "url 2.5.8",
 ]
 
 [[package]]
@@ -6544,7 +6931,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
 dependencies = [
  "cc",
- "cfg-if",
+ "cfg-if 1.0.4",
  "getrandom 0.2.17",
  "libc",
  "untrusted 0.9.0",
@@ -6572,6 +6959,16 @@ dependencies = [
  "serde_derive",
  "typeid",
  "unicode-ident",
+]
+
+[[package]]
+name = "rs-libc"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ebd46ef448b3591b52a40970b56e0ab830a408c18a226181a44e1fa64fabcc1"
+dependencies = [
+ "cc",
+ "zeroize",
 ]
 
 [[package]]
@@ -6612,7 +7009,7 @@ version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c845311f0ff7951c5506121a9ad75aec44d083c31583b2ea5a30bcb0b0abba0"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "glob",
  "proc-macro-crate",
  "proc-macro2",
@@ -6630,7 +7027,7 @@ version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "796e8d2b6696392a43bea58116b667fb4c29727dc5abd27d6acf338bb4f688c7"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "ordered-multimap",
 ]
 
@@ -6727,7 +7124,7 @@ dependencies = [
  "core-foundation",
  "core-foundation-sys",
  "jni",
- "log",
+ "log 0.4.29",
  "once_cell",
  "rustls",
  "rustls-native-certs",
@@ -6785,7 +7182,7 @@ dependencies = [
  "curl",
  "enum_dispatch",
  "foreign-types",
- "log",
+ "log 0.4.29",
  "openssl",
  "openssl-sys",
  "s390_pv_core",
@@ -6802,12 +7199,18 @@ checksum = "ba83bc04ef65f9a404af077f4e6b84d59569ae2ce6c473a923105059df79ec54"
 dependencies = [
  "byteorder",
  "libc",
- "log",
+ "log 0.4.29",
  "regex",
  "serde",
  "thiserror 2.0.20",
  "zerocopy",
 ]
+
+[[package]]
+name = "safemem"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef703b7cb59335eae2eb93ceb664c0eb7ea6bf567079d843e09420219668e072"
 
 [[package]]
 name = "salsa20"
@@ -7014,6 +7417,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_ignored"
+version = "0.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "190e9765dcedb56be63b6e0993a006c7e3b071a016a304736e4a315dc01fb142"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_json"
 version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7108,7 +7520,7 @@ dependencies = [
  "serde_core",
  "serde_json",
  "serde_with_macros",
- "time",
+ "time 0.3.47",
 ]
 
 [[package]]
@@ -7164,7 +7576,7 @@ checksum = "a6df5ed973ad8d834e09f824f9e9f449af6b9a3745f78dec7cc752770bd3bf11"
 dependencies = [
  "futures-executor",
  "futures-util",
- "log",
+ "log 0.4.29",
  "once_cell",
  "parking_lot",
  "serial_test_derive",
@@ -7202,7 +7614,7 @@ dependencies = [
  "serde-big-array",
  "serde_bytes",
  "static_assertions",
- "uuid",
+ "uuid 1.26.0",
 ]
 
 [[package]]
@@ -7221,9 +7633,31 @@ dependencies = [
  "lazy_static",
  "libc",
  "openssl",
- "rdrand",
+ "rdrand 0.8.3",
  "static_assertions",
- "uuid",
+ "uuid 1.26.0",
+]
+
+[[package]]
+name = "sgx-isa"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6e0a0ec672089f6662b6b5fc4ca8a88e979aae8ceb3e24f1c63ffdab681a12e"
+dependencies = [
+ "bitflags 1.3.2",
+]
+
+[[package]]
+name = "sgx_pkix"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e37bf0c8687a46ef72891bee1e3deeca3c8f5300c10add6ed3db50527eb87d"
+dependencies = [
+ "byteorder",
+ "lazy_static",
+ "pkix",
+ "quick-error",
+ "sgx-isa",
 ]
 
 [[package]]
@@ -7237,7 +7671,7 @@ version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "cpufeatures 0.2.17",
  "digest 0.10.7",
 ]
@@ -7259,7 +7693,7 @@ version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "cpufeatures 0.2.17",
  "digest 0.10.7",
 ]
@@ -7270,7 +7704,7 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "cpufeatures 0.3.0",
  "digest 0.11.3",
 ]
@@ -7381,7 +7815,7 @@ dependencies = [
  "async-trait",
  "aws-lc-rs",
  "base64 0.22.1",
- "cfg-if",
+ "cfg-if 1.0.4",
  "chrono",
  "const-oid 0.9.6",
  "crypto_secretbox",
@@ -7414,7 +7848,7 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
- "url",
+ "url 2.5.8",
  "x509-cert",
  "zeroize",
 ]
@@ -7447,10 +7881,10 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d585997b0ac10be3c5ee635f1bab02d512760d14b7c468801ac8a01d9ae5f1d"
 dependencies = [
- "num-bigint",
+ "num-bigint 0.4.6",
  "num-traits",
  "thiserror 2.0.20",
- "time",
+ "time 0.3.47",
 ]
 
 [[package]]
@@ -7734,6 +8168,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tdx-ql"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1049d46702f3ad20c16feb164fda0d282578cd2b0ff076373925eb6ae3b61733"
+dependencies = [
+ "nix 0.30.1",
+ "sgx-isa",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7770,10 +8214,10 @@ dependencies = [
  "either",
  "etcetera",
  "ferroid",
- "futures",
+ "futures 0.3.34",
  "http 1.4.0",
  "itertools 0.14.0",
- "log",
+ "log 0.4.29",
  "memchr",
  "parse-display",
  "pin-project-lite",
@@ -7784,7 +8228,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tokio-util",
- "url",
+ "url 2.5.8",
 ]
 
 [[package]]
@@ -7833,7 +8277,18 @@ version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
+]
+
+[[package]]
+name = "time"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b797afad3f312d1c66a56d11d0316f916356d11bd158fbc6ca6389ff6bf805a"
+dependencies = [
+ "libc",
+ "wasi 0.10.0+wasi-snapshot-preview1",
+ "winapi",
 ]
 
 [[package]]
@@ -8012,7 +8467,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b319ef9394889dab2e1b4f0085b45ba11d0c79dc9d1a9d1afc057d009d0f1c7"
 dependencies = [
  "bytes",
- "futures",
+ "futures 0.3.34",
  "libc",
  "tokio",
  "vsock",
@@ -8086,7 +8541,7 @@ dependencies = [
  "hyper 1.9.0",
  "hyper-timeout",
  "hyper-util",
- "percent-encoding",
+ "percent-encoding 2.3.2",
  "pin-project",
  "socket2 0.6.3",
  "sync_wrapper",
@@ -8171,7 +8626,7 @@ dependencies = [
  "tower",
  "tower-layer",
  "tower-service",
- "url",
+ "url 2.5.8",
 ]
 
 [[package]]
@@ -8192,7 +8647,7 @@ version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
- "log",
+ "log 0.4.29",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -8225,7 +8680,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
 dependencies = [
- "log",
+ "log 0.4.29",
  "once_cell",
  "tracing-core",
 ]
@@ -8262,6 +8717,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "traitobject"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04a79e25382e2e852e8da874249358d382ebaf259d0d34e75d8db16a7efabbc7"
+
+[[package]]
 name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8277,7 +8738,7 @@ dependencies = [
  "enumflags2",
  "getrandom 0.4.2",
  "hostname-validator",
- "log",
+ "log 0.4.29",
  "mbox",
  "num-derive",
  "num-traits",
@@ -8310,9 +8771,9 @@ dependencies = [
  "async-trait",
  "byteorder",
  "crossbeam",
- "futures",
+ "futures 0.3.34",
  "libc",
- "log",
+ "log 0.4.29",
  "nix 0.26.4",
  "protobuf",
  "protobuf-codegen",
@@ -8359,6 +8820,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "typeable"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1410f6f91f21d1612654e7cc69193b0334f909dcf2c790c4826254fbb86f8887"
+
+[[package]]
 name = "typeid"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8378,9 +8845,24 @@ checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
 name = "unicase"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f4765f83163b74f957c797ad9253caf97f103fb064d3999aea9568d09fc8a33"
+dependencies = [
+ "version_check 0.1.5",
+]
+
+[[package]]
+name = "unicase"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
+
+[[package]]
+name = "unicode-bidi"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
 
 [[package]]
 name = "unicode-ident"
@@ -8461,8 +8943,8 @@ checksum = "dea7109cdcd5864d4eeb1b58a1648dc9bf520360d7af16ec26d0a9354bafcfc0"
 dependencies = [
  "base64 0.22.1",
  "cookie_store",
- "log",
- "percent-encoding",
+ "log 0.4.29",
+ "percent-encoding 2.3.2",
  "serde",
  "serde_json",
  "ureq-proto",
@@ -8478,7 +8960,18 @@ dependencies = [
  "base64 0.22.1",
  "http 1.4.0",
  "httparse",
- "log",
+ "log 0.4.29",
+]
+
+[[package]]
+name = "url"
+version = "1.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd4e7c0d531266369519a4aa4f399d748bd37043b00bde1e4ff1f60a120b355a"
+dependencies = [
+ "idna 0.1.5",
+ "matches",
+ "percent-encoding 1.0.1",
 ]
 
 [[package]]
@@ -8488,8 +8981,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
 dependencies = [
  "form_urlencoded",
- "idna",
- "percent-encoding",
+ "idna 1.1.0",
+ "percent-encoding 2.3.2",
  "serde",
  "serde_derive",
 ]
@@ -8537,6 +9030,17 @@ dependencies = [
 
 [[package]]
 name = "uuid"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1436e58182935dcd9ce0add9ea0b558e8a87befe01c1a301e6020aeb0876363"
+dependencies = [
+ "cfg-if 0.1.10",
+ "rand 0.4.6",
+ "serde",
+]
+
+[[package]]
+name = "uuid"
 version = "1.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5772d71c9be8a8a6ac2117d949c5b224c1b72241bb611d9a3012edcf8af7812"
@@ -8559,6 +9063,12 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "version_check"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd"
 
 [[package]]
 name = "version_check"
@@ -8618,6 +9128,12 @@ dependencies = [
 
 [[package]]
 name = "wasi"
+version = "0.10.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
+
+[[package]]
+name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
@@ -8646,7 +9162,7 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1757e0d1f8456693c7e5c6c629bdb54884e032aa0bb53c155f6a39f94440d332"
 dependencies = [
- "wasi",
+ "wasi 0.11.1+wasi-snapshot-preview1",
 ]
 
 [[package]]
@@ -8655,7 +9171,7 @@ version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49ace1d07c165b0864824eee619580c4689389afa9dc9ed3a4c75040d82e6790"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "once_cell",
  "rustversion",
  "wasm-bindgen-macro",
@@ -9145,7 +9661,7 @@ dependencies = [
  "anyhow",
  "bitflags 2.13.1",
  "indexmap 2.14.0",
- "log",
+ "log 0.4.29",
  "serde",
  "serde_derive",
  "serde_json",
@@ -9164,13 +9680,25 @@ dependencies = [
  "anyhow",
  "id-arena",
  "indexmap 2.14.0",
- "log",
+ "log 0.4.29",
  "semver",
  "serde",
  "serde_derive",
  "serde_json",
  "unicode-xid",
  "wasmparser",
+]
+
+[[package]]
+name = "wrapcenum-derive"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a76ff259533532054cfbaefb115c613203c73707017459206380f03b3b3f266e"
+dependencies = [
+ "darling 0.20.11",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -9237,11 +9765,31 @@ dependencies = [
 
 [[package]]
 name = "yasna"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79af3189e6b0484c9fd54208f8eeb8818cadee00ec81438b67a64c8e6f2f3694"
+dependencies = [
+ "bit-vec 0.5.1",
+ "num-bigint 0.2.6",
+]
+
+[[package]]
+name = "yasna"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de7bff972b4f2a06c85f6d8454b09df153af7e3a4ec2aac81db1b105b684ddb"
+dependencies = [
+ "bit-vec 0.6.3",
+ "num-bigint 0.2.6",
+]
+
+[[package]]
+name = "yasna"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e262a29d0e61ccf2b6190d7050d4b237535fc76ce4c1210d9caa316f71dffa75"
 dependencies = [
- "num-bigint",
+ "num-bigint 0.4.6",
 ]
 
 [[package]]

--- a/attestation-agent/Makefile
+++ b/attestation-agent/Makefile
@@ -60,14 +60,14 @@ else
 endif
 
 ifeq ($(ATTESTER), none)
-    AA_FEATURES := kbs,coco_as,bin,$(RPC),$(CRYPTO)
-    AA_CHECK_FEATURES := kbs,coco_as,bin,ttrpc,grpc,$(CRYPTO)
+    AA_FEATURES := kbs,coco_as,ccm_as,bin,$(RPC),$(CRYPTO)
+    AA_CHECK_FEATURES := kbs,coco_as,ccm_as,bin,ttrpc,grpc,$(CRYPTO)
     ATTESTER_PKG_FEATURES := bin
     KBC_FEATURES := cc_kbc,$(CRYPTO)
     KBS_PROTOCOL_FEATURES := background_check,passport,$(CRYPTO),bin,aa_ttrpc,pqc-experimental
 else
-    AA_FEATURES := kbs,coco_as,bin,$(RPC),$(CRYPTO),$(ATTESTER)
-    AA_CHECK_FEATURES := kbs,coco_as,bin,ttrpc,grpc,$(CRYPTO),$(ATTESTER)
+    AA_FEATURES := kbs,coco_as,ccm_as,bin,$(RPC),$(CRYPTO),$(ATTESTER)
+    AA_CHECK_FEATURES := kbs,coco_as,ccm_as,bin,ttrpc,grpc,$(CRYPTO),$(ATTESTER)
     ATTESTER_PKG_FEATURES := $(ATTESTER),bin
     KBC_FEATURES := cc_kbc,$(ATTESTER),$(CRYPTO)
     KBS_PROTOCOL_FEATURES := background_check,passport,$(CRYPTO),$(ATTESTER),bin,aa_ttrpc,pqc-experimental
@@ -115,7 +115,7 @@ ifneq ($(RUSTFLAGS_ARGS),)
 endif
 
 build:
-	cd attestation-agent && $(RUST_FLAGS) cargo build $(release) --no-default-features --features "$(AA_FEATURES)" $(binary) $(LIBC_FLAG)
+	cd attestation-agent && env -u DESTDIR $(RUST_FLAGS) cargo build $(release) --no-default-features --features "$(AA_FEATURES)" $(binary) $(LIBC_FLAG)
 	mv $(TARGET_DIR)/$(binary_name) $(TARGET)
 
 TARGET := $(TARGET_DIR)/$(BIN_NAME)

--- a/attestation-agent/attestation-agent/Cargo.toml
+++ b/attestation-agent/attestation-agent/Cargo.toml
@@ -47,6 +47,16 @@ toml.workspace = true
 tonic = { workspace = true, optional = true }
 ttrpc = { workspace = true, features = ["async"], optional = true }
 
+# SEV-SNP/TDX/NVIDIA attestation and CCM workload-certificate issuance, used
+# by the ccm_as token type.
+attestation = { git = "https://github.com/fortanix/attestation.git", rev = "fade7bf57c93fefaeaca77fe453b87a7909c9cd4", default-features = false, features = [
+    "sev-guest",
+    "tdx-guest",
+    "nvidia-evidence",
+], optional = true }
+client = { git = "https://github.com/fortanix/attestation.git", rev = "fade7bf57c93fefaeaca77fe453b87a7909c9cd4", optional = true }
+x509-cert = { version = "0.2.5", features = ["pem"], optional = true }
+
 [dev-dependencies]
 rstest.workspace = true
 serial_test.workspace = true
@@ -66,6 +76,11 @@ kbs = ["kbs_protocol/background_check", "token"]
 
 # CoCoAS Attestation Token
 coco_as = ["reqwest", "token"]
+
+# CCM_AS Token: local attestation to the Fortanix Node Agent/CCM, returning a
+# CCM-issued workload cert+key as the token (used by CDH's ccm_kbc for DSM key
+# release).
+ccm_as = ["dep:client", "dep:x509-cert", "tokio/rt", "token"]
 
 all-attesters = [
     "tdx-attester",

--- a/attestation-agent/attestation-agent/build.rs
+++ b/attestation-agent/attestation-agent/build.rs
@@ -28,7 +28,7 @@ fn main() -> std::io::Result<()> {
             enabled_features.join(", ")
         }
 
-        let token_plugins = feature_list(vec![], vec!["KBS", "COCO_AS"]);
+        let token_plugins = feature_list(vec![], vec!["KBS", "COCO_AS", "CCM_AS"]);
         let attester = feature_list(
             vec!["SAMPLE_ATTESTER", "SAMPLE_DEVICE_ATTESTER"],
             vec![

--- a/attestation-agent/attestation-agent/src/config/ccm_as.rs
+++ b/attestation-agent/attestation-agent/src/config/ccm_as.rs
@@ -1,0 +1,16 @@
+// Copyright (c) Fortanix, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+use serde::Deserialize;
+
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+pub struct CcmAsConfig {
+    /// Domain name(s) CCM issues the workload certificate for.
+    pub ccm_domain_names: Vec<String>,
+
+    /// Optional Fortanix AppConfig ID (hex-encoded).
+    #[serde(default)]
+    pub ccm_appconfig_id: Option<String>,
+}

--- a/attestation-agent/attestation-agent/src/config/mod.rs
+++ b/attestation-agent/attestation-agent/src/config/mod.rs
@@ -19,6 +19,9 @@ pub mod coco_as;
 #[cfg(feature = "kbs")]
 pub mod kbs;
 
+#[cfg(feature = "ccm_as")]
+pub mod ccm_as;
+
 pub const DEFAULT_AA_CONFIG_PATH: &str = "/etc/attestation-agent.conf";
 
 pub const DEFAULT_EVENTLOG_HASH: &str = "sha384";
@@ -111,6 +114,10 @@ pub struct TokenConfigs {
     /// This config item is used when `kbs` feature is enabled.
     #[cfg(feature = "kbs")]
     pub kbs: Option<kbs::KbsConfig>,
+
+    /// This config item is used when `ccm_as` feature is enabled.
+    #[cfg(feature = "ccm_as")]
+    pub ccm_as: Option<ccm_as::CcmAsConfig>,
 }
 
 impl TokenConfigs {
@@ -123,6 +130,8 @@ impl TokenConfigs {
             coco_as: None,
             #[cfg(feature = "kbs")]
             kbs,
+            #[cfg(feature = "ccm_as")]
+            ccm_as: None,
         }
     }
 }
@@ -341,6 +350,7 @@ M9QaC1mzQ/OStg==
             },
             log: LogConfig::default(),
         })]
+    // TODO: Add test for "ccm_as"
     fn parse_configs(#[case] config: &str, #[case] expected: Config) {
         let _config = Config::try_from(config).expect("failed to parse config file");
         assert_eq!(_config, expected);

--- a/attestation-agent/attestation-agent/src/lib.rs
+++ b/attestation-agent/attestation-agent/src/lib.rs
@@ -190,6 +190,22 @@ impl AttestationAPIs for AttestationAgent {
                 .get_token()
                 .await
             }
+            #[cfg(feature = "ccm_as")]
+            token::TokenType::CcmAs => {
+                token::ccm_as::CcmAsTokenGetter::new(
+                    self.config
+                        .read()
+                        .await
+                        .token_configs
+                        .ccm_as
+                        .as_ref()
+                        .ok_or(anyhow::anyhow!(
+                            "ccm_as token config not configured in config file"
+                        ))?,
+                )
+                .get_token()
+                .await
+            }
         }
     }
 

--- a/attestation-agent/attestation-agent/src/token/ccm_as.rs
+++ b/attestation-agent/attestation-agent/src/token/ccm_as.rs
@@ -1,0 +1,134 @@
+// Copyright (c) Fortanix, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+use crate::config::ccm_as::CcmAsConfig;
+use anyhow::{Context, Result, bail};
+use client::{Attest, BaremetalSevSnp, BaremetalTdx, NodeAgentClient, certificate::AppCert};
+use kbs_types::Tee;
+use serde::Serialize;
+use std::sync::LazyLock;
+use std::time::SystemTime;
+use tokio::sync::Mutex;
+use tracing::{info, warn};
+use x509_cert::Certificate;
+use x509_cert::der::DecodePem;
+
+#[derive(Serialize, Clone)]
+struct Message {
+    cert_pem: String,
+    key_pem: String,
+}
+
+// Serializes concurrent get_token() calls onto a single attestation instead of each one
+// independently re-attesting — CDH fires several overlapping key requests per image decrypt.
+// Reused while still valid per the cert's own dates (see cert_is_currently_valid); no separate TTL.
+static CACHE: LazyLock<Mutex<Option<Message>>> = LazyLock::new(|| Mutex::new(None));
+
+// Make sure the cert is currently valid. If it can't be parsed, treat it as invalid so
+// it gets refreshed.
+fn cert_is_currently_valid(cert_pem: &str) -> bool {
+    match Certificate::from_pem(cert_pem.as_bytes()) {
+        Ok(cert) => {
+            let now = SystemTime::now();
+            let validity = cert.tbs_certificate.validity;
+            now >= validity.not_before.to_system_time() && now < validity.not_after.to_system_time()
+        }
+        Err(e) => {
+            warn!(
+                "ccm_as: failed to parse cached cert for validity check ({e}), treating as invalid"
+            );
+            false
+        }
+    }
+}
+
+pub struct CcmAsTokenGetter {
+    ccm_domain_names: Vec<String>,
+    ccm_appconfig_id: Option<String>,
+}
+
+impl CcmAsTokenGetter {
+    pub fn new(config: &CcmAsConfig) -> Self {
+        Self {
+            ccm_domain_names: config.ccm_domain_names.clone(),
+            ccm_appconfig_id: config.ccm_appconfig_id.clone(),
+        }
+    }
+
+    pub async fn get_token(&self) -> Result<Vec<u8>> {
+        let mut cache = CACHE.lock().await;
+
+        if let Some(cached) = cache.as_ref() {
+            if cert_is_currently_valid(&cached.cert_pem) {
+                info!("ccm_as: reusing cached workload credential");
+                return serde_json::to_vec(cached).context("ccm_as: serialize token");
+            }
+            info!("ccm_as: cached workload credential no longer valid, re-attesting");
+        } else {
+            info!("ccm_as: workload credential not found in cache, performing attestation");
+        }
+
+        let (cert_pem, key_pem) = self.attest_and_issue_cert().await?;
+        info!("ccm_as: attested and issued a new workload credential");
+        let message = Message { cert_pem, key_pem };
+        *cache = Some(message.clone());
+        drop(cache);
+
+        serde_json::to_vec(&message).context("ccm_as: serialize token")
+    }
+
+    async fn attest_and_issue_cert(&self) -> Result<(String, String)> {
+        let tee = attester::detect_tee_type();
+
+        let appconfig_id = self
+            .ccm_appconfig_id
+            .as_deref()
+            .map(|id| hex::decode(id.trim()))
+            .transpose()
+            .context("ccm_as: ccm_appconfig_id is not valid hex")?;
+
+        // `AppCert::request_app_cert_csr` in the `fortanix/attestation/client` crate reads the
+        // workload cert's subject alt names from this env var rather than taking them as a parameter
+        unsafe { std::env::set_var("APP_CERT_ALT_NAMES", self.ccm_domain_names.join(",")) };
+
+        tokio::task::spawn_blocking(move || -> Result<(String, String)> {
+            let mut app_cert = AppCert::init().context("ccm_as: AppCert::init")?;
+            let na_client = NodeAgentClient::init().context("ccm_as: NodeAgentClient::init")?;
+
+            match tee {
+                Tee::Snp => {
+                    BaremetalSevSnp::attest_and_request_app_cert(
+                        &mut app_cert,
+                        &na_client,
+                        appconfig_id,
+                    )
+                    .context("ccm_as: SNP attest_and_request_app_cert")?;
+                }
+                Tee::Tdx => {
+                    BaremetalTdx::attest_and_request_app_cert(
+                        &mut app_cert,
+                        &na_client,
+                        appconfig_id,
+                    )
+                    .context("ccm_as: TDX attest_and_request_app_cert")?;
+                }
+                other => bail!("ccm_as: unsupported TEE {other:?}"),
+            }
+
+            let cert_pem = app_cert
+                .cert
+                .clone()
+                .ok_or_else(|| anyhow::anyhow!("ccm_as: CCM returned no workload certificate"))?;
+            let key_pem = app_cert
+                .key
+                .write_private_pem_string()
+                .context("ccm_as: export workload private key")?;
+
+            Ok((cert_pem, key_pem))
+        })
+        .await
+        .context("ccm_as: spawn_blocking join")?
+    }
+}

--- a/attestation-agent/attestation-agent/src/token/mod.rs
+++ b/attestation-agent/attestation-agent/src/token/mod.rs
@@ -12,6 +12,9 @@ pub mod kbs;
 #[cfg(feature = "coco_as")]
 pub mod coco_as;
 
+#[cfg(feature = "ccm_as")]
+pub mod ccm_as;
+
 fn make_error(_: &str) -> Error {
     Error::msg("Invalid resource type")
 }
@@ -26,4 +29,8 @@ pub enum TokenType {
     #[cfg(feature = "coco_as")]
     #[strum(serialize = "coco_as")]
     CoCoAS,
+
+    #[cfg(feature = "ccm_as")]
+    #[strum(serialize = "ccm_as")]
+    CcmAs,
 }

--- a/confidential-data-hub/hub/Cargo.toml
+++ b/confidential-data-hub/hub/Cargo.toml
@@ -110,3 +110,5 @@ grpc = ["prost", "tonic", "tokio/signal", "protos/grpc"]
 
 # for secret_cli
 cli = ["clap/derive", "tokio/rt-multi-thread", "tokio/sync", "tokio/macros"]
+
+ccm_kbc = ["kms/ccm_kbc"]

--- a/confidential-data-hub/hub/build.rs
+++ b/confidential-data-hub/hub/build.rs
@@ -28,6 +28,11 @@ fn main() {
         } else {
             "disabled"
         };
+        let ccm_kbc = if env::var("CARGO_FEATURE_CCM_KBC").is_ok() {
+            "enabled"
+        } else {
+            "disabled"
+        };
         let kms = feature_list(vec!["ALIYUN", "AWS"]);
 
         let out_dir = env::var("OUT_DIR").unwrap();
@@ -35,6 +40,7 @@ fn main() {
         let mut f = File::create(dest_path).unwrap();
 
         writeln!(f, "kbs: {kbs}").unwrap();
+        writeln!(f, "ccm_kbc: {ccm_kbc}").unwrap();
         write!(f, "kms plugins: {kms}").unwrap();
     }
 

--- a/confidential-data-hub/hub/src/config/mod.rs
+++ b/confidential-data-hub/hub/src/config/mod.rs
@@ -38,6 +38,20 @@ pub struct KbsConfig {
     pub kbs_cert: Option<String>,
 }
 
+#[derive(Clone, Deserialize, Debug, PartialEq, Default)]
+pub struct KbcConfigs {
+    /// This config item is used when the `ccm_kbc` feature is enabled.
+    #[cfg(feature = "ccm_kbc")]
+    pub ccm_kbc: Option<CcmKbcConfig>,
+}
+
+#[cfg(feature = "ccm_kbc")]
+#[derive(Clone, Deserialize, Debug, PartialEq, Default)]
+pub struct CcmKbcConfig {
+    #[serde(default)]
+    pub dsm_app_id: Option<String>,
+}
+
 impl KbsConfig {
     fn new() -> Result<Self> {
         debug!("Try to get kbc and url from env and kernel commandline.");
@@ -106,6 +120,9 @@ pub struct CdhConfig {
     pub aa: AaConfig,
 
     #[serde(default)]
+    pub kbc_configs: KbcConfigs,
+
+    #[serde(default)]
     pub credentials: Vec<Credential>,
 
     /// Image pull configuration. Note that if `[image]` section is not given,
@@ -137,6 +154,7 @@ impl CdhConfig {
         Ok(Self {
             kbc: KbsConfig::new()?,
             aa: AaConfig::default(),
+            kbc_configs: KbcConfigs::default(),
             credentials: Vec::new(),
             socket: default_socket_addr(),
             image: ImageConfig::from_kernel_cmdline(),
@@ -211,6 +229,19 @@ impl CdhConfig {
             env::set_var("KBS_CERT", kbs_cert);
         }
 
+        // CCM configurations
+        #[cfg(feature = "ccm_kbc")]
+        if let Some(dsm_app_id) = self
+            .kbc_configs
+            .ccm_kbc
+            .as_ref()
+            .and_then(|c| c.dsm_app_id.as_deref())
+        {
+            if !dsm_app_id.is_empty() {
+                env::set_var("CCM_KBC_APP_ID", dsm_app_id);
+            }
+        }
+
         if self.skip_sealed_secret_verification {
             env::set_var("SKIP_SEALED_SECRET_VERIFICATION", "true");
         }
@@ -237,8 +268,8 @@ mod tests {
     use serial_test::serial;
 
     use crate::{
-        config::DEFAULT_AA_SOCKET_ADDR, config::DEFAULT_CDH_SOCKET_ADDR, AaConfig, CdhConfig,
-        KbsConfig, LogConfig,
+        config::{KbcConfigs, DEFAULT_AA_SOCKET_ADDR, DEFAULT_CDH_SOCKET_ADDR},
+        AaConfig, CdhConfig, KbsConfig, LogConfig,
     };
 
     #[rstest]
@@ -277,6 +308,7 @@ location = "example-mirror-0.local/mirror-for-foo"
 https_proxy = "http://127.0.0.1:8080"
     "#,
         Some(CdhConfig {
+        kbc_configs: KbcConfigs::default(),
             log: LogConfig::default(),
             aa: AaConfig::default(),
             kbc: KbsConfig {
@@ -338,6 +370,7 @@ kbs_cert = ""
 name = "offline_fs_kbc"
 "#,
     Some(CdhConfig {
+        kbc_configs: KbcConfigs::default(),
         log: LogConfig::default(),
         aa: AaConfig::default(),
         kbc: KbsConfig {
@@ -369,6 +402,7 @@ name = "offline_fs_kbc"
 some_undefined_field = "unknown value"
 "#,
     Some(CdhConfig {
+        kbc_configs: KbcConfigs::default(),
         log: LogConfig {
             level: "warn".to_string(),
         },

--- a/confidential-data-hub/kms/Cargo.toml
+++ b/confidential-data-hub/kms/Cargo.toml
@@ -35,7 +35,9 @@ tokio = { workspace = true, features = ["fs"] }
 toml.workspace = true
 tonic = { workspace = true, optional = true }
 tracing.workspace = true
+ttrpc = { workspace = true, optional = true }
 url = { workspace = true, optional = true }
+uuid = { workspace = true, optional = true }
 
 [dev-dependencies]
 rstest.workspace = true
@@ -64,3 +66,11 @@ aliyun = [
 ]
 aws = ["aws-sdk-kms", "aws-sdk-secretsmanager"]
 kbs = ["kbs_protocol"]
+ccm_kbc = [
+    "uuid",
+    "reqwest/rustls",
+    "reqwest/json",
+    "ttrpc/async",
+    "protos",
+    "protos/ttrpc",
+]

--- a/confidential-data-hub/kms/src/plugins/kbs/ccm_kbc.rs
+++ b/confidential-data-hub/kms/src/plugins/kbs/ccm_kbc.rs
@@ -1,0 +1,84 @@
+// Copyright (c) Fortanix, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+mod aa_token_client;
+mod config;
+mod dsm_client;
+mod identity;
+
+use super::{Kbc, ResourceUri};
+use crate::{Error, Result};
+use async_trait::async_trait;
+use config::CcmKbcConfig;
+use tracing::info;
+
+pub struct CcmKbc {
+    dsm_endpoint: String,
+    dsm_app_id: String,
+    aa_socket: String,
+}
+
+impl CcmKbc {
+    pub(crate) async fn new(uri: &str, aa_socket: &str) -> Result<Self> {
+        let cfg = CcmKbcConfig::from_env_or_cmdline()?;
+        let uri = uri.trim().trim_end_matches('/');
+        let dsm_endpoint = if uri.is_empty() {
+            cfg.dsm_endpoint.ok_or_else(|| {
+                Error::KbsClientError(
+                    "ccm_kbc: no DSM endpoint configured - set [kbc].url in cdh.toml \
+                     (delivered via initdata), or pass ccm.kbc_dsm_endpoint= on the \
+                     kernel cmdline"
+                        .to_string(),
+                )
+            })?
+        } else {
+            info!("ccm_kbc: DSM endpoint sourced from aa_kbc_params uri");
+            uri.to_string()
+        };
+
+        let dsm_app_id = cfg.dsm_app_id.ok_or_else(|| {
+            Error::KbsClientError(
+                "ccm_kbc: no DSM app id configured - set cdh.toml \
+                 [kbc_configs.ccm_kbc].dsm_app_id, CCM_KBC_APP_ID, or ccm.kbc_app_id="
+                    .to_string(),
+            )
+        })?;
+
+        info!("ccm_kbc: KBC loaded (dsm_endpoint={dsm_endpoint})");
+
+        Ok(Self {
+            dsm_endpoint,
+            dsm_app_id,
+            aa_socket: aa_socket.to_string(),
+        })
+    }
+}
+
+#[async_trait]
+impl Kbc for CcmKbc {
+    async fn get_resource(&mut self, rid: ResourceUri) -> Result<Vec<u8>> {
+        let key_uuid = identity::parse_dsm_uuid(&rid)?;
+
+        let credential = aa_token_client::get_ccm_as_credential(&self.aa_socket)
+            .await
+            .map_err(|e| Error::KbsClientError(format!("ccm_kbc: {e:#}")))?;
+
+        let bytes = dsm_client::unwrap_key(
+            &self.dsm_endpoint,
+            &credential.cert_pem,
+            &credential.key_pem,
+            &self.dsm_app_id,
+            key_uuid,
+        )
+        .await
+        .map_err(|e| Error::KbsClientError(format!("ccm_kbc: DSM key export: {e:#}")))?;
+
+        info!(
+            "ccm_kbc: DSM returned {} bytes for key {key_uuid}",
+            bytes.len()
+        );
+        Ok(bytes)
+    }
+}

--- a/confidential-data-hub/kms/src/plugins/kbs/ccm_kbc/aa_token_client.rs
+++ b/confidential-data-hub/kms/src/plugins/kbs/ccm_kbc/aa_token_client.rs
@@ -1,0 +1,43 @@
+// Copyright (c) Fortanix, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+//! Asks the attestation agent for a 'ccm_as' token: the CCM-issued workload
+//! certificate and the private key it certifies.
+
+use anyhow::{Context, Result};
+use protos::ttrpc::aa::{
+    attestation_agent::GetTokenRequest, attestation_agent_ttrpc::AttestationAgentServiceClient,
+};
+use serde::Deserialize;
+use ttrpc::context;
+
+const TOKEN_TYPE: &str = "ccm_as";
+
+const TIMEOUT_NANOS: i64 = 50 * 1000 * 1000 * 1000;
+
+#[derive(Deserialize)]
+pub(super) struct CcmAsCredential {
+    pub cert_pem: String,
+    pub key_pem: String,
+}
+
+pub(super) async fn get_ccm_as_credential(aa_socket: &str) -> Result<CcmAsCredential> {
+    let conn = ttrpc::r#async::Client::connect(aa_socket)
+        .await
+        .context("ttrpc connect to attestation-agent failed")?;
+    let client = AttestationAgentServiceClient::new(conn);
+
+    let req = GetTokenRequest {
+        TokenType: TOKEN_TYPE.to_string(),
+        ..Default::default()
+    };
+
+    let resp = client
+        .get_token(context::with_timeout(TIMEOUT_NANOS), &req)
+        .await
+        .context("attestation-agent GetToken(ccm_as) failed")?;
+
+    serde_json::from_slice(&resp.Token).context("deserialize ccm_as token payload failed")
+}

--- a/confidential-data-hub/kms/src/plugins/kbs/ccm_kbc/config.rs
+++ b/confidential-data-hub/kms/src/plugins/kbs/ccm_kbc/config.rs
@@ -1,0 +1,59 @@
+// Copyright (c) Fortanix, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+use std::env;
+
+use tracing::{debug, info, warn};
+
+use crate::Result;
+
+const ENV_ENDPOINT: &str = "CCM_KBC_DSM_ENDPOINT";
+const ENV_APP_ID: &str = "CCM_KBC_APP_ID";
+
+const CMDLINE_ENDPOINT: &str = "ccm.kbc_dsm_endpoint=";
+const CMDLINE_APP_ID: &str = "ccm.kbc_app_id=";
+
+const CMDLINE_PATH: &str = "/proc/cmdline";
+
+pub(super) struct CcmKbcConfig {
+    pub(super) dsm_endpoint: Option<String>,
+    pub(super) dsm_app_id: Option<String>,
+}
+
+fn get_env_or_cmdline(env_var: &str, cmdline_prefix: &str) -> Option<String> {
+    if let Ok(value) = env::var(env_var) {
+        debug!("ccm_kbc: {env_var} loaded from env (len={})", value.len());
+        return Some(value);
+    }
+
+    let cmdline = std::fs::read_to_string(CMDLINE_PATH).ok()?;
+    let value = cmdline
+        .split_ascii_whitespace()
+        .find_map(|p| p.strip_prefix(cmdline_prefix).map(String::from))?;
+
+    debug!(
+        "ccm_kbc: {env_var} loaded from cmdline (len={})",
+        value.len()
+    );
+    Some(value)
+}
+
+impl CcmKbcConfig {
+    pub(super) fn from_env_or_cmdline() -> Result<Self> {
+        let dsm_endpoint = get_env_or_cmdline(ENV_ENDPOINT, CMDLINE_ENDPOINT)
+            .map(|e| e.trim_end_matches('/').to_string());
+        let dsm_app_id = get_env_or_cmdline(ENV_APP_ID, CMDLINE_APP_ID);
+        if dsm_app_id.is_none() {
+            warn!("ccm_kbc: no DSM app id configured");
+        }
+
+        info!("ccm_kbc: config loaded (endpoint={dsm_endpoint:?}, app_id={dsm_app_id:?})");
+
+        Ok(Self {
+            dsm_endpoint,
+            dsm_app_id,
+        })
+    }
+}

--- a/confidential-data-hub/kms/src/plugins/kbs/ccm_kbc/dsm_client.rs
+++ b/confidential-data-hub/kms/src/plugins/kbs/ccm_kbc/dsm_client.rs
@@ -1,0 +1,113 @@
+// Copyright (c) Fortanix, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+// DSM client: authenticate with the CCM-issued workload certificate,
+// then unwrap a key.
+
+use anyhow::{Context, Result, bail};
+use base64::Engine;
+use reqwest::Client;
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+pub(super) async fn unwrap_key(
+    endpoint: &str,
+    cert_pem: &str,
+    key_pem: &str,
+    app_uuid: &str,
+    key_uuid: Uuid,
+) -> Result<Vec<u8>> {
+    // Cert chain + private key in one PEM blob become the reqwest TLS client
+    // identity. DSM authenticates the mTLS handshake.
+    let mut identity_pem = String::with_capacity(cert_pem.len() + key_pem.len() + 1);
+    identity_pem.push_str(cert_pem.trim_end());
+    identity_pem.push('\n');
+    identity_pem.push_str(key_pem);
+
+    let identity = reqwest::Identity::from_pem(identity_pem.as_bytes())
+        .context("build TLS identity from cert and key failed")?;
+
+    let http = Client::builder()
+        .use_rustls_tls()
+        .identity(identity)
+        .build()
+        .context("build mTLS client failed")?;
+
+    let token = authenticate(&http, endpoint, app_uuid).await?;
+    export_sobject(&http, endpoint, &token, key_uuid).await
+}
+
+async fn authenticate(http: &Client, endpoint: &str, app_uuid: &str) -> Result<String> {
+    let url = format!("{endpoint}/sys/v1/session/auth");
+    let basic = base64::engine::general_purpose::STANDARD.encode(format!("{app_uuid}:"));
+
+    let resp = http
+        .post(&url)
+        .header(reqwest::header::AUTHORIZATION, format!("Basic {basic}"))
+        .send()
+        .await
+        .context("DSM auth POST failed")?;
+
+    let status = resp.status();
+    if !status.is_success() {
+        let body = resp.text().await.unwrap_or_default();
+        bail!("DSM auth returned {status}: {body}");
+    }
+
+    #[derive(Deserialize)]
+    struct AuthResp {
+        access_token: String,
+    }
+
+    let auth: AuthResp = resp
+        .json()
+        .await
+        .context("DSM auth response was not valid JSON")?;
+    Ok(auth.access_token)
+}
+
+async fn export_sobject(
+    http: &Client,
+    endpoint: &str,
+    token: &str,
+    kek_uuid: Uuid,
+) -> Result<Vec<u8>> {
+    let url = format!("{endpoint}/crypto/v1/keys/export");
+
+    #[derive(Serialize)]
+    struct ExportReq {
+        kid: String,
+    }
+
+    #[derive(Deserialize)]
+    struct ExportResp {
+        value: String,
+    }
+
+    let resp = http
+        .post(&url)
+        .header(reqwest::header::AUTHORIZATION, format!("Bearer {token}"))
+        .json(&ExportReq {
+            kid: kek_uuid.to_string(),
+        })
+        .send()
+        .await
+        .context("DSM export POST failed")?;
+
+    let status = resp.status();
+    if !status.is_success() {
+        let body = resp.text().await.unwrap_or_default();
+        bail!("DSM export returned {status}: {body}");
+    }
+
+    let body: ExportResp = resp
+        .json()
+        .await
+        .context("DSM export response was not valid JSON")?;
+
+    base64::engine::general_purpose::STANDARD
+        .decode(body.value.as_bytes())
+        .context("DSM export 'value' was not valid base64")
+}

--- a/confidential-data-hub/kms/src/plugins/kbs/ccm_kbc/identity.rs
+++ b/confidential-data-hub/kms/src/plugins/kbs/ccm_kbc/identity.rs
@@ -1,0 +1,35 @@
+// Copyright (c) Fortanix, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+use crate::{Error, Result};
+use resource_uri::{ResourcePluginPath, ResourceUri};
+use uuid::Uuid;
+
+const EXPECTED_URI: &str = "kbs:///dsm/key/<uuid>";
+
+pub(super) fn parse_dsm_uuid(rid: &ResourceUri) -> Result<Uuid> {
+    let uri = rid.whole_uri();
+    let bad = |detail: String| {
+        Error::KbsClientError(format!(
+            "ccm_kbc: invalid resource uri '{uri}': {detail}; expected {EXPECTED_URI}"
+        ))
+    };
+
+    let path = ResourcePluginPath::try_from(rid.clone()).map_err(|e| bad(e.to_string()))?;
+
+    if path.repo != "dsm" {
+        return Err(bad(format!(
+            "repository must be 'dsm', got '{}'",
+            path.repo
+        )));
+    }
+
+    if path.r#type != "key" {
+        return Err(bad(format!("type must be 'key', got '{}'", path.r#type)));
+    }
+
+    Uuid::parse_str(&path.tag)
+        .map_err(|e| bad(format!("tag '{}' is not a valid UUID: {e}", path.tag)))
+}

--- a/confidential-data-hub/kms/src/plugins/kbs/mod.rs
+++ b/confidential-data-hub/kms/src/plugins/kbs/mod.rs
@@ -8,6 +8,9 @@
 #[cfg(feature = "kbs")]
 mod cc_kbc;
 
+#[cfg(feature = "ccm_kbc")]
+mod ccm_kbc;
+
 mod offline_fs;
 
 use std::{env, sync::Arc};
@@ -29,6 +32,8 @@ pub trait Kbc: Send + Sync {
 pub enum KbcClient {
     #[cfg(feature = "kbs")]
     Cc(Arc<Mutex<cc_kbc::CcKbc>>),
+    #[cfg(feature = "ccm_kbc")]
+    Ccm(Arc<Mutex<ccm_kbc::CcmKbc>>),
     OfflineFs(Arc<Mutex<offline_fs::OfflineFsKbc>>),
 }
 
@@ -46,12 +51,19 @@ impl KbcClient {
                     cc_kbc::CcKbc::new(&params.uri, &aa_socket).await?,
                 )))
             }
+            #[cfg(feature = "ccm_kbc")]
+            "ccm_kbc" => {
+                let aa_socket = env::var("AA_SOCKET").expect("must be initialized");
+                Self::Ccm(Arc::new(Mutex::new(
+                    ccm_kbc::CcmKbc::new(&params.uri, &aa_socket).await?,
+                )))
+            }
             "offline_fs_kbc" => {
                 Self::OfflineFs(Arc::new(Mutex::new(offline_fs::OfflineFsKbc::new().await?)))
             }
             others => {
                 return Err(Error::KbsClientError(format!(
-                    "unknown kbc name {others}, only support `cc_kbc`(feature `kbs`) and `offline_fs_kbc`."
+                    "unknown kbc name {others}, only support `cc_kbc`(feature `kbs`), `ccm_kbc` (feature `ccm_kbc`) and `offline_fs_kbc`."
                 )));
             }
         };
@@ -69,6 +81,8 @@ impl Getter for KbcClient {
         match self {
             #[cfg(feature = "kbs")]
             Self::Cc(c) => c.lock().await.get_resource(resource_uri).await,
+            #[cfg(feature = "ccm_kbc")]
+            Self::Ccm(c) => c.lock().await.get_resource(resource_uri).await,
             Self::OfflineFs(c) => c.lock().await.get_resource(resource_uri).await,
         }
     }


### PR DESCRIPTION
**What**

Implements the `ccm_as` / `ccm_kbc` design proposed in #1513. This allows a confidential guest to release a key from Fortanix DSM, with the release gated on successful attestation to Fortanix CCM.

This adds two paired, opt-in plugins:

### `attestation-agent`

Adds a new `ccm_as` token type alongside the existing `kbs` and `coco_as` token types.

The Attestation Agent (AA) performs local attestation to CCM over vsock, with SEV-SNP and TDX supported today. Once attestation succeeds, CCM returns a short-lived workload X.509 certificate and private key, which the AA exposes as the token.

The credential is cached for the lifetime of the AA process. The AA only performs attestation again when the cached certificate expires.

### `confidential-data-hub`

Adds a new `ccm_kbc` KBS client, alongside the existing `cc_kbc`, `online_sev_kbc`, and `offline_fs_kbc` implementations.

For resource URIs in the form:

```text
kbs:///dsm/key/<uuid>
```

the KBC:

1. Fetches the `ccm_as` credential from the AA over ttrpc.
2. Uses that credential as an mTLS client identity when connecting to DSM.
3. Requests the specified key from DSM.

Both plugins are opt-in through the `ccm_as` and `ccm_kbc` Cargo features. They are disabled by default, so existing builds don't incur any additional compile-time or runtime cost, and existing KBCs and token types continue to behave exactly as before.

### Why `ccm_kbc` doesn't use the attester directly

The attestation and evidence collection are handled entirely by `ccm_as` on the AA side.

`ccm_kbc` only needs to:

* Fetch the credential from AA over ttrpc.
* Present that credential to DSM.

This uses the same ttrpc mechanism already used for CDH ↔ AA token fetching and follows the existing two-phase model used by `cc_kbc`: the AA handles attestation and produces a credential, while the KBC presents that credential to the actual KMS.

## Out of scope

The `coco_keyprovider` changes are intentionally not part of this PR.

This includes:

* DSM-wrapped-KEK image encryption.
* The corresponding CDH-side `decrypt_with_kek` / `Decrypter` support.

Those changes will be handled in a follow-up PR.

For this PR, `ccm_kbc` only implements the `kbs:///dsm/key/<uuid>` resource-release path through `get_resource()`. It does not add image-decryption support.

Ref : [#1513](https://github.com/confidential-containers/guest-components/issues/1513)

Assisted-by: Claude Sonnet 5