### PR TITLE
coco_keyprovider: read the algorithm parameter from the right key

### DIFF
--- a/attestation-agent/coco_keyprovider/src/enc_mods/mod.rs
+++ b/attestation-agent/coco_keyprovider/src/enc_mods/mod.rs
@@ -82,7 +82,7 @@ fn parse_input_params(input: &str) -> Result<InputParams> {
     let keyid = map.get("keyid").map(|id| id.to_string());
     let keypath = map.get("keypath").map(|p| p.to_string());
     let algorithm = map
-        .get("keypath")
+        .get("algorithm")
         .map(|alg| (*alg).try_into().unwrap_or_default())
         .unwrap_or_default();
     Ok(InputParams {


### PR DESCRIPTION
## Problem

`parse_input_params` reads the `algorithm` parameter from the wrong map key:

```rust
let keypath = map.get("keypath").map(|p| p.to_string());
let algorithm = map
    .get("keypath")          // <- should be "algorithm"
    .map(|alg| (*alg).try_into().unwrap_or_default())
    .unwrap_or_default();
```

Both lines read `keypath`, so the `algorithm` parameter documented in the README is never looked up. Passing `algorithm=A256CTR` has no effect and encryption always falls back to the default `A256GCM`.

## Fix

One word: read `algorithm` from `map.get("algorithm")`.